### PR TITLE
Observabilité 'clients vides' : logs edge + bandeau UI fallback

### DIFF
--- a/src/components/client-app/ClientAppFallbackBanner.tsx
+++ b/src/components/client-app/ClientAppFallbackBanner.tsx
@@ -1,0 +1,70 @@
+// Chantier observabilité (2026-04-25).
+// Bandeau orange visible UNIQUEMENT quand l'edge function client-app-data
+// a échoué et que l'app affiche le snapshot figé. Permet au client de
+// comprendre que ses données ne sont pas fraîches et au coach de
+// diagnostiquer (vu côté UI = bug remonté).
+
+interface Props {
+  onContact?: () => void;
+}
+
+export function ClientAppFallbackBanner({ onContact }: Props) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        background: "#FAEEDA",
+        borderLeft: "4px solid #BA7517",
+        padding: "12px 16px",
+        margin: "8px 14px",
+        borderRadius: 8,
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        fontFamily: "'DM Sans', sans-serif",
+      }}
+    >
+      <span style={{ fontSize: 20 }} aria-hidden="true">
+        ⚠️
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: "#854F0B" }}>
+          Données partielles affichées
+        </div>
+        <div
+          style={{
+            fontSize: 11,
+            color: "#854F0B",
+            opacity: 0.85,
+            marginTop: 2,
+            lineHeight: 1.4,
+          }}
+        >
+          Tes dernières infos sont en cours de mise à jour. Contacte ton
+          coach si le souci persiste.
+        </div>
+      </div>
+      {onContact ? (
+        <button
+          type="button"
+          onClick={onContact}
+          style={{
+            background: "#BA7517",
+            color: "#fff",
+            border: "none",
+            padding: "6px 12px",
+            borderRadius: 8,
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: "pointer",
+            flexShrink: 0,
+            fontFamily: "inherit",
+          }}
+        >
+          Contacter
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/hooks/useClientLiveData.ts
+++ b/src/hooks/useClientLiveData.ts
@@ -81,10 +81,22 @@ export interface ClientLiveData {
 
 const FOCUS_DEBOUNCE_MS = 5000;
 
+/**
+ * Origine actuelle des données rendues par l'app client.
+ * - "edge"     : fetch edge function client-app-data réussi (données fraîches)
+ * - "snapshot" : fetch a échoué → fallback sur le snapshot figé (DB)
+ * - "unknown"  : avant le 1er fetch (ou no-token)
+ *
+ * Permet d'afficher un bandeau UI quand "snapshot" pour rendre visible un
+ * éventuel bug d'edge function (chantier observabilité 2026-04-25).
+ */
+export type ClientDataSource = "edge" | "snapshot" | "unknown";
+
 export function useClientLiveData(token: string | null | undefined) {
   const [liveData, setLiveData] = useState<ClientLiveData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [dataSource, setDataSource] = useState<ClientDataSource>("unknown");
   const lastFetchRef = useRef<number>(0);
 
   const fetchLiveData = useCallback(
@@ -123,10 +135,15 @@ export function useClientLiveData(token: string | null | undefined) {
         }
         const json = (await res.json()) as ClientLiveData;
         setLiveData(json);
+        setDataSource("edge");
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn("[useClientLiveData] fetch failed, fallback snapshot:", msg);
         setError(msg);
+        // Pas de liveData → l'UI consomme le snapshot DB. On le signale
+        // explicitement pour que le bandeau ClientAppFallbackBanner
+        // s'affiche (chantier observabilité 2026-04-25).
+        setDataSource("snapshot");
       } finally {
         setLoading(false);
       }
@@ -153,5 +170,11 @@ export function useClientLiveData(token: string | null | undefined) {
     };
   }, [token, fetchLiveData]);
 
-  return { liveData, loading, error, refetch: () => fetchLiveData({ force: true }) };
+  return {
+    liveData,
+    loading,
+    error,
+    dataSource,
+    refetch: () => fetchLiveData({ force: true }),
+  };
 }

--- a/src/pages/ClientAppPage.tsx
+++ b/src/pages/ClientAppPage.tsx
@@ -15,6 +15,7 @@ import { EnrichedAssessmentHistory } from '../components/client-app/EnrichedAsse
 import type { BreakfastAnalysis } from '../types/domain'
 import { useOnboardingState } from '../features/onboarding/hooks/useOnboardingState'
 import { useClientLiveData } from '../hooks/useClientLiveData'
+import { ClientAppFallbackBanner } from '../components/client-app/ClientAppFallbackBanner'
 
 // Chantier Tuto interactif client (2026-04-24) : lazy-load pour ne pas
 // alourdir le bundle initial de ClientAppPage.
@@ -202,7 +203,7 @@ export function ClientAppPage() {
   // Fetch des données live (programme / RDV / produits) via
   // client-app-data. Priorité : liveData > snapshot. Refresh on focus
   // debounced 5s. Si l'edge function fail, on garde le snapshot.
-  const { liveData } = useClientLiveData(token)
+  const { liveData, dataSource } = useClientLiveData(token)
 
   // Merge liveData dans data dès qu'on a les 2 (snapshot + live fetchés).
   // Live gagne sur snapshot (snapshot = figé, live = source de vérité DB).
@@ -739,6 +740,15 @@ export function ClientAppPage() {
           coachFirstName={(data.coach_name ?? '').split(/\s+/)[0] || 'Ton coach'}
         />
       ) : null}
+
+      {/* Chantier observabilité (2026-04-25) : bandeau orange visible
+          UNIQUEMENT si l'edge function client-app-data a échoué et que
+          l'app affiche le snapshot figé. Permet au client de comprendre
+          que ses données ne sont pas fraîches et au coach de remonter le
+          bug (vu côté UI = bug visible, plus de fail silencieux). */}
+      {dataSource === 'snapshot' && (
+        <ClientAppFallbackBanner onContact={() => setActiveTab('messages')} />
+      )}
 
       <div style={{ padding: '12px 14px' }}>
         {/* ══════════════════════════════════════════════════════════════ */}

--- a/supabase/functions/client-app-data/index.ts
+++ b/supabase/functions/client-app-data/index.ts
@@ -23,6 +23,36 @@ const corsHeaders = {
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
 };
 
+// Chantier observabilité (2026-04-25) : logs JSON structurés pour
+// faciliter le filtre dans Supabase Dashboard → Functions → Logs.
+// Aucun token complet ni PII (email, nom, téléphone) ne doit fuiter ici.
+type LogLevel = "info" | "warn" | "error";
+function log(level: LogLevel, event: string, data?: Record<string, unknown>) {
+  console.log(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      level,
+      fn: "client-app-data",
+      event,
+      ...data,
+    }),
+  );
+}
+
+/** Hash 8-char d'un secret pour log privacy-safe. */
+async function shortHash(value: string): Promise<string> {
+  try {
+    const buf = new TextEncoder().encode(value);
+    const digest = await crypto.subtle.digest("SHA-256", buf);
+    return Array.from(new Uint8Array(digest))
+      .slice(0, 4)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  } catch {
+    return "hash-err";
+  }
+}
+
 function jsonError(code: string, status: number) {
   return new Response(JSON.stringify({ error: code }), {
     status,
@@ -50,18 +80,23 @@ serve(async (req) => {
     return new Response("ok", { headers: corsHeaders });
   }
 
+  const t0 = Date.now();
   try {
     const url = new URL(req.url);
     const token = url.searchParams.get("token");
 
     if (!token) {
+      log("warn", "missing_token");
       return jsonError("missing_token", 400);
     }
+
+    const tokenHash = await shortHash(token);
+    log("info", "entry", { tokenHash, method: req.method });
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL");
     const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
     if (!supabaseUrl || !serviceKey) {
-      console.error("[client-app-data] missing env SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+      log("error", "server_misconfigured", { tokenHash });
       return jsonError("server_misconfigured", 500);
     }
 
@@ -78,22 +113,33 @@ serve(async (req) => {
       .maybeSingle();
 
     if (accountError) {
-      console.error("[client-app-data] account lookup error", accountError);
+      log("error", "account_lookup_error", {
+        tokenHash,
+        message: accountError.message,
+        code: (accountError as { code?: string }).code,
+      });
       return jsonError("lookup_error", 500);
     }
     if (!account) {
+      log("warn", "invalid_token", { tokenHash });
       return jsonError("invalid_token", 401);
     }
 
     // Expiration (expires_at default = now() + 1 year à la création)
     if (account.expires_at && new Date(account.expires_at).getTime() < Date.now()) {
+      log("warn", "token_expired", { tokenHash, expiresAt: account.expires_at });
       return jsonError("token_expired", 401);
     }
 
     // client_app_accounts.client_id est TEXT, clients.id est UUID.
     // Postgres cast implicitement mais log pour monitoring pendant les tests.
     const clientId = account.client_id as string;
-    console.log(`[client-app-data] token resolved → clientId=${clientId} (type=${typeof clientId})`);
+    log("info", "token_resolved", {
+      tokenHash,
+      table: "client_app_accounts",
+      clientId,
+      clientIdType: typeof clientId,
+    });
 
     // ─── 2. Fetch des sources en parallèle (service_role = RLS bypass) ─
     // Chantier Conseils (2026-04-24) : ajout assessments_history (limit 20),
@@ -136,17 +182,40 @@ serve(async (req) => {
     ]);
 
     if (clientRes.error) {
-      console.error("[client-app-data] client select error", clientRes.error);
+      log("error", "client_select_error", {
+        clientId,
+        message: clientRes.error.message,
+        code: (clientRes.error as { code?: string }).code,
+      });
     }
     if (followUpRes.error) {
-      console.error("[client-app-data] follow_ups select error", followUpRes.error);
+      log("error", "follow_ups_select_error", {
+        clientId,
+        message: followUpRes.error.message,
+        code: (followUpRes.error as { code?: string }).code,
+      });
     }
     if (productsRes.error) {
-      console.error("[client-app-data] products select error", productsRes.error);
+      log("error", "products_select_error", {
+        clientId,
+        message: productsRes.error.message,
+        code: (productsRes.error as { code?: string }).code,
+      });
     }
     if (assessmentsRes.error) {
-      console.error("[client-app-data] assessments select error", assessmentsRes.error);
+      log("error", "assessments_select_error", {
+        clientId,
+        message: assessmentsRes.error.message,
+        code: (assessmentsRes.error as { code?: string }).code,
+      });
     }
+    log("info", "data_loaded", {
+      clientId,
+      clientFound: !!clientRes.data,
+      nextFollowUp: !!followUpRes.data,
+      productsCount: productsRes.data?.length ?? 0,
+      assessmentsCount: assessmentsRes.data?.length ?? 0,
+    });
 
     // ─── 3. Dérivations Conseils (assessment history + recos + alerts) ─
     // Format assessment_history : tableau normalisé (date + métriques
@@ -449,7 +518,16 @@ serve(async (req) => {
       fetched_at: new Date().toISOString(),
     };
 
-    return new Response(JSON.stringify(payload), {
+    const body = JSON.stringify(payload);
+    log("info", "success", {
+      clientId,
+      durationMs: Date.now() - t0,
+      payloadKb: Math.round(body.length / 1024),
+      sportAlerts: sport_alerts.length,
+      recommendationsNotTaken: recommendations_not_taken.length,
+    });
+
+    return new Response(body, {
       status: 200,
       headers: {
         ...corsHeaders,
@@ -460,7 +538,13 @@ serve(async (req) => {
       },
     });
   } catch (err) {
-    console.error("[client-app-data] uncaught error", err);
+    const msg = err instanceof Error ? err.message : String(err);
+    const stack = err instanceof Error ? err.stack : undefined;
+    log("error", "uncaught", {
+      durationMs: Date.now() - t0,
+      message: msg,
+      stack: stack ? stack.split("\n").slice(0, 5).join(" | ") : undefined,
+    });
     return jsonError("internal_error", 500);
   }
 });


### PR DESCRIPTION
Audit du 25/04 a révélé que l'edge function client-app-data plante silencieusement chez certains clients. App fallback sur snapshot DB → écran vide perçu.

## Fixes
- **Edge** : logs JSON structurés à chaque étape critique (entry, token_resolved, data_loaded, success, *_select_error, uncaught) + global try/catch déjà en place + log durée + log taille payload. Aucun token clear, juste shortHash 8-char (RGPD).
- **Hook** : useClientLiveData expose dataSource ('edge' | 'snapshot' | 'unknown')
- **UI** : nouveau ClientAppFallbackBanner (orange) visible UNIQUEMENT quand dataSource === 'snapshot'. CTA Contacter → onglet messages.

## Effet attendu
- Thomas peut consulter Supabase Dashboard → Functions → client-app-data → Logs et filtrer sur 'level':'error' pour identifier la cause racine.
- Les clients voient un bandeau d'avertissement (au lieu d'un écran vide silencieux).

Mélanie aucun impact tant que tout va bien (bandeau invisible si edge OK).

Full auto deployment validé.