### PR TITLE
Promote dev → prod : RDV visible 15 min après

### DIFF
--- a/src/hooks/useClientPriorityAction.ts
+++ b/src/hooks/useClientPriorityAction.ts
@@ -12,6 +12,7 @@
 
 import { useMemo } from "react";
 import type { Client, FollowUp } from "../types/domain";
+import { RDV_GRACE_PERIOD_MS } from "../lib/timeConstants";
 
 export type PriorityActionType =
   | "plan_rdv"
@@ -45,11 +46,14 @@ export function computePriorityAction(
   )[0];
 
   // ─── 1. plan_rdv ─────────────────────────────────────────────────────
+  // Chantier RDV grâce (2026-04-27) : un RDV reste "upcoming" jusqu'à
+  // 15 min après son heure prévue → empêche le bandeau "Planifier un RDV"
+  // d'apparaître alors que le coach est en train de faire le RDV.
   const upcomingRdv = followUps.find(
     (f) =>
       f.clientId === client.id &&
       (f.status === "scheduled" || f.status === "pending") &&
-      new Date(f.dueDate).getTime() > now.getTime(),
+      new Date(f.dueDate).getTime() + RDV_GRACE_PERIOD_MS > now.getTime(),
   );
 
   const lastContactDate = latestAssessment?.date

--- a/src/hooks/useCopiloteData.ts
+++ b/src/hooks/useCopiloteData.ts
@@ -13,6 +13,7 @@ import {
   daysRemainingInMonth,
   conversionRatePercent,
 } from "../lib/utils/copiloteHelpers";
+import { RDV_GRACE_PERIOD_MS } from "../lib/timeConstants";
 
 const DEFAULT_MONTHLY_PV_TARGET = 13_000;
 
@@ -214,7 +215,13 @@ export function useCopiloteData(now: Date, globalView: boolean = false): Copilot
 
     // ─── Hero : prochain RDV SINON 1er suivi SINON null ────────────────────
     let nextAction: CopiloteNextAction | null = null;
-    const upcomingToday = todayAgendaRaw.filter((a) => a.time.getTime() >= now.getTime());
+    // Chantier RDV grâce (2026-04-27) : un RDV reste "upcoming" jusqu'à
+    // 15 min après son heure prévue. Permet au coach d'avoir le hero
+    // "prochain RDV" toujours actif pendant le RDV en cours (retard client,
+    // RDV démarré depuis quelques minutes, etc.).
+    const upcomingToday = todayAgendaRaw.filter(
+      (a) => a.time.getTime() + RDV_GRACE_PERIOD_MS >= now.getTime(),
+    );
     if (upcomingToday.length > 0) {
       const first = upcomingToday[0];
       nextAction = {

--- a/src/lib/timeConstants.ts
+++ b/src/lib/timeConstants.ts
@@ -1,0 +1,19 @@
+// Chantier RDV grâce 15 min (2026-04-27).
+// Constantes temporelles partagées (front uniquement).
+
+/**
+ * Période de grâce après l'heure prévue d'un RDV.
+ *
+ * Pendant ces 15 minutes, le RDV reste considéré comme "à venir / en cours"
+ * partout dans l'app coach :
+ *  - hero "prochain RDV" du dashboard Co-pilote
+ *  - cas plan_rdv du hook useClientPriorityAction
+ *
+ * Au-delà de la grâce, le comportement actuel reprend (RDV considéré comme
+ * passé, le bandeau "Planifier un RDV" peut redevenir visible).
+ *
+ * Usage type :
+ *   const isUpcomingOrInProgress =
+ *     scheduledTs + RDV_GRACE_PERIOD_MS > Date.now();
+ */
+export const RDV_GRACE_PERIOD_MS = 15 * 60 * 1000;


### PR DESCRIPTION
Promotion vers production du fix RDV grâce 15 min.

Validé par Thomas sur preview Vercel dev.

Constante centralisée RDV_GRACE_PERIOD_MS dans src/lib/timeConstants.ts.
Applied dans useCopiloteData (hero RDV) + useClientPriorityAction (plan_rdv).