### PR TITLE
feat(academy): section 9 sandbox - mode pratique zero risque

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,26 @@ Workflow complet : `docs/DEV_WORKFLOW.md`
 
 ---
 
+## Roadmap Academy V2 — différée (note 2026-04-29)
+
+Idées validées par Thomas pour plus tard :
+
+### Tier S #1 — Narration vocale par step
+Audio 5-10s enregistré par Thomas pour chaque step Academy. Player
+inline avec play auto + replay. Storage : Supabase Storage bucket
+`academy-audio/`. Effet "Thomas est avec eux" — chaud humain.
+
+### Tier S #2 — Vidéo intro 90s avant section 1
+Vidéo plein écran shot pro (Thomas studio). Skipable. Pose le ton
+"club premium" dès le premier contact avec l'Academy. Storage :
+Vimeo ou Mux pour le streaming, embed in `AcademyOverviewPage`.
+
+Quand on les attaque : créer `feat/academy-narration` depuis
+`dev/thomas-test`. Prévoir migration `academy_audio_steps` (table
+mapping step_id → url_audio) et hook `useStepAudio`.
+
+---
+
 ## Page remerciement post-bilan (2026-04-27)
 
 ### Route dédiée

--- a/docs/ROADMAP_HORS_ACADEMY.md
+++ b/docs/ROADMAP_HORS_ACADEMY.md
@@ -1,0 +1,297 @@
+# Roadmap chantiers hors-Academy
+
+Document de scoping pour les 5 chantiers validés par Thomas le 2026-04-29.
+Ordre de priorité = ordre des sections ci-dessous (du plus simple/impactant
+au plus complexe).
+
+---
+
+## 🎯 Synthèse — quel ordre attaquer
+
+| # | Chantier | Impact | Effort | Reco ordre |
+|---|---|---|---|---|
+| C | Refonte page /clients (filtres + actions groupées) | Productivité ×3 | 2-3j | **1er** — gain immédiat |
+| D | Reporting / Analytics admin | Pilotage business | 2j | **2e** — data déjà en base |
+| E | Templates messages WhatsApp | Vélocité coach | 1.5j | **3e** — réutilise IA |
+| B | Assistant IA intégré | Différenciation | 3j | **4e** — coût API à valider |
+| A | Onboarding CLIENT (PWA) | Fidélisation | 2-3j | **5e** — moins urgent que coach |
+
+**Total** : ~11-12 jours dev. Étalable sur 2 semaines en gardant la prod stable.
+
+---
+
+## 1. Chantier C — Refonte page /clients
+
+### Problème actuel
+La page `/clients` (`src/pages/ClientsPage.tsx`) est une grosse liste
+plate. Quand tu as 50+ clients, c'est dur de filtrer (qui est en pause,
+qui a fait 2 bilans, qui n'a plus eu de contact depuis 30j, etc.).
+
+### Solution proposée
+
+**1.1 Filtres rapides en haut de page**
+- Bouton chips multi-select : `À relancer` / `Au cap` / `Inactifs >30j` /
+  `Sans RDV planifié` / `Bilan incomplet` / `VIP (≥3 bilans)` /
+  `Nouveaux (≤14j)` / `Anniversaire ce mois`
+- Chaque chip recalcule un compteur ("À relancer · 12")
+- État sauvegardé dans `localStorage` pour retrouver le filtre actif au refresh
+
+**1.2 Vue Kanban (toggle list ↔ kanban)**
+- Colonnes : `À contacter` / `RDV programmé` / `En suivi actif` /
+  `Au cap (programme stable)` / `En pause`
+- Drag-and-drop entre colonnes pour changer le `lifecycle_status`
+- Limite 10 cards par colonne avec "+X autres" en bas
+
+**1.3 Actions groupées**
+- Checkbox sur chaque ligne → bouton "Actions sur N clients sélectionnés"
+- Actions : envoyer message WhatsApp groupé (1 message commun, ouvre
+  N onglets `wa.me/`), planifier RDV groupé (modal date/heure → applique
+  à tous), exporter CSV des sélectionnés, marquer en pause groupé.
+
+### Fichiers impactés
+- `src/pages/ClientsPage.tsx` — réécriture significative
+- `src/components/clients/ClientsFilterBar.tsx` (nouveau)
+- `src/components/clients/ClientsKanban.tsx` (nouveau)
+- `src/components/clients/BulkActionsBar.tsx` (nouveau)
+- `src/hooks/useClientFilters.ts` (nouveau)
+
+### Risques / dépendances
+- Doit cohabiter avec le toggle `useGlobalView` (vue admin / vue distri)
+- Drag-and-drop : utiliser `@dnd-kit/core` (déjà ?? à vérifier)
+- Pas de migration SQL nécessaire — tout est calculé front depuis les
+  données déjà chargées dans `AppContext`
+
+### Critère de done
+- Filtres marchent et persistent au refresh
+- Toggle list/kanban switch sans perte de filtres
+- Actions groupées : 1 test e2e qui sélectionne 3 clients, ouvre
+  3 onglets WhatsApp simultanément
+
+---
+
+## 2. Chantier D — Reporting / Analytics admin
+
+### Problème actuel
+Toi et Mel pilotez à l'instinct. Aucune vue chiffrée des tendances,
+conversions, top produits, performance équipe.
+
+### Solution proposée
+
+**2.1 Page `/analytics` (admin only)**
+
+Sections :
+- **KPI principaux (4 cards)** : nb bilans ce mois / conversion bilan→client /
+  PV équipe vs target / clients actifs vs M-1
+- **Funnel conversion** : bilans → clients (inscription) → actifs
+  (≥30j) → renouvellement. Pourcentages à chaque étape.
+- **Top produits** : top 5 produits vendus ce mois en quantité + en PV
+- **Top distri** : top 3 distri par bilans / par PV ce mois
+- **Tendance 12 mois** : graphe ligne nb bilans/mois sur 12 mois
+- **Alertes** : "3 distri sans bilan depuis 14j", "5 clients en pause
+  depuis ≥60j sans relance", etc.
+
+**2.2 Implémentation**
+
+- Nouvelle RPC `get_admin_analytics()` qui agrège tout en 1 appel
+  (économise les round-trips)
+- Page `src/pages/AnalyticsPage.tsx` avec route `/analytics`
+- Liens depuis l'onglet Équipe vers /analytics
+- Charts : `recharts` (à ajouter en dep) pour la courbe + barres
+
+### Fichiers
+- `supabase/migrations/2026XXXX_admin_analytics_rpc.sql`
+- `src/pages/AnalyticsPage.tsx` (nouveau)
+- `src/hooks/useAdminAnalytics.ts` (nouveau)
+- `src/components/analytics/*` (4-5 sub-components)
+- `src/App.tsx` — route `/analytics`
+- `package.json` — ajout `recharts`
+
+### Critère de done
+- Page charge en <1.5s
+- Les 4 KPI matchent les chiffres calculés à la main sur 1 mois récent
+- Refresh manuel + auto toutes les 5 min via `useEffect` setInterval
+
+---
+
+## 3. Chantier E — Templates messages WhatsApp avec IA
+
+### Problème actuel
+Quand le coach veut envoyer un message à un client, il rédige tout à
+la main. Répétitif et chronophage.
+
+### Solution proposée
+
+**3.1 Bouton "💬 IA suggère un message"**
+
+Sur `ClientDetailPage`, dans la section actions, ajouter un bouton qui :
+- Lit le contexte client (nom, prochain RDV, dernier bilan, perte poids,
+  produits actifs, dernière interaction)
+- Appelle Claude API avec un system prompt "tu es coach Lor'Squad,
+  ton bienveillant, max 200 caractères"
+- Propose 3 messages alternatifs (différents tons : motivationnel /
+  questionnant / informatif)
+- Le coach clique celui qui colle → ouvre WhatsApp prérempli
+
+**3.2 Templates "manuels" en complément**
+
+Scénarios pré-câblés sans IA (réponse instantanée, 0 coût API) :
+- Confirmation RDV demain
+- Rappel produit à commander
+- Anniversaire client
+- Félicitation perte poids
+- Relance client inactif >14j
+
+### Fichiers
+- `src/components/client-detail/AiMessageSuggester.tsx` (nouveau)
+- `src/lib/messageTemplates.ts` (nouveau — les 5 templates manuels)
+- `supabase/functions/suggest-coach-message/index.ts` (nouvelle edge function)
+- Page settings : champ pour saisir clé API Anthropic (par admin)
+
+### Risques / dépendances
+- Coût API Claude : ~0.001€ par suggestion (avec Haiku) → max 100/mois
+  pour 10€. Très raisonnable.
+- Rate limit : ne pas spammer l'API → debounce 5s côté front
+- Stockage clé API : pas dans le client. Edge function lit
+  `Deno.env.get("ANTHROPIC_API_KEY")` configurée via Supabase secrets.
+
+### Critère de done
+- Bouton "IA suggère" génère 3 messages en <3s
+- Les 5 templates manuels marchent en <100ms
+- Clic sur un message ouvre WhatsApp avec le bon numéro et message prérempli
+
+---
+
+## 4. Chantier B — Assistant IA intégré
+
+### Problème actuel
+Les distri débutants posent les mêmes questions à Thomas/Mel via WhatsApp
+("comment je gère un client qui veut arrêter ?", "quoi répondre à un
+client qui dit que c'est trop cher ?"). Bouffe du temps coach.
+
+### Solution proposée
+
+**4.1 Bouton flottant "🤖 Lor'Squad IA"**
+
+Présent en bas-droite de toutes les pages coach. Click ouvre un modal
+chat avec :
+- Historique conversation (sauvegardé Supabase, 1 thread par user)
+- Input zone, envoi par Enter
+- Streaming response (mots qui apparaissent au fur à mesure)
+
+**4.2 System prompt enrichi avec contexte**
+
+Le system prompt inclut :
+- "Tu es l'assistant Lor'Squad, formé sur les méthodes Herbalife et le ton bienveillant"
+- "Les distri qui te parlent sont les coachs de Thomas Houbert"
+- "Tu peux référencer les sections Academy : section 1 = welcome, section 2 = first-bilan, etc."
+- Si l'user est sur une page client → injecte un résumé du client courant
+- Si l'user est sur l'agenda → injecte les RDV de la journée
+
+**4.3 Cas d'usage cibles**
+
+- "J'ai un client qui doute, comment je gère ?" → réponse coaching
+- "Quel produit pour quelqu'un qui veut prendre du muscle ?" → réponse produit
+- "Comment je gère un follow-up à J+7 ?" → réponse process
+
+### Fichiers
+- `src/features/ai-assistant/components/AssistantFloatingButton.tsx`
+- `src/features/ai-assistant/components/AssistantChatModal.tsx`
+- `src/features/ai-assistant/hooks/useAssistantThread.ts`
+- `supabase/functions/ai-assistant/index.ts` (proxy vers Anthropic API
+  avec streaming)
+- Migration `2026XXXX_ai_assistant_threads.sql` (table threads + messages)
+
+### Risques / dépendances
+- Coût API : streaming Claude Sonnet ~0.01€ par échange → 100€/mois si
+  10 distri échangent 30x/jour. À budgéter.
+- Possibilité de switcher vers Haiku (×10 moins cher) pour les questions
+  simples. Decision à faire après tests.
+- Rate limit par user (max 50 messages/jour) pour éviter les abus.
+
+### Critère de done
+- Bouton flottant cliquable depuis toutes les pages
+- Réponse en streaming en <2s pour les 3 premiers tokens
+- Contexte client injecté correctement quand on est sur ClientDetailPage
+- Historique persisté et restauré au prochain login
+
+---
+
+## 5. Chantier A — Onboarding CLIENT (PWA)
+
+### Problème actuel
+Le client reçoit un lien vers la PWA et débarque sans guide. Il ne sait
+pas où regarder son évolution, comment lire un bilan, comment parler
+au coach.
+
+### Solution proposée
+
+**5.1 Mini-tour 4 étapes au premier lancement**
+
+Au premier mount de `ClientAppPage` (détecté via `client_app_accounts.first_seen_at`
+null), un overlay de bienvenue propose :
+
+- Étape 1 : "Bonjour [Prénom] ! Voici ton espace personnel"
+  + spotlight sur le header (nom + photo coach)
+- Étape 2 : "Ton onglet Évolution → suis tes progrès dans le temps"
+  + spotlight sur tab Évolution
+- Étape 3 : "Tes Conseils perso adaptés à ton profil"
+  + spotlight sur tab Conseils
+- Étape 4 : "Ton coach est à un message de toi"
+  + spotlight sur le bouton WhatsApp coach
+
+Peut être skippé. Au skip, marquer `first_seen_at` quand même.
+
+**5.2 Onboarding de complétion progressive**
+
+À chaque visite, si une donnée importante manque (ex: avatar pas uploadé,
+pas de profil photo client), afficher un bandeau gold discret avec CTA
+"Complète ton profil pour une meilleure expérience". Ferme par X.
+
+### Fichiers
+- `src/components/client-app/ClientWelcomeTour.tsx` (nouveau)
+- `src/components/client-app/ClientCompletionBanner.tsx` (nouveau)
+- `src/hooks/useClientOnboarding.ts` (nouveau — gère les flags)
+- Migration `2026XXXX_client_app_onboarding.sql` (ajout colonnes
+  `first_seen_at`, `tour_completed_at`, `tour_skipped_at` sur
+  `client_app_accounts`)
+
+### Risques / dépendances
+- L'app client tourne sans React Router (page unique avec tabs internes)
+  → le tour doit utiliser le SpotlightOverlay existant adapté
+- Mobile-first : tester sur iOS Safari + Android Chrome avant de pusher
+- Le flag `first_seen_at` doit être set côté serveur (edge function
+  `client-app-data` étendue) pour éviter les double-affichages si le
+  client clear son localStorage
+
+### Critère de done
+- Premier lancement : tour s'affiche, 4 étapes, skipable
+- Lancements suivants : tour ne re-déclenche plus
+- Bandeau de complétion s'affiche si avatar manquant, disparait après upload
+- Test mobile iOS + Android validés
+
+---
+
+## 📅 Planning recommandé sur 2 semaines
+
+### Semaine 1
+- **J1-J3** : Chantier C (clients filtres + kanban + actions groupées)
+- **J4-J5** : Chantier D (analytics admin)
+
+### Semaine 2
+- **J6-J7** : Chantier E (templates messages + IA suggérer)
+- **J8-J10** : Chantier B (assistant IA intégré)
+
+### Semaine 3 (optionnelle)
+- **J11-J13** : Chantier A (onboarding client PWA)
+
+---
+
+## ⚠️ Conditions transverses à toutes les semaines
+
+1. **Toujours créer une feat/X depuis dev/thomas-test**, jamais depuis prod.
+2. **Tests E2E avant chaque merge prod** (la checklist du 2026-04-29 reste valable).
+3. **Backup DB Supabase avant toute migration** (Dashboard → Database → Backups).
+4. **CLAUDE.md mis à jour à la fin de chaque chantier** avec les notes
+   d'archi importantes (pour la mémoire long-terme).
+5. **Pas de big-bang merge** : chaque chantier mergé indépendamment, pour
+   pouvoir rollback ciblé si un truc pète.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,6 +178,13 @@ const AcademyCertificatePage = lazy(() =>
     default: module.AcademyCertificatePage
   }))
 );
+// Chantier Academy section 9 sandbox (2026-04-29) : wizard auto-portant
+// pour le mode pratique (creation de bilan fictif sans toucher la base).
+const AcademySandboxPage = lazy(() =>
+  import("./pages/AcademySandboxPage").then((module) => ({
+    default: module.AcademySandboxPage
+  }))
+);
 // Pages démo Academy (2026-04-28) : mockups visuels avec données fictives
 // pour les tours, sans dépendre de l'état réel de la base.
 const DemoFicheClient = lazy(() =>
@@ -270,6 +277,10 @@ export default function App() {
               {/* Lor'Squad Academy Phase 1 (2026-04-26) */}
               <Route path="academy" element={<AcademyOverviewPage />} />
               <Route path="academy/certificat" element={<AcademyCertificatePage />} />
+              {/* Section 9 sandbox (2026-04-29) : route AVANT /:sectionId
+                  pour que /academy/sandbox match cette page-ci, pas le
+                  param dynamique generique. */}
+              <Route path="academy/sandbox" element={<AcademySandboxPage />} />
               <Route path="academy/:sectionId" element={<AcademySectionPage />} />
               {/* Pages démo Academy (2026-04-28) — mockups pour les tours */}
               <Route path="academy/demo/fiche-client" element={<DemoFicheClient />} />

--- a/src/features/academy/sections.ts
+++ b/src/features/academy/sections.ts
@@ -653,6 +653,21 @@ export const ACADEMY_SECTIONS: AcademySection[] = [
       ],
     },
   },
+  // ─── Section 9 : Mode pratique sandbox (2026-04-29) ─────────────────────
+  // Section bonus interactive ou le distri cree un faux client + bilan
+  // complet sans toucher a la base. Wizard auto-portant rendu par
+  // AcademySandboxPage. Steps[] vide = AcademySectionPage redirige
+  // immediatement vers /academy/sandbox.
+  {
+    id: "sandbox",
+    title: "À toi de jouer — pratique en mode bac à sable",
+    shortLabel: "Pratique",
+    description:
+      "Crée un client fictif et fais ton premier bilan complet, sans risque de polluer la base. Apprentissage par la pratique en 5 minutes.",
+    estimatedDurationMinutes: 5,
+    icon: "🎮",
+    steps: [],
+  },
 ];
 
 // ============================================================================

--- a/src/pages/AcademySandboxPage.tsx
+++ b/src/pages/AcademySandboxPage.tsx
@@ -1,0 +1,816 @@
+// =============================================================================
+// Lor'Squad Academy — Section 9 : Mode pratique sandbox (2026-04-29)
+// =============================================================================
+//
+// Wizard 4 etapes qui permet au distri de simuler la creation d un client +
+// d un bilan complet SANS toucher a la base. Aucune donnee n est persistee :
+// tout est en state React local.
+//
+// Etapes :
+//   1. Profil client (prenom, nom, age, objectif)
+//   2. Bilan corporel (poids, taille, % MG, % MM, eau)
+//   3. Recommandations produits (cocher 2+ produits)
+//   4. Recap final avec celebration + markSectionDone("sandbox")
+//
+// Architecture :
+//   - Self-contained (pas le TourRunner / SpotlightOverlay)
+//   - Etat local via useState, pas de DB
+//   - Validation legere par etape (champs requis + ranges realistes)
+//   - A la fin : appel a markSectionDone("sandbox") puis navigate /academy
+//
+// Differences avec /academy/demo/fiche-client :
+//   - Demo = mockup statique pour spotlights pendant un tour
+//   - Sandbox = wizard interactif que le user remplit lui-meme
+// =============================================================================
+
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAcademyProgress } from "../features/academy/hooks/useAcademyProgress";
+import { DemoBanner } from "../features/academy/components/DemoBanner";
+
+// ─── Types et constantes ─────────────────────────────────────────────────────
+
+type SandboxObjective = "weight-loss" | "sport";
+
+interface SandboxClient {
+  firstName: string;
+  lastName: string;
+  age: number;
+  city: string;
+  objective: SandboxObjective;
+}
+
+interface SandboxBilan {
+  weightKg: number;
+  heightCm: number;
+  bodyFatPct: number;
+  muscleMassPct: number;
+  hydrationPct: number;
+}
+
+interface SandboxProduct {
+  id: string;
+  name: string;
+  emoji: string;
+  pv: number;
+  priceEur: number;
+  durationDays: number;
+  matchObjective: SandboxObjective[];
+}
+
+const SANDBOX_PRODUCTS: SandboxProduct[] = [
+  { id: "f1-vanille", name: "Formula 1 Vanille", emoji: "🥤", pv: 23, priceEur: 56, durationDays: 30, matchObjective: ["weight-loss", "sport"] },
+  { id: "the-concentre", name: "Thé Concentré 50g", emoji: "🍵", pv: 17, priceEur: 42, durationDays: 60, matchObjective: ["weight-loss", "sport"] },
+  { id: "aloe", name: "Aloe Vera Original", emoji: "🌿", pv: 19, priceEur: 48, durationDays: 30, matchObjective: ["weight-loss"] },
+  { id: "phyto", name: "Phyto Complete", emoji: "🌱", pv: 21, priceEur: 52, durationDays: 30, matchObjective: ["weight-loss", "sport"] },
+  { id: "f3-proteine", name: "Formula 3 Proteine", emoji: "💪", pv: 25, priceEur: 62, durationDays: 30, matchObjective: ["sport"] },
+  { id: "cr7-drive", name: "CR7 Drive (boost performance)", emoji: "⚡", pv: 28, priceEur: 68, durationDays: 30, matchObjective: ["sport"] },
+];
+
+const DEFAULT_CLIENT: SandboxClient = {
+  firstName: "Sarah",
+  lastName: "Démo",
+  age: 34,
+  city: "Verdun",
+  objective: "weight-loss",
+};
+
+const DEFAULT_BILAN: SandboxBilan = {
+  weightKg: 68,
+  heightCm: 165,
+  bodyFatPct: 28,
+  muscleMassPct: 26,
+  hydrationPct: 54,
+};
+
+const STEP_LABELS = [
+  "Profil client",
+  "Bilan corporel",
+  "Programme",
+  "Récap & badge",
+];
+
+// ─── Composant principal ─────────────────────────────────────────────────────
+
+export function AcademySandboxPage() {
+  const navigate = useNavigate();
+  const { markSectionDone } = useAcademyProgress();
+
+  const [step, setStep] = useState(0);
+  const [client, setClient] = useState<SandboxClient>(DEFAULT_CLIENT);
+  const [bilan, setBilan] = useState<SandboxBilan>(DEFAULT_BILAN);
+  const [selectedProducts, setSelectedProducts] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  // ─── Derives ────────────────────────────────────────────────────────────
+  const bmi = useMemo(() => {
+    const h = bilan.heightCm / 100;
+    if (!h) return 0;
+    return bilan.weightKg / (h * h);
+  }, [bilan.heightCm, bilan.weightKg]);
+
+  const filteredProducts = useMemo(
+    () => SANDBOX_PRODUCTS.filter((p) => p.matchObjective.includes(client.objective)),
+    [client.objective],
+  );
+
+  const totalPv = useMemo(
+    () => selectedProducts.reduce((acc, id) => {
+      const p = SANDBOX_PRODUCTS.find((x) => x.id === id);
+      return acc + (p?.pv ?? 0);
+    }, 0),
+    [selectedProducts],
+  );
+
+  const totalPrice = useMemo(
+    () => selectedProducts.reduce((acc, id) => {
+      const p = SANDBOX_PRODUCTS.find((x) => x.id === id);
+      return acc + (p?.priceEur ?? 0);
+    }, 0),
+    [selectedProducts],
+  );
+
+  // ─── Validations par etape ──────────────────────────────────────────────
+  const canAdvance = useMemo(() => {
+    if (step === 0) {
+      return client.firstName.trim().length >= 2
+          && client.lastName.trim().length >= 2
+          && client.age >= 18 && client.age <= 100
+          && client.city.trim().length >= 2;
+    }
+    if (step === 1) {
+      return bilan.weightKg >= 35 && bilan.weightKg <= 200
+          && bilan.heightCm >= 130 && bilan.heightCm <= 220
+          && bilan.bodyFatPct >= 5 && bilan.bodyFatPct <= 60
+          && bilan.muscleMassPct >= 10 && bilan.muscleMassPct <= 60;
+    }
+    if (step === 2) {
+      return selectedProducts.length >= 2;
+    }
+    return true;
+  }, [step, client, bilan, selectedProducts]);
+
+  const handleNext = () => {
+    if (!canAdvance) return;
+    setStep((s) => Math.min(s + 1, STEP_LABELS.length - 1));
+  };
+
+  const handleBack = () => {
+    setStep((s) => Math.max(s - 1, 0));
+  };
+
+  const handleFinish = async () => {
+    setSubmitting(true);
+    try {
+      await markSectionDone("sandbox");
+    } catch (err) {
+      console.warn("[Sandbox] markSectionDone failed:", err);
+    }
+    navigate("/academy?completed=sandbox");
+  };
+
+  // ─── Render ─────────────────────────────────────────────────────────────
+  return (
+    <div style={{ maxWidth: 720, margin: "0 auto", padding: "24px 16px 80px" }}>
+      <DemoBanner label="Mode pratique — aucune donnée n'est sauvegardée" />
+
+      {/* Header avec progression */}
+      <div style={{ marginTop: 20, marginBottom: 24 }}>
+        <button
+          type="button"
+          onClick={() => navigate("/academy")}
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "var(--ls-text-muted, #6B6B62)",
+            fontSize: 13,
+            cursor: "pointer",
+            padding: 0,
+            marginBottom: 12,
+          }}
+        >
+          ← Quitter le mode pratique
+        </button>
+
+        <h1
+          style={{
+            fontFamily: "Syne, Georgia, serif",
+            fontSize: 26,
+            fontWeight: 500,
+            margin: "0 0 6px 0",
+            color: "var(--ls-text, #2C2C2A)",
+          }}
+        >
+          🎮 À toi de jouer
+        </h1>
+        <p style={{ fontSize: 14, color: "var(--ls-text-muted, #5F5E5A)", margin: 0 }}>
+          Étape {step + 1} sur {STEP_LABELS.length} — {STEP_LABELS[step]}
+        </p>
+
+        {/* Barre de progression */}
+        <div
+          style={{
+            marginTop: 16,
+            height: 6,
+            borderRadius: 3,
+            background: "var(--ls-surface2, #EDE6D0)",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              width: `${((step + 1) / STEP_LABELS.length) * 100}%`,
+              height: "100%",
+              background: "linear-gradient(90deg, #B8922A, #BA7517)",
+              transition: "width 250ms ease",
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Contenu de l etape */}
+      {step === 0 && (
+        <SandboxStep1Profil client={client} onChange={setClient} />
+      )}
+      {step === 1 && (
+        <SandboxStep2Bilan bilan={bilan} onChange={setBilan} bmi={bmi} />
+      )}
+      {step === 2 && (
+        <SandboxStep3Programme
+          objective={client.objective}
+          products={filteredProducts}
+          selected={selectedProducts}
+          onToggle={(id) => setSelectedProducts((prev) =>
+            prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+          )}
+          totalPv={totalPv}
+          totalPrice={totalPrice}
+        />
+      )}
+      {step === 3 && (
+        <SandboxStep4Recap
+          client={client}
+          bilan={bilan}
+          bmi={bmi}
+          selectedProducts={selectedProducts.map((id) =>
+            SANDBOX_PRODUCTS.find((p) => p.id === id),
+          ).filter(Boolean) as SandboxProduct[]}
+          totalPv={totalPv}
+          totalPrice={totalPrice}
+        />
+      )}
+
+      {/* Footer navigation */}
+      <div
+        style={{
+          marginTop: 32,
+          display: "flex",
+          gap: 12,
+          flexWrap: "wrap",
+          justifyContent: "space-between",
+        }}
+      >
+        <button
+          type="button"
+          onClick={handleBack}
+          disabled={step === 0}
+          style={{
+            background: "transparent",
+            border: "0.5px solid var(--ls-border, #C9C2AB)",
+            color: "var(--ls-text-muted, #6B6B62)",
+            padding: "10px 18px",
+            borderRadius: 10,
+            fontSize: 13,
+            cursor: step === 0 ? "not-allowed" : "pointer",
+            opacity: step === 0 ? 0.5 : 1,
+          }}
+        >
+          ← Précédent
+        </button>
+
+        {step < STEP_LABELS.length - 1 ? (
+          <button
+            type="button"
+            onClick={handleNext}
+            disabled={!canAdvance}
+            style={{
+              background: canAdvance ? "linear-gradient(135deg, #B8922A, #BA7517)" : "var(--ls-surface2, #EDE6D0)",
+              color: canAdvance ? "white" : "var(--ls-text-muted, #6B6B62)",
+              border: "none",
+              padding: "10px 22px",
+              borderRadius: 10,
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: canAdvance ? "pointer" : "not-allowed",
+            }}
+          >
+            Suivant →
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleFinish}
+            disabled={submitting}
+            style={{
+              background: "linear-gradient(135deg, #B8922A, #BA7517)",
+              color: "white",
+              border: "none",
+              padding: "12px 24px",
+              borderRadius: 10,
+              fontSize: 14,
+              fontWeight: 500,
+              cursor: submitting ? "wait" : "pointer",
+              opacity: submitting ? 0.8 : 1,
+            }}
+          >
+            {submitting ? "..." : "🎉 Terminer & gagner le badge"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Sous-composants par etape ───────────────────────────────────────────────
+
+function SandboxStep1Profil({
+  client,
+  onChange,
+}: {
+  client: SandboxClient;
+  onChange: (c: SandboxClient) => void;
+}) {
+  return (
+    <Card title="👤 Profil de ton client">
+      <p style={{ fontSize: 13, color: "var(--ls-text-muted, #5F5E5A)", marginBottom: 16 }}>
+        On commence par les infos de base. Tu peux garder Sarah Démo ou inventer un autre profil — c'est juste pour t'entraîner.
+      </p>
+
+      <Field label="Prénom">
+        <input
+          type="text"
+          value={client.firstName}
+          onChange={(e) => onChange({ ...client, firstName: e.target.value })}
+          style={inputStyle}
+        />
+      </Field>
+
+      <Field label="Nom">
+        <input
+          type="text"
+          value={client.lastName}
+          onChange={(e) => onChange({ ...client, lastName: e.target.value })}
+          style={inputStyle}
+        />
+      </Field>
+
+      <Field label="Âge">
+        <input
+          type="number"
+          min={18}
+          max={100}
+          value={client.age}
+          onChange={(e) => onChange({ ...client, age: Number(e.target.value) })}
+          style={inputStyle}
+        />
+      </Field>
+
+      <Field label="Ville">
+        <input
+          type="text"
+          value={client.city}
+          onChange={(e) => onChange({ ...client, city: e.target.value })}
+          style={inputStyle}
+        />
+      </Field>
+
+      <Field label="Objectif">
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+          {([
+            { id: "weight-loss", label: "🌱 Perte de poids", color: "#5A8C7B" },
+            { id: "sport", label: "💪 Prise de masse / sport", color: "#B8922A" },
+          ] as const).map((opt) => {
+            const active = client.objective === opt.id;
+            return (
+              <button
+                key={opt.id}
+                type="button"
+                onClick={() => onChange({ ...client, objective: opt.id })}
+                style={{
+                  flex: "1 1 200px",
+                  padding: "12px 14px",
+                  background: active ? opt.color : "transparent",
+                  color: active ? "white" : "var(--ls-text, #2C2C2A)",
+                  border: active ? `1px solid ${opt.color}` : "0.5px solid var(--ls-border, #C9C2AB)",
+                  borderRadius: 10,
+                  fontSize: 13,
+                  fontWeight: active ? 500 : 400,
+                  cursor: "pointer",
+                  transition: "all 150ms ease",
+                }}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+      </Field>
+    </Card>
+  );
+}
+
+function SandboxStep2Bilan({
+  bilan,
+  onChange,
+  bmi,
+}: {
+  bilan: SandboxBilan;
+  onChange: (b: SandboxBilan) => void;
+  bmi: number;
+}) {
+  const bmiCategory = bmi < 18.5 ? "Insuffisant" : bmi < 25 ? "Normal" : bmi < 30 ? "Surpoids" : "Obésité";
+  const bmiColor = bmi < 18.5 ? "#5A8C7B" : bmi < 25 ? "#5A8C7B" : bmi < 30 ? "#B8922A" : "#C97A5C";
+
+  return (
+    <Card title="⚖️ Bilan corporel">
+      <p style={{ fontSize: 13, color: "var(--ls-text-muted, #5F5E5A)", marginBottom: 16 }}>
+        Saisie des données mesurées au scan. Les ranges réalistes sont préchargés.
+      </p>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
+        <Field label="Poids (kg)">
+          <input
+            type="number"
+            min={35}
+            max={200}
+            step={0.1}
+            value={bilan.weightKg}
+            onChange={(e) => onChange({ ...bilan, weightKg: Number(e.target.value) })}
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Taille (cm)">
+          <input
+            type="number"
+            min={130}
+            max={220}
+            value={bilan.heightCm}
+            onChange={(e) => onChange({ ...bilan, heightCm: Number(e.target.value) })}
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="% Masse grasse">
+          <input
+            type="number"
+            min={5}
+            max={60}
+            step={0.1}
+            value={bilan.bodyFatPct}
+            onChange={(e) => onChange({ ...bilan, bodyFatPct: Number(e.target.value) })}
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="% Masse musculaire">
+          <input
+            type="number"
+            min={10}
+            max={60}
+            step={0.1}
+            value={bilan.muscleMassPct}
+            onChange={(e) => onChange({ ...bilan, muscleMassPct: Number(e.target.value) })}
+            style={inputStyle}
+          />
+        </Field>
+      </div>
+
+      {/* IMC live */}
+      <div
+        style={{
+          marginTop: 20,
+          padding: "14px 16px",
+          background: "var(--ls-surface2, #FAF6E8)",
+          border: `1px solid ${bmiColor}30`,
+          borderRadius: 12,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 10,
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 11, color: "var(--ls-text-muted, #6B6B62)", letterSpacing: 0.4, textTransform: "uppercase" }}>
+            IMC calculé
+          </div>
+          <div style={{ fontFamily: "Syne, Georgia, serif", fontSize: 24, fontWeight: 500, color: bmiColor }}>
+            {bmi.toFixed(1)}
+          </div>
+        </div>
+        <div
+          style={{
+            padding: "6px 12px",
+            background: `${bmiColor}15`,
+            color: bmiColor,
+            borderRadius: 6,
+            fontSize: 12,
+            fontWeight: 500,
+          }}
+        >
+          {bmiCategory}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function SandboxStep3Programme({
+  objective,
+  products,
+  selected,
+  onToggle,
+  totalPv,
+  totalPrice,
+}: {
+  objective: SandboxObjective;
+  products: SandboxProduct[];
+  selected: string[];
+  onToggle: (id: string) => void;
+  totalPv: number;
+  totalPrice: number;
+}) {
+  return (
+    <Card title="🎯 Recommande un programme">
+      <p style={{ fontSize: 13, color: "var(--ls-text-muted, #5F5E5A)", marginBottom: 16 }}>
+        Coche au moins 2 produits adaptés à l'objectif <strong>{objective === "sport" ? "sport" : "perte de poids"}</strong>. Le total PV se met à jour en temps réel.
+      </p>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {products.map((p) => {
+          const isSelected = selected.includes(p.id);
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => onToggle(p.id)}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                padding: "12px 14px",
+                background: isSelected ? "color-mix(in srgb, #B8922A 8%, var(--ls-surface, #FFFEF8))" : "var(--ls-surface, #FFFEF8)",
+                border: isSelected ? "1px solid #B8922A" : "0.5px solid var(--ls-border, #E5DFCF)",
+                borderRadius: 10,
+                cursor: "pointer",
+                textAlign: "left",
+                transition: "all 150ms ease",
+              }}
+            >
+              <span style={{ fontSize: 24 }}>{p.emoji}</span>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 14, fontWeight: 500, color: "var(--ls-text, #2C2C2A)" }}>{p.name}</div>
+                <div style={{ fontSize: 12, color: "var(--ls-text-muted, #6B6B62)", marginTop: 2 }}>
+                  {p.priceEur}€ · {p.pv} PV · {p.durationDays}j
+                </div>
+              </div>
+              <div
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: 6,
+                  border: isSelected ? "1px solid #B8922A" : "1px solid var(--ls-border, #C9C2AB)",
+                  background: isSelected ? "#B8922A" : "transparent",
+                  color: "white",
+                  fontSize: 14,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                {isSelected ? "✓" : ""}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Total PV / prix */}
+      <div
+        style={{
+          marginTop: 18,
+          padding: "12px 16px",
+          background: "var(--ls-surface2, #FAF6E8)",
+          borderRadius: 10,
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 10,
+        }}
+      >
+        <div style={{ fontSize: 13, color: "var(--ls-text-muted, #6B6B62)" }}>
+          {selected.length} produit{selected.length > 1 ? "s" : ""} sélectionné{selected.length > 1 ? "s" : ""}
+        </div>
+        <div style={{ fontFamily: "Syne, Georgia, serif", fontSize: 18, color: "#B8922A", fontWeight: 500 }}>
+          {totalPrice}€ · {totalPv} PV
+        </div>
+      </div>
+
+      {selected.length < 2 && (
+        <p style={{ marginTop: 12, fontSize: 12, color: "#C97A5C" }}>
+          ⚠️ Sélectionne au moins 2 produits pour passer à la suite.
+        </p>
+      )}
+    </Card>
+  );
+}
+
+function SandboxStep4Recap({
+  client,
+  bilan,
+  bmi,
+  selectedProducts,
+  totalPv,
+  totalPrice,
+}: {
+  client: SandboxClient;
+  bilan: SandboxBilan;
+  bmi: number;
+  selectedProducts: SandboxProduct[];
+  totalPv: number;
+  totalPrice: number;
+}) {
+  return (
+    <Card title="🎉 Bravo, bilan complet !">
+      <p style={{ fontSize: 14, color: "var(--ls-text, #2C2C2A)", marginBottom: 18, lineHeight: 1.6 }}>
+        Tu viens de réaliser un bilan complet de bout en bout. Voici le récap de ton client fictif :
+      </p>
+
+      <div style={{ display: "grid", gap: 14 }}>
+        <RecapBlock
+          title="👤 Client"
+          rows={[
+            ["Nom", `${client.firstName} ${client.lastName}`],
+            ["Âge", `${client.age} ans`],
+            ["Ville", client.city],
+            ["Objectif", client.objective === "sport" ? "Prise de masse / sport" : "Perte de poids"],
+          ]}
+        />
+
+        <RecapBlock
+          title="⚖️ Bilan corporel"
+          rows={[
+            ["Poids", `${bilan.weightKg} kg`],
+            ["Taille", `${bilan.heightCm} cm`],
+            ["IMC", bmi.toFixed(1)],
+            ["% Masse grasse", `${bilan.bodyFatPct}%`],
+            ["% Masse musculaire", `${bilan.muscleMassPct}%`],
+          ]}
+        />
+
+        <RecapBlock
+          title={`🎯 Programme (${selectedProducts.length} produits)`}
+          rows={[
+            ...selectedProducts.map((p) => [
+              `${p.emoji} ${p.name}`,
+              `${p.priceEur}€ · ${p.pv} PV`,
+            ] as [string, string]),
+            ["TOTAL", `${totalPrice}€ · ${totalPv} PV`],
+          ]}
+          highlightLast
+        />
+      </div>
+
+      <div
+        style={{
+          marginTop: 20,
+          padding: "14px 16px",
+          background: "linear-gradient(135deg, #FFF5E0, #FAF0CB)",
+          border: "1px solid #EFD9A1",
+          borderRadius: 12,
+          textAlign: "center",
+        }}
+      >
+        <div style={{ fontSize: 32, marginBottom: 6 }}>🏆</div>
+        <div style={{ fontFamily: "Syne, Georgia, serif", fontSize: 16, color: "#5C4A0F", fontWeight: 500 }}>
+          Tu maîtrises le flow complet bilan → programme.
+        </div>
+        <div style={{ fontSize: 12, color: "#6B6B62", marginTop: 6 }}>
+          Aucune donnée n'a été enregistrée — tu peux refaire l'exercice quand tu veux depuis l'Academy.
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ─── UI helpers ──────────────────────────────────────────────────────────────
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        background: "var(--ls-surface, #FFFEF8)",
+        border: "0.5px solid var(--ls-border, #E5DFCF)",
+        borderRadius: 16,
+        padding: 22,
+      }}
+    >
+      <h2
+        style={{
+          fontFamily: "Syne, Georgia, serif",
+          fontSize: 18,
+          fontWeight: 500,
+          margin: "0 0 14px 0",
+          color: "var(--ls-text, #2C2C2A)",
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ display: "block", marginBottom: 14 }}>
+      <div
+        style={{
+          fontSize: 12,
+          color: "var(--ls-text-muted, #6B6B62)",
+          marginBottom: 6,
+          letterSpacing: 0.3,
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </div>
+      {children}
+    </label>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "10px 12px",
+  fontSize: 14,
+  border: "0.5px solid var(--ls-border, #C9C2AB)",
+  borderRadius: 8,
+  background: "var(--ls-surface, #FFFEF8)",
+  color: "var(--ls-text, #2C2C2A)",
+  fontFamily: "inherit",
+};
+
+function RecapBlock({
+  title,
+  rows,
+  highlightLast = false,
+}: {
+  title: string;
+  rows: [string, string][];
+  highlightLast?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        background: "var(--ls-surface2, #FAF6E8)",
+        borderRadius: 10,
+        padding: "12px 14px",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 11,
+          color: "var(--ls-text-muted, #6B6B62)",
+          letterSpacing: 0.4,
+          textTransform: "uppercase",
+          marginBottom: 8,
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {rows.map(([label, value], i) => {
+          const isLast = i === rows.length - 1 && highlightLast;
+          return (
+            <div
+              key={`${label}-${i}`}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                fontSize: 13,
+                padding: isLast ? "6px 0 0 0" : 0,
+                borderTop: isLast ? "0.5px solid var(--ls-border, #E5DFCF)" : "none",
+                marginTop: isLast ? 6 : 0,
+                color: isLast ? "#B8922A" : "var(--ls-text, #2C2C2A)",
+                fontWeight: isLast ? 500 : 400,
+              }}
+            >
+              <span>{label}</span>
+              <span>{value}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AcademySectionPage.tsx
+++ b/src/pages/AcademySectionPage.tsx
@@ -24,6 +24,14 @@ export function AcademySectionPage() {
 
   const section = sectionId ? getAcademySectionById(sectionId) : undefined;
 
+  // Section 9 sandbox (2026-04-29) : redirige vers le wizard auto-portant
+  // /academy/sandbox des qu on arrive sur /academy/sandbox via l overview.
+  useEffect(() => {
+    if (sectionId === "sandbox") {
+      navigate("/academy/sandbox", { replace: true });
+    }
+  }, [sectionId, navigate]);
+
   // Chantier Academy section 1 fix runtime (2026-04-27) : on demarre le
   // tour via le contexte global (rendu par AppLayout) puis on navigue
   // immediatement a la 1ere route du tour. AcademySectionPage peut alors


### PR DESCRIPTION
Nouveau parcours bonus "A toi de jouer" qui permet au distri de simuler la creation d un client + bilan complet de bout en bout, sans toucher a la base. Wizard 4 etapes auto-portant (pas le tour engine).

Etapes :
1. Profil client (prenom, nom, age, ville, objectif)
2. Bilan corporel (poids, taille, MG, MM) avec IMC live
3. Programme (cocher 2+ produits adaptes a l objectif)
4. Recap final avec celebration + markSectionDone

Architecture :
- AcademySandboxPage : page autonome a /academy/sandbox
- Section 9 dans ACADEMY_SECTIONS avec steps[]=[] (pas de tour)
- AcademySectionPage redirige sectionId="sandbox" -> /academy/sandbox
- DemoBanner gold "aucune donnee n est sauvegardee" en haut
- Validations realistes par etape (ranges anthropometriques)

Aucune migration DB (tout en state React local). Section 9 marquee done via le hook useAcademyProgress existant.

Plus : roadmap docs/ROADMAP_HORS_ACADEMY.md avec 5 chantiers a venir (refonte clients, analytics admin, templates IA, assistant IA chat, onboarding client PWA) + memo CLAUDE.md sur les Tier S 1+2 differes (narration audio + video intro 90s).