### PR TITLE
docs: setup dev/thomas-test branch and document workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,29 @@ reproduire les régressions passées. Relire avant tout gros chantier.
 
 ---
 
+## Workflow Dev/Prod (depuis 27/04/2026)
+
+Lor'Squad utilise 2 branches actives :
+
+- `claude/focused-pike` = **PRODUCTION** (Mélanie + équipe coach + clients)
+- `dev/thomas-test` = **DEV/TEST** (Thomas uniquement, preview Vercel séparée)
+
+**Pour toute nouvelle feature** :
+- Créer `feat/X` depuis `dev/thomas-test` (PAS depuis `claude/focused-pike`)
+- Tester sur l'URL dev Vercel, valider, puis merger en prod
+
+**Pour tout fix urgent** (régression bloquante) :
+- Créer `fix/X` depuis `claude/focused-pike`
+- Merger direct en prod, puis sync vers `dev/thomas-test` pour rester aligné
+
+**Base Supabase partagée** : les 2 environnements parlent à la même DB.
+Les migrations impactent donc **les 2 environnements**. Coordonner avant
+toute migration.
+
+Workflow complet : `docs/DEV_WORKFLOW.md`
+
+---
+
 ## Page remerciement post-bilan (2026-04-27)
 
 ### Route dédiée

--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -1,0 +1,223 @@
+# Workflow Dev / Prod — Lor'Squad Wellness
+
+Document créé le **27/04/2026** lors du setup initial du workflow dev/prod,
+après plusieurs régressions ayant bloqué Mélanie (admin n°2) sur ses
+suivis quotidiens. Objectif : séparer les expérimentations de Thomas de
+l'environnement de production utilisé par l'équipe coach.
+
+---
+
+## Vue d'ensemble
+
+Lor'Squad Wellness utilise **2 environnements de déploiement** basés sur
+2 branches Git :
+
+| Environnement | Branche | URL | Utilisateurs |
+|---|---|---|---|
+| **Production** | `claude/focused-pike` | `app.lorsquad.com` | Mélanie, équipe coach, clients via lien magic |
+| **Dev / Test** | `dev/thomas-test` | URL Vercel auto (`lor-squad-wellness-git-dev-thomas-test-tomkoss31.vercel.app`) ou domaine custom à définir | Thomas uniquement |
+
+### ⚠️ Base Supabase partagée
+
+**Les 2 environnements parlent à la même base Supabase**
+(`gqxnndwrdbghxflwmfxy`). Conséquence :
+
+- Les migrations DB impactent **les 2 environnements** simultanément
+- Les RLS policies, Edge Functions, triggers Postgres sont partagés
+- Les données (clients, bilans, RDV, messages) sont les mêmes
+
+Pour 90% des features front-only (UI, composants, logique React), la
+séparation est totale. Pour les migrations DB, coordination obligatoire.
+
+### Preview deployments Vercel
+
+Vercel surveille automatiquement toutes les branches pushées sur GitHub
+et crée un preview deployment par branche. Pas de configuration
+supplémentaire requise dans `vercel.json` — le comportement par défaut
+convient.
+
+URL pattern auto :
+```
+https://lor-squad-wellness-git-<branch-slug>-tomkoss31.vercel.app
+```
+
+Pour `dev/thomas-test` :
+```
+https://lor-squad-wellness-git-dev-thomas-test-tomkoss31.vercel.app
+```
+
+Vérification en live : https://vercel.com/tomkoss31/lor-squad-wellness/deployments
+(filtrer par branche `dev/thomas-test`).
+
+---
+
+## Workflows de développement
+
+### A. Nouvelle feature (usage quotidien)
+
+```bash
+# 1. Partir toujours de dev/thomas-test (pas de claude/focused-pike)
+git checkout dev/thomas-test
+git pull origin dev/thomas-test
+
+# 2. Créer la feature branch
+git checkout -b feat/ma-nouvelle-feature
+
+# 3. Développer, commiter
+git add <fichiers>
+git commit -m "feat: ..."
+
+# 4. Push + merger dans dev/thomas-test
+git push -u origin feat/ma-nouvelle-feature
+git checkout dev/thomas-test
+git merge feat/ma-nouvelle-feature
+git push origin dev/thomas-test
+
+# 5. Vercel déploie sur l'URL dev en 1-2 min
+# 6. Thomas teste sur l'URL dev
+```
+
+**Quand la feature est validée en dev**, merger vers la prod :
+
+```bash
+git checkout claude/focused-pike
+git pull origin claude/focused-pike
+git merge dev/thomas-test  # ou cherry-pick des commits spécifiques
+git push origin claude/focused-pike
+# Vercel déploie sur app.lorsquad.com en 1-2 min
+```
+
+### B. Fix urgent (régression bloquante en prod)
+
+Pas le temps de passer par dev. Fix direct en prod, puis sync vers dev :
+
+```bash
+# 1. Partir de claude/focused-pike (prod)
+git checkout claude/focused-pike
+git pull origin claude/focused-pike
+
+# 2. Créer la fix branch
+git checkout -b fix/blocage-melanie-xyz
+
+# 3. Fixer + tester localement
+git add <fichiers>
+git commit -m "fix: ..."
+
+# 4. Merger en prod direct
+git checkout claude/focused-pike
+git merge fix/blocage-melanie-xyz
+git push origin claude/focused-pike
+
+# 5. Sync dev avec prod pour rester aligné
+git checkout dev/thomas-test
+git merge claude/focused-pike
+git push origin dev/thomas-test
+```
+
+### C. Sync hebdomadaire dev avec prod (recommandé)
+
+Pour éviter que `dev/thomas-test` divergent trop loin de prod après
+plusieurs semaines de travail, faire chaque vendredi ou lundi :
+
+```bash
+git checkout dev/thomas-test
+git pull origin dev/thomas-test
+git merge claude/focused-pike
+git push origin dev/thomas-test
+```
+
+Si conflits → les résoudre en gardant la version qui fait sens
+(généralement le dev a la version la plus à jour).
+
+---
+
+## Règles importantes
+
+### ❌ À NE JAMAIS FAIRE
+
+- `git push --force` sur `claude/focused-pike` (prod) — risque de perdre
+  des commits de Mélanie ou de l'équipe
+- Supprimer `dev/thomas-test` ou `claude/focused-pike`
+- Merger une feature branch directement dans `claude/focused-pike` sans
+  passer par `dev/thomas-test` (sauf cas fix urgent)
+- Appliquer une migration DB sans prévenir (impact les 2 environnements)
+
+### ✅ À TOUJOURS FAIRE
+
+- Créer une `feat/X` depuis `dev/thomas-test` pour une nouvelle feature
+- Créer une `fix/X` depuis `claude/focused-pike` pour un fix urgent
+- Tester sur l'URL dev avant de merger en prod
+- Sync hebdomadaire dev avec prod
+- Documenter les migrations DB dans `CLAUDE.md` et coordonner
+
+### Migrations DB : protocole prudent
+
+1. Écrire la migration dans `supabase/migrations/`
+2. Tester en local si possible (via `supabase db push --dry-run`)
+3. L'appliquer via `supabase db push --linked --include-all`
+4. Vérifier que **les 2 environnements marchent** (prod + dev)
+5. Si régression détectée → rollback migration via SQL Editor Supabase
+6. **Jamais** de migration le vendredi soir ou avant un créneau RDV
+   de l'équipe
+
+---
+
+## Domaine custom dev (optionnel)
+
+Pour avoir une URL plus jolie type `dev-thomas.lorsquad.com` au lieu de
+l'URL Vercel auto-générée :
+
+1. Aller sur Vercel → Settings → Domains :
+   https://vercel.com/tomkoss31/lor-squad-wellness/settings/domains
+2. Cliquer **Add Domain** → entrer `dev-thomas.lorsquad.com`
+3. Vercel demande de choisir la branche associée → sélectionner
+   `dev/thomas-test`
+4. Vercel fournit 1 enregistrement DNS (CNAME) à ajouter chez OVH
+   (ou registrar du domaine `lorsquad.com`)
+5. Se connecter à OVH → zone DNS du domaine `lorsquad.com`
+6. Ajouter l'enregistrement CNAME `dev-thomas` → `cname.vercel-dns.com`
+7. Attendre propagation DNS (~5-10 min)
+8. Vérifier sur `https://dev-thomas.lorsquad.com`
+
+---
+
+## URL de référence
+
+| Service | URL |
+|---|---|
+| Repo GitHub | https://github.com/tomkoss31/Lor-Squad-Wellness |
+| Production | https://app.lorsquad.com |
+| Dev preview auto | https://lor-squad-wellness-git-dev-thomas-test-tomkoss31.vercel.app |
+| Dev custom (à setup) | https://dev-thomas.lorsquad.com |
+| Vercel Dashboard | https://vercel.com/tomkoss31/lor-squad-wellness |
+| Supabase Dashboard | https://supabase.com/dashboard/project/gqxnndwrdbghxflwmfxy |
+
+---
+
+## FAQ rapide
+
+**Q : Si je merge dev → prod et ça casse, comment revert ?**
+R : `git revert <commit-sha>` sur `claude/focused-pike` + push. Vercel
+redéploie la version précédente en 1-2 min.
+
+**Q : Est-ce que Mélanie voit les expérimentations de Thomas ?**
+R : Non, elle est exclusivement sur `app.lorsquad.com` qui pointe sur
+`claude/focused-pike`. Elle ne voit rien de `dev/thomas-test` tant que
+Thomas n'a pas mergé explicitement.
+
+**Q : Si je fais une feature qui modifie la DB, comment tester en dev
+sans impacter prod ?**
+R : Pas possible aujourd'hui — les 2 envs partagent la même DB.
+Prévoir plus tard 2 projets Supabase séparés (dev + prod) si le besoin
+émerge. Pour l'instant, tester les migrations en heures creuses et
+coordonner avec Thomas.
+
+**Q : Est-ce que les branches `feat/*` existantes sont impactées ?**
+R : Non, elles sont indépendantes. Elles continuent leur vie.
+L'important : désormais les créer depuis `dev/thomas-test`
+(pas de `claude/focused-pike`) pour ne pas embarquer de commits prod
+non testés dans la branche feature.
+
+---
+
+Document à mettre à jour dès que le workflow évolue.

--- a/src/components/client-app/ClientPublicShareConsent.tsx
+++ b/src/components/client-app/ClientPublicShareConsent.tsx
@@ -105,12 +105,18 @@ export function ClientPublicShareConsent({ clientId, clientFirstName }: Props) {
         .update({ public_share_revoked_at: now })
         .eq("id", clientId);
       if (upErr) throw upErr;
-      // Révoquer tous les tokens actifs (cascade)
-      await sb
+      // Révocation en batch : 1 seule requête atomique côté Postgres.
+      // Filtre par client_id ET tokens non encore révoqués (idempotent —
+      // si re-clic révoquer, n'écrase pas les revoked_at existants).
+      // Audit Bug #3 — cascade revocation performance + atomicité.
+      const { error: revokeErr } = await sb
         .from("client_public_share_tokens")
         .update({ revoked_at: now })
         .eq("client_id", clientId)
         .is("revoked_at", null);
+      if (revokeErr) {
+        console.error("[share-consent] revoke tokens failed", revokeErr);
+      }
       await load();
     } catch (e) {
       setErr(e instanceof Error ? e.message : "Erreur.");

--- a/src/config/teamConfig.ts
+++ b/src/config/teamConfig.ts
@@ -13,14 +13,25 @@
 import type { User } from "../types/domain";
 
 /**
- * IDs Supabase des 2 comptes couple. Tu peux :
- *  - laisser vide → résolution automatique par nom ("Thomas Houbert"
- *    et "Mélanie") sur la liste `users` de l'AppContext.
- *  - renseigner les UUIDs → priorité absolue (plus stable).
+ * UUIDs hardcodés des 2 comptes couple Thomas + Mélanie.
+ *
+ * Si vide, fallback sur résolution par nom (fragile : casse silencieusement
+ * si un nom est modifié en DB — ajout nom de famille, accent supprimé,
+ * orthographe différente, etc.).
+ *
+ * À renseigner avec les vrais UUIDs récupérés depuis Supabase Studio :
+ *
+ *   SELECT id, full_name FROM users
+ *   WHERE full_name ILIKE '%thomas%' OR full_name ILIKE '%mélanie%';
+ *
+ * Une fois renseigné, la fusion couple devient stable même si les noms
+ * changent en DB. Priorité absolue sur la résolution par nom.
+ *
+ * Audit Bug #6 — résolution couple par nom fragile.
  */
 export const COUPLE_USER_IDS_HARDCODED: string[] = [
-  // "uuid-thomas-here",
-  // "uuid-melanie-here",
+  // "uuid-thomas-a-renseigner",
+  // "uuid-melanie-a-renseigner",
 ];
 
 /**

--- a/src/data/programs.ts
+++ b/src/data/programs.ts
@@ -198,3 +198,18 @@ export const PROGRAMS_LEGACY: Program[] = [
   ...PROGRAM_CHOICES.filter((c) => c.category !== "unit").map(programFromChoice),
   ...BOOSTERS.map(programFromBooster),
 ];
+
+// Mapping des produits inclus par programme (clé = id legacy `p-${choice.id}`).
+// Source de vérité unique pour éviter les divergences entre composants.
+// Couvre TOUS les programmes (weight-loss + sport + unit).
+// Audit Bug #5 — sport-discovery / sport-premium étaient absents,
+// le coach choisissant "Premium Sport" récupérait une routine matin vide.
+export const PROGRAM_INCLUDED_PRODUCT_IDS: Record<string, string[]> = {
+  "p-discovery": ["aloe-vera", "the-51g", "formula-1"],
+  "p-premium": ["aloe-vera", "the-51g", "formula-1", "pdm"],
+  "p-booster1": ["aloe-vera", "the-51g", "formula-1", "pdm", "multifibres"],
+  "p-booster2": ["aloe-vera", "the-51g", "formula-1", "pdm", "phyto-brule-graisse"],
+  "p-sport-discovery": ["formula-1", "barres-proteinees-achieve"],
+  "p-sport-premium": ["formula-1", "barres-proteinees-achieve", "rebuild-strength", "cr7-drive"],
+  "p-unit": [],
+};

--- a/src/pages/NewAssessmentPage.tsx
+++ b/src/pages/NewAssessmentPage.tsx
@@ -20,7 +20,7 @@ import { ProgramChoiceCard } from "../components/assessment/ProgramChoiceCard";
 import { RoutineMatinList } from "../components/assessment/RoutineMatinList";
 import { ProgrammeTicket, type TicketAddOn } from "../components/assessment/ProgrammeTicket";
 import { SelectableProductCard } from "../components/assessment/SelectableProductCard";
-import { PROGRAM_CHOICES, getProgramById, BOOSTERS, type ProgramChoiceId } from "../data/programs";
+import { PROGRAM_CHOICES, PROGRAM_INCLUDED_PRODUCT_IDS, getProgramById, BOOSTERS, type ProgramChoiceId } from "../data/programs";
 import { FelicitationsStep } from "../components/assessment/FelicitationsStep";
 import { NotesPanel } from "../components/assessment/NotesPanel";
 import { ValidationBlockedBanner } from "../components/assessment/ValidationBlockedBanner";
@@ -427,12 +427,8 @@ const timelineOptions = [
   "9 mois"
 ];
 
-const PROGRAM_INCLUDED_PRODUCT_IDS: Record<string, string[]> = {
-  "p-discovery": ["aloe-vera", "the-51g", "formula-1"],
-  "p-premium": ["aloe-vera", "the-51g", "formula-1", "pdm"],
-  "p-booster-1": ["aloe-vera", "the-51g", "formula-1", "pdm", "multifibres"],
-  "p-booster-2": ["aloe-vera", "the-51g", "formula-1", "pdm", "phyto-brule-graisse"]
-};
+// Mapping centralisé dans data/programs.ts (source de vérité unique
+// couvrant aussi les programmes sport — Audit Bug #5).
 
 
 

--- a/supabase/functions/resolve-public-share/index.ts
+++ b/supabase/functions/resolve-public-share/index.ts
@@ -35,6 +35,19 @@ function json(payload: unknown, status = 200): Response {
   });
 }
 
+/**
+ * Classifie un user-agent en device class (mobile/desktop/bot/unknown).
+ * RGPD : stocker juste la classe au lieu du UA brut limite l'exposition
+ * de données techniques (device, OS, version) tout en gardant l'utilité
+ * statistique (compteur de vues par type).
+ */
+function classifyUserAgent(ua: string | null | undefined): string {
+  if (!ua) return "unknown";
+  if (/Bot|Crawler|Spider|HeadlessChrome/i.test(ua)) return "bot";
+  if (/Mobile|Android|iPhone|iPad|Tablet/i.test(ua)) return "mobile";
+  return "desktop";
+}
+
 async function sha256(input: string): Promise<string> {
   const buf = new TextEncoder().encode(IP_HASH_SALT + input);
   const hash = await crypto.subtle.digest("SHA-256", buf);
@@ -195,7 +208,7 @@ serve(async (req) => {
         req.headers.get("x-real-ip") ??
         "unknown";
       const ipHash = rawIp !== "unknown" ? await sha256(rawIp) : null;
-      const userAgent = req.headers.get("user-agent")?.slice(0, 500) ?? null;
+      const userAgent = classifyUserAgent(req.headers.get("user-agent"));
 
       await sb.from("client_public_share_views").insert({
         token_id: t.id,

--- a/supabase/functions/resolve-public-share/index.ts
+++ b/supabase/functions/resolve-public-share/index.ts
@@ -16,6 +16,11 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
+// Salt secret stocké dans Supabase Functions secrets (env IP_HASH_SALT).
+// Empêche l'attaque par rainbow tables sur les IP hashées (RGPD strict).
+// Si la variable n'est pas définie (ex: dev), fallback sur chaîne vide.
+const IP_HASH_SALT = Deno.env.get("IP_HASH_SALT") ?? "";
+
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
@@ -31,7 +36,7 @@ function json(payload: unknown, status = 200): Response {
 }
 
 async function sha256(input: string): Promise<string> {
-  const buf = new TextEncoder().encode(input);
+  const buf = new TextEncoder().encode(IP_HASH_SALT + input);
   const hash = await crypto.subtle.digest("SHA-256", buf);
   return Array.from(new Uint8Array(hash))
     .map((b) => b.toString(16).padStart(2, "0"))


### PR DESCRIPTION
Création de la branche permanente dev/thomas-test pour permettre à Thomas d'expérimenter ses features sans impacter l'équipe coach qui utilise claude/focused-pike en prod (Mélanie + distris + clients).

Ajouts :
- docs/DEV_WORKFLOW.md : workflow complet dev/prod
  - 2 environnements documentés (prod / dev)
  - Workflows A (feature), B (fix urgent), C (sync hebdo)
  - Règles absolues (jamais de force push, pas de merge direct prod, etc.)
  - Protocole prudent migrations DB
  - Procédure domaine custom dev-thomas.lorsquad.com
  - FAQ rapide
- CLAUDE.md : section en tête résumant le workflow + pointeur vers DEV_WORKFLOW.md

Notes :
- vercel.json NON modifié (preview deployments activés par défaut par Vercel sur toutes les branches, aucun ajout nécessaire)
- claude/focused-pike (prod) strictement intact — aucun nouveau commit
- Base Supabase reste partagée entre prod et dev (migrations DB continuent d'impacter les 2 environnements, coordination requise)