### PR TITLE
Fix bugs panier étape 13 (auto-sélection + quantités + besoins)

### DIFF
--- a/src/pages/NewAssessmentPage.tsx
+++ b/src/pages/NewAssessmentPage.tsx
@@ -440,6 +440,11 @@ export function NewAssessmentPage() {
   const prospectId = searchParams.get("prospectId");
   const sourceProspect = prospectId ? prospects.find((p) => p.id === prospectId) : undefined;
   const stepRailRef = useRef<HTMLDivElement | null>(null);
+  // Chantier fix bugs panier (2026-04-27) : flag pour init UNIQUE des
+  // suggestions par défaut à l'entrée de l'étape "program". Sans ce flag,
+  // l'useEffect réinjectait les défauts à chaque fois que l'utilisateur
+  // vidait le panier (auto-sélection forcée).
+  const programInitRef = useRef(false);
   const [form, setForm] = useState(initialForm);
   const [currentStep, setCurrentStep] = useState(0);
   const [saveError, setSaveError] = useState("");
@@ -666,8 +671,11 @@ export function NewAssessmentPage() {
   const defaultSuggestedProductIds = recommendationPlan.needs
     .flatMap((need) => need.products.slice(0, 1).map((product) => product.id))
     .filter((productId, index, array) => array.indexOf(productId) === index);
-  const effectiveSelectedProductIds =
-    form.selectedProductIds.length > 0 ? form.selectedProductIds : defaultSuggestedProductIds;
+  // Chantier fix bugs panier (2026-04-27) : plus de fallback render-time
+  // vers defaultSuggestedProductIds. Si l'utilisateur a tout désélectionné,
+  // le panier reste vide (comportement attendu). L'initialisation des
+  // recommandations se fait via useEffect ref-guardé ci-dessous.
+  const effectiveSelectedProductIds = form.selectedProductIds;
   const allRecommendableProducts = [
     ...recommendationPlan.needs.flatMap((need) => need.products),
     ...recommendationPlan.optionalUpsells,
@@ -696,15 +704,24 @@ export function NewAssessmentPage() {
   const addOnProducts = selectedRecommendationProducts;
 
   useEffect(() => {
+    // Reset le flag dès qu'on quitte l'étape program → permet une nouvelle
+    // initialisation propre si l'utilisateur revient en arrière puis avance.
     if (currentStepId !== 'program') {
+      programInitRef.current = false;
       return;
     }
 
-    if (form.selectedProductIds.length || !defaultSuggestedProductIds.length) {
+    // Garde-fou : init UNE SEULE fois par entrée dans l'étape. Sans ça,
+    // toute désélection complète relance le pré-remplissage automatique
+    // (= bug "auto-sélection forcée" remonté le 27/04).
+    if (programInitRef.current) {
       return;
     }
+    programInitRef.current = true;
 
-    update("selectedProductIds", defaultSuggestedProductIds);
+    if (defaultSuggestedProductIds.length && !form.selectedProductIds.length) {
+      update("selectedProductIds", defaultSuggestedProductIds);
+    }
   }, [currentStepId, defaultSuggestedProductIds, form.selectedProductIds.length]);
 
 

--- a/src/pages/NewAssessmentPage.tsx
+++ b/src/pages/NewAssessmentPage.tsx
@@ -686,13 +686,11 @@ export function NewAssessmentPage() {
         effectiveSelectedProductIds.includes(product.id) &&
         array.findIndex((item) => item.id === product.id) === index
     );
-  const recommendedProgram =
-    mainPrograms.find((program) => program.id === recommendationPlan.recommendedProgramId) ??
-    null;
-  const activeProgram = selectedProgram ?? recommendedProgram;
   // displayedProgramPrice* + addOnProductsTotalPrice retirés avec le résumé
   // administratif (Chantier Félicitations 2026-04-20). selectedProgram reste
   // utilisé pour le titre programme dans handleSaveAssessment.
+  // `activeProgram` et `recommendedProgram` supprimés en 2026-04-27 avec
+  // le retrait du filtre includedProgramProductIds (plus consommés).
   // Chantier fix bugs panier (2026-04-27) : on retire le filtre
   // `includedProgramProductIds` qui exclut auparavant tout produit déjà
   // inclus dans le programme de base. Conséquence du filtre : Formula 1,

--- a/src/pages/NewAssessmentPage.tsx
+++ b/src/pages/NewAssessmentPage.tsx
@@ -20,7 +20,7 @@ import { ProgramChoiceCard } from "../components/assessment/ProgramChoiceCard";
 import { RoutineMatinList } from "../components/assessment/RoutineMatinList";
 import { ProgrammeTicket, type TicketAddOn } from "../components/assessment/ProgrammeTicket";
 import { SelectableProductCard } from "../components/assessment/SelectableProductCard";
-import { PROGRAM_CHOICES, PROGRAM_INCLUDED_PRODUCT_IDS, getProgramById, BOOSTERS, type ProgramChoiceId } from "../data/programs";
+import { PROGRAM_CHOICES, getProgramById, BOOSTERS, type ProgramChoiceId } from "../data/programs";
 import { FelicitationsStep } from "../components/assessment/FelicitationsStep";
 import { NotesPanel } from "../components/assessment/NotesPanel";
 import { ValidationBlockedBanner } from "../components/assessment/ValidationBlockedBanner";
@@ -685,12 +685,15 @@ export function NewAssessmentPage() {
   // displayedProgramPrice* + addOnProductsTotalPrice retirés avec le résumé
   // administratif (Chantier Félicitations 2026-04-20). selectedProgram reste
   // utilisé pour le titre programme dans handleSaveAssessment.
-  const includedProgramProductIds = activeProgram
-    ? new Set(PROGRAM_INCLUDED_PRODUCT_IDS[activeProgram.id] ?? [])
-    : new Set<string>();
-  const addOnProducts = selectedRecommendationProducts.filter(
-    (product) => !includedProgramProductIds.has(product.id)
-  );
+  // Chantier fix bugs panier (2026-04-27) : on retire le filtre
+  // `includedProgramProductIds` qui exclut auparavant tout produit déjà
+  // inclus dans le programme de base. Conséquence du filtre : Formula 1,
+  // PDM, Mélange Boisson Protéinée etc. cochés "Retenu" dans les sections
+  // besoins restaient invisibles dans le total. Désormais : si l'utilisateur
+  // coche "Retenir" sur un produit, il apparaît toujours dans les ajouts
+  // (avec sa quantité), même si le programme inclut déjà 1 unité. Le coach
+  // pilote le stockage explicitement via le stepper.
+  const addOnProducts = selectedRecommendationProducts;
 
   useEffect(() => {
     if (currentStepId !== 'program') {


### PR DESCRIPTION
## Bugs corrigés

### Bug 3 — Produits "besoins" jamais ajoutés au panier (priorité)
Formula 1, PDM, Xtra-Cal, Mélange Boisson Protéinée cochés "Retenu" mais
absents du total et "PV ajouts" reste à 0.0.

**Cause** : `addOnProducts` filtrait tous les produits déjà inclus dans le
programme. **Fix** : retirer le filtre. Le coach pilote explicitement.

### Bug 2 — Quantités ignorées dans le total (résolu par fix Bug 3)
Formula 1 × 5 affichait 63,50€ au lieu de 317,50€.

**Cause** : symptôme dérivé. ProgrammeTicket multipliait déjà par quantity,
mais Formula 1 était strippé par le filtre Bug 3 → invisible dans le ticket.
**Fix Bug 3 résout aussi Bug 2.**

### Bug 1 — Auto-sélection forcée
Impossible d'avoir un panier vide. Désélectionner réintroduit auto.

**Cause** : `effectiveSelectedProductIds` avait un fallback render-time vers
`defaultSuggestedProductIds`. **Fix** : drop fallback + `useRef` flag pour
init unique par entrée dans l'étape.

## Tests à faire sur preview Vercel dev

### Test mode prise de masse
1. Bilan sport intensif/musculation/mass-gain
2. Programme : Premium Sport (285€)
3. Section "besoins" : cocher Formula 1 (quantité 1), puis quantité 2
4. ✅ Panier doit afficher Formula 1 × 2 = 127,00€

### Test mode perte de poids
1. Bilan perte de poids
2. Programme : Premium (234€)
3. Section "besoins" : cocher Formula 1 (×5)
4. ✅ Panier doit afficher Formula 1 × 5 = 317,50€ et total 234 + 317,50 = 551,50€

### Test panier vide
1. Étape 13 Programme
2. Tout désélectionner (boosters + besoins)
3. ✅ Panier doit afficher "AJOUTS (0)" et total = programme seul

### Test mode "À l'unité"
1. Programme : À l'unité (0€)
2. Cocher quelques produits avec quantités variées
3. ✅ Panier doit afficher tous les produits avec leurs quantités

Bugs préexistants remontés lors du test de la PR Top 5 fixes (27/04).