### PR TITLE
Top 5 fixes audit (Bug #5, #4, #11, #6, #3)

### DIFF
--- a/src/components/client-app/ClientPublicShareConsent.tsx
+++ b/src/components/client-app/ClientPublicShareConsent.tsx
@@ -105,12 +105,18 @@ export function ClientPublicShareConsent({ clientId, clientFirstName }: Props) {
         .update({ public_share_revoked_at: now })
         .eq("id", clientId);
       if (upErr) throw upErr;
-      // Révoquer tous les tokens actifs (cascade)
-      await sb
+      // Révocation en batch : 1 seule requête atomique côté Postgres.
+      // Filtre par client_id ET tokens non encore révoqués (idempotent —
+      // si re-clic révoquer, n'écrase pas les revoked_at existants).
+      // Audit Bug #3 — cascade revocation performance + atomicité.
+      const { error: revokeErr } = await sb
         .from("client_public_share_tokens")
         .update({ revoked_at: now })
         .eq("client_id", clientId)
         .is("revoked_at", null);
+      if (revokeErr) {
+        console.error("[share-consent] revoke tokens failed", revokeErr);
+      }
       await load();
     } catch (e) {
       setErr(e instanceof Error ? e.message : "Erreur.");

--- a/src/config/teamConfig.ts
+++ b/src/config/teamConfig.ts
@@ -13,14 +13,25 @@
 import type { User } from "../types/domain";
 
 /**
- * IDs Supabase des 2 comptes couple. Tu peux :
- *  - laisser vide → résolution automatique par nom ("Thomas Houbert"
- *    et "Mélanie") sur la liste `users` de l'AppContext.
- *  - renseigner les UUIDs → priorité absolue (plus stable).
+ * UUIDs hardcodés des 2 comptes couple Thomas + Mélanie.
+ *
+ * Si vide, fallback sur résolution par nom (fragile : casse silencieusement
+ * si un nom est modifié en DB — ajout nom de famille, accent supprimé,
+ * orthographe différente, etc.).
+ *
+ * À renseigner avec les vrais UUIDs récupérés depuis Supabase Studio :
+ *
+ *   SELECT id, full_name FROM users
+ *   WHERE full_name ILIKE '%thomas%' OR full_name ILIKE '%mélanie%';
+ *
+ * Une fois renseigné, la fusion couple devient stable même si les noms
+ * changent en DB. Priorité absolue sur la résolution par nom.
+ *
+ * Audit Bug #6 — résolution couple par nom fragile.
  */
 export const COUPLE_USER_IDS_HARDCODED: string[] = [
-  // "uuid-thomas-here",
-  // "uuid-melanie-here",
+  // "uuid-thomas-a-renseigner",
+  // "uuid-melanie-a-renseigner",
 ];
 
 /**

--- a/src/data/programs.ts
+++ b/src/data/programs.ts
@@ -198,3 +198,18 @@ export const PROGRAMS_LEGACY: Program[] = [
   ...PROGRAM_CHOICES.filter((c) => c.category !== "unit").map(programFromChoice),
   ...BOOSTERS.map(programFromBooster),
 ];
+
+// Mapping des produits inclus par programme (clé = id legacy `p-${choice.id}`).
+// Source de vérité unique pour éviter les divergences entre composants.
+// Couvre TOUS les programmes (weight-loss + sport + unit).
+// Audit Bug #5 — sport-discovery / sport-premium étaient absents,
+// le coach choisissant "Premium Sport" récupérait une routine matin vide.
+export const PROGRAM_INCLUDED_PRODUCT_IDS: Record<string, string[]> = {
+  "p-discovery": ["aloe-vera", "the-51g", "formula-1"],
+  "p-premium": ["aloe-vera", "the-51g", "formula-1", "pdm"],
+  "p-booster1": ["aloe-vera", "the-51g", "formula-1", "pdm", "multifibres"],
+  "p-booster2": ["aloe-vera", "the-51g", "formula-1", "pdm", "phyto-brule-graisse"],
+  "p-sport-discovery": ["formula-1", "barres-proteinees-achieve"],
+  "p-sport-premium": ["formula-1", "barres-proteinees-achieve", "rebuild-strength", "cr7-drive"],
+  "p-unit": [],
+};

--- a/src/pages/NewAssessmentPage.tsx
+++ b/src/pages/NewAssessmentPage.tsx
@@ -20,7 +20,7 @@ import { ProgramChoiceCard } from "../components/assessment/ProgramChoiceCard";
 import { RoutineMatinList } from "../components/assessment/RoutineMatinList";
 import { ProgrammeTicket, type TicketAddOn } from "../components/assessment/ProgrammeTicket";
 import { SelectableProductCard } from "../components/assessment/SelectableProductCard";
-import { PROGRAM_CHOICES, getProgramById, BOOSTERS, type ProgramChoiceId } from "../data/programs";
+import { PROGRAM_CHOICES, PROGRAM_INCLUDED_PRODUCT_IDS, getProgramById, BOOSTERS, type ProgramChoiceId } from "../data/programs";
 import { FelicitationsStep } from "../components/assessment/FelicitationsStep";
 import { NotesPanel } from "../components/assessment/NotesPanel";
 import { ValidationBlockedBanner } from "../components/assessment/ValidationBlockedBanner";
@@ -427,12 +427,8 @@ const timelineOptions = [
   "9 mois"
 ];
 
-const PROGRAM_INCLUDED_PRODUCT_IDS: Record<string, string[]> = {
-  "p-discovery": ["aloe-vera", "the-51g", "formula-1"],
-  "p-premium": ["aloe-vera", "the-51g", "formula-1", "pdm"],
-  "p-booster-1": ["aloe-vera", "the-51g", "formula-1", "pdm", "multifibres"],
-  "p-booster-2": ["aloe-vera", "the-51g", "formula-1", "pdm", "phyto-brule-graisse"]
-};
+// Mapping centralisé dans data/programs.ts (source de vérité unique
+// couvrant aussi les programmes sport — Audit Bug #5).
 
 
 

--- a/supabase/functions/resolve-public-share/index.ts
+++ b/supabase/functions/resolve-public-share/index.ts
@@ -35,6 +35,19 @@ function json(payload: unknown, status = 200): Response {
   });
 }
 
+/**
+ * Classifie un user-agent en device class (mobile/desktop/bot/unknown).
+ * RGPD : stocker juste la classe au lieu du UA brut limite l'exposition
+ * de données techniques (device, OS, version) tout en gardant l'utilité
+ * statistique (compteur de vues par type).
+ */
+function classifyUserAgent(ua: string | null | undefined): string {
+  if (!ua) return "unknown";
+  if (/Bot|Crawler|Spider|HeadlessChrome/i.test(ua)) return "bot";
+  if (/Mobile|Android|iPhone|iPad|Tablet/i.test(ua)) return "mobile";
+  return "desktop";
+}
+
 async function sha256(input: string): Promise<string> {
   const buf = new TextEncoder().encode(IP_HASH_SALT + input);
   const hash = await crypto.subtle.digest("SHA-256", buf);
@@ -195,7 +208,7 @@ serve(async (req) => {
         req.headers.get("x-real-ip") ??
         "unknown";
       const ipHash = rawIp !== "unknown" ? await sha256(rawIp) : null;
-      const userAgent = req.headers.get("user-agent")?.slice(0, 500) ?? null;
+      const userAgent = classifyUserAgent(req.headers.get("user-agent"));
 
       await sb.from("client_public_share_views").insert({
         token_id: t.id,

--- a/supabase/functions/resolve-public-share/index.ts
+++ b/supabase/functions/resolve-public-share/index.ts
@@ -16,6 +16,11 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
+// Salt secret stocké dans Supabase Functions secrets (env IP_HASH_SALT).
+// Empêche l'attaque par rainbow tables sur les IP hashées (RGPD strict).
+// Si la variable n'est pas définie (ex: dev), fallback sur chaîne vide.
+const IP_HASH_SALT = Deno.env.get("IP_HASH_SALT") ?? "";
+
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
@@ -31,7 +36,7 @@ function json(payload: unknown, status = 200): Response {
 }
 
 async function sha256(input: string): Promise<string> {
-  const buf = new TextEncoder().encode(input);
+  const buf = new TextEncoder().encode(IP_HASH_SALT + input);
   const hash = await crypto.subtle.digest("SHA-256", buf);
   return Array.from(new Uint8Array(hash))
     .map((b) => b.toString(16).padStart(2, "0"))


### PR DESCRIPTION
Application des 5 fixes prioritaires identifiés dans l'audit du 27/04/2026.

## Fixes appliqués
- **Bug #5** : PROGRAM_INCLUDED_PRODUCT_IDS complet pour sport (fix bonus : p-booster1/2 nomenclature)
- **Bug #4** : Salt sur IP hash RGPD (env IP_HASH_SALT, fallback backward-compat)
- **Bug #11** : User_agent simplifié (mobile/desktop/bot/unknown)
- **Bug #6** : Documentation COUPLE_USER_IDS_HARDCODED + SQL helper
- **Bug #3** : Capture d'erreur sur batch revocation (observability)

## Tests à faire sur preview Vercel dev
- Bug #5 : nouveau bilan sport → "Premium Sport" → routine matin = 4 produits
- Bug #6 : page Team → couple Thomas+Mélanie OK
- Bug #3 : créer consentement, 2-3 tokens, retirer accord → tokens revoked

## Actions post-merge prod (faites en auto par le prompt)
- Doc UUIDs couple à renseigner manuellement par Thomas
- Secret IP_HASH_SALT à créer
- Redeploy edge function resolve-public-share