### PR TITLE
feat(coach-badges): chantier #10 — badges crédibilité coach

### DIFF
--- a/src/components/bilan-online/CoachCredibilityBadges.tsx
+++ b/src/components/bilan-online/CoachCredibilityBadges.tsx
@@ -1,0 +1,223 @@
+// =============================================================================
+// CoachCredibilityBadges — Chantier #10 (2026-05-17)
+//
+// Affiche 3 badges crédibilité coach (rang Herbalife + nb bilans réalisés
+// + ancienneté) sur les pages publiques de conversion. 3 variants visuels :
+//   - "welcome"    : sous la coach-card de BilanOnlineWelcomePage (chip pills)
+//   - "business"   : page /business (grid 3 colonnes, plus généreux)
+//   - "newsletter" : footer newsletter publique (ligne compacte serif)
+//
+// La source de données est la RPC `get_coach_credibility(_by_slug)`
+// (migration 20261112000000_coach_credibility.sql). Échec silencieux : si
+// la RPC renvoie null ou plante (réseau, slug bidon), le composant ne rend
+// rien — la page reste utilisable.
+//
+// Avis ⭐ : volontairement out of scope V1. Sera branché quand le chantier
+// #11 (témoignages clients) livrera la donnée. Voir BRAINSTORM Égypte § #11.
+// =============================================================================
+
+import { useEffect, useState } from "react";
+import { getSupabaseClient } from "../../services/supabaseClient";
+import { BO } from "./BilanOnlineShell";
+
+export interface CoachCredibility {
+  user_id: string;
+  first_name: string | null;
+  name: string | null;
+  rank: string;
+  rank_label: string;
+  bilans_count: number;
+  tenure_months: number;
+}
+
+type Variant = "welcome" | "business" | "newsletter";
+
+interface Props {
+  coachSlug?: string | null;
+  coachUserId?: string | null;
+  variant?: Variant;
+  /** Données préchargées (optionnel) — évite un fetch supplémentaire. */
+  preloaded?: CoachCredibility | null;
+  /** Notif au parent : on a résolu le coach (utile pour afficher le nom officiel). */
+  onResolved?: (data: CoachCredibility | null) => void;
+}
+
+function formatTenure(months: number): string {
+  if (months < 12) {
+    return `${months} mois d'expérience`;
+  }
+  const years = Math.floor(months / 12);
+  const rest = months % 12;
+  if (rest === 0) {
+    return `${years} an${years > 1 ? "s" : ""} d'expérience`;
+  }
+  return `${years} an${years > 1 ? "s" : ""} d'expérience`;
+}
+
+export function CoachCredibilityBadges({
+  coachSlug,
+  coachUserId,
+  variant = "welcome",
+  preloaded,
+  onResolved,
+}: Props) {
+  const [data, setData] = useState<CoachCredibility | null>(preloaded ?? null);
+  const [loading, setLoading] = useState<boolean>(!preloaded && !!(coachSlug || coachUserId));
+
+  useEffect(() => {
+    if (preloaded) {
+      setData(preloaded);
+      setLoading(false);
+      return;
+    }
+    if (!coachSlug && !coachUserId) {
+      setData(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    (async () => {
+      try {
+        const sb = await getSupabaseClient();
+        if (!sb) {
+          if (!cancelled) { setData(null); setLoading(false); }
+          return;
+        }
+        const { data: rpc, error } = coachUserId
+          ? await sb.rpc("get_coach_credibility", { p_user_id: coachUserId })
+          : await sb.rpc("get_coach_credibility_by_slug", { p_slug: coachSlug });
+        if (cancelled) return;
+        if (error || !rpc) {
+          setData(null);
+        } else {
+          const parsed = rpc as CoachCredibility;
+          setData(parsed);
+          onResolved?.(parsed);
+        }
+      } catch {
+        if (!cancelled) setData(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+    // onResolved is callback-stable enough (called once per resolve)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [coachSlug, coachUserId, preloaded]);
+
+  if (loading) {
+    return <BadgesSkeleton variant={variant} />;
+  }
+  if (!data) return null;
+
+  const items = [
+    { icon: "🏆", label: data.rank_label, key: "rank" },
+    { icon: "📋", label: `${data.bilans_count} bilan${data.bilans_count > 1 ? "s" : ""} réalisé${data.bilans_count > 1 ? "s" : ""}`, key: "bilans" },
+    { icon: "🗓", label: formatTenure(data.tenure_months), key: "tenure" },
+  ];
+
+  if (variant === "newsletter") {
+    return (
+      <div style={{
+        display: "flex", flexWrap: "wrap", justifyContent: "center", gap: 14,
+        fontFamily: BO.fontBody, fontSize: 12, color: BO.textMuted,
+        lineHeight: 1.4,
+      }}>
+        {items.map((it, i) => (
+          <span key={it.key} style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+            <span aria-hidden="true">{it.icon}</span>{it.label}
+            {i < items.length - 1 && (
+              <span style={{ marginLeft: 14, opacity: 0.4 }} aria-hidden="true">·</span>
+            )}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  if (variant === "business") {
+    return (
+      <div style={{
+        display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12,
+        margin: "0 auto", maxWidth: 520,
+      }}>
+        {items.map((it) => (
+          <div key={it.key} style={{
+            background: "white", borderRadius: 14,
+            border: `1px solid ${BO.border}`,
+            padding: "16px 12px", textAlign: "center",
+            boxShadow: "0 2px 10px rgba(11,13,17,0.04)",
+          }}>
+            <div style={{ fontSize: 22, lineHeight: 1, marginBottom: 8 }} aria-hidden="true">{it.icon}</div>
+            <div style={{
+              fontFamily: BO.fontDisplay, fontSize: 14, fontWeight: 700,
+              color: BO.text, lineHeight: 1.25,
+            }}>{it.label}</div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // welcome (default) : chips horizontales discrètes, alignées sur coach-card
+  return (
+    <div style={{
+      display: "flex", flexWrap: "wrap", justifyContent: "center", gap: 8,
+      marginBottom: 24,
+      animation: "bo-fadeIn 0.4s ease-out 0.1s both",
+    }}>
+      {items.map((it) => (
+        <span key={it.key} style={{
+          display: "inline-flex", alignItems: "center", gap: 6,
+          padding: "7px 12px",
+          background: "white",
+          border: `1px solid ${BO.border}`,
+          borderRadius: 999,
+          fontFamily: BO.fontBody, fontSize: 12, fontWeight: 600,
+          color: BO.text,
+          boxShadow: "0 2px 8px rgba(11, 13, 17, 0.04)",
+        }}>
+          <span aria-hidden="true" style={{ fontSize: 13 }}>{it.icon}</span>
+          {it.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function BadgesSkeleton({ variant }: { variant: Variant }) {
+  const count = 3;
+  if (variant === "business") {
+    return (
+      <div style={{
+        display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12,
+        margin: "0 auto", maxWidth: 520,
+      }}>
+        {Array.from({ length: count }).map((_, i) => (
+          <div key={i} style={{
+            height: 76, background: BO.surface2, borderRadius: 14,
+            opacity: 0.5,
+          }} />
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div style={{
+      display: "flex", flexWrap: "wrap", justifyContent: "center", gap: 8,
+      marginBottom: 24,
+    }}>
+      {Array.from({ length: count }).map((_, i) => (
+        <span key={i} style={{
+          width: 110, height: 28,
+          background: BO.surface2, borderRadius: 999,
+          opacity: 0.5,
+        }} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/BilanOnlineWelcomePage.tsx
+++ b/src/pages/BilanOnlineWelcomePage.tsx
@@ -7,6 +7,7 @@
 import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { BO, BilanOnlineShell, BoBrand, BoCtaPrimary } from "../components/bilan-online/BilanOnlineShell";
+import { CoachCredibilityBadges } from "../components/bilan-online/CoachCredibilityBadges";
 
 function normalizeSlug(input: string): string {
   return input
@@ -104,6 +105,10 @@ export function BilanOnlineWelcomePage() {
               </div>
             </div>
           </div>
+        )}
+
+        {slug && (
+          <CoachCredibilityBadges coachSlug={slug} variant="welcome" />
         )}
 
         <div style={{

--- a/supabase/migrations/20261112000000_coach_credibility.sql
+++ b/supabase/migrations/20261112000000_coach_credibility.sql
@@ -1,0 +1,170 @@
+-- =============================================================================
+-- Chantier #10 — Badges + certifications coach (2026-05-17)
+--
+-- Expose une RPC publique `get_coach_credibility(p_user_id)` consommée par la
+-- page Welcome bilan online (et + tard /business, newsletter). Renvoie un
+-- payload safe : prénom, rang Herbalife (clé + libellé court FR), nombre de
+-- bilans initiaux réalisés, ancienneté en mois. AUCUNE donnée sensible.
+--
+-- Helper `get_coach_credibility_by_slug(p_slug)` : résout d'abord le slug
+-- (mêmes règles que submit-online-bilan, sans accents, lowercase, alphanum
+-- only) puis appelle get_coach_credibility.
+--
+-- SECURITY DEFINER : permet à un visiteur anonyme (page Welcome publique) de
+-- lire ces stats sans contourner les RLS de `users` / `clients` / `assessments`.
+-- Bornage strict : ne retourne JAMAIS l'email, le téléphone ou la sponsor
+-- chain. Lecture seule.
+-- =============================================================================
+
+begin;
+
+-- ─── 1. Helper de normalisation slug (mirror JS submit-online-bilan) ────────
+create or replace function public.ls_normalize_slug(p_input text)
+returns text
+language sql
+immutable
+as $$
+  select regexp_replace(
+    translate(
+      lower(coalesce(p_input, '')),
+      'àáâãäåæçèéêëìíîïñòóôõöøùúûüýÿ',
+      'aaaaaaaceeeeiiiinoooooouuuuyy'
+    ),
+    '[^a-z0-9]', '', 'g'
+  );
+$$;
+
+comment on function public.ls_normalize_slug(text) is
+  'Chantier #10 — normalise un prénom en slug URL (lowercase, sans accents, alphanum). Mirror exact de la fonction normalizeSlug() côté JS dans submit-online-bilan.';
+
+-- ─── 2. Mapping rang → libellé court FR (cohérent avec RANK_LABELS front) ───
+create or replace function public.ls_rank_short_label(p_rank text)
+returns text
+language sql
+immutable
+as $$
+  select case p_rank
+    when 'distributor_25'        then 'Distributor'
+    when 'senior_consultant_35'  then 'Senior Consultant'
+    when 'success_builder_42'    then 'Success Builder'
+    when 'supervisor_50'         then 'Supervisor'
+    when 'active_supervisor_50'  then 'Active Supervisor'
+    when 'world_team_50'         then 'World Team'
+    when 'active_world_team_50'  then 'Active World Team'
+    when 'get_team_50'           then 'G.E.T. Team'
+    when 'get_team_2500_50'      then 'G.E.T. 2 500 RO'
+    when 'millionaire_50'        then 'Millionaire Team'
+    when 'millionaire_7500_50'   then 'Millionaire 7 500 RO'
+    when 'presidents_50'         then 'President''s Team'
+    else 'Distributor'
+  end;
+$$;
+
+-- ─── 3. RPC principale : get_coach_credibility(user_id) ─────────────────────
+create or replace function public.get_coach_credibility(p_user_id uuid)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_user record;
+  v_bilans_count integer;
+  v_tenure_months integer;
+  v_first_name text;
+begin
+  if p_user_id is null then
+    return null;
+  end if;
+
+  select id, name, current_rank, created_at, role, active
+    into v_user
+    from public.users
+    where id = p_user_id
+      and active = true
+      and role in ('distributor', 'admin', 'referent')
+    limit 1;
+
+  if not found then
+    return null;
+  end if;
+
+  -- Prénom : on prend la 1ʳᵉ partie du `name` (cohérent avec slug Welcome).
+  v_first_name := nullif(split_part(coalesce(v_user.name, ''), ' ', 1), '');
+
+  -- Compte les bilans initiaux du distri (uniquement type 'initial', les
+  -- follow-ups n'inflatent pas la métrique).
+  select count(*)::integer
+    into v_bilans_count
+    from public.assessments a
+    join public.clients c on c.id = a.client_id
+    where c.distributor_id = p_user_id
+      and a.type = 'initial';
+
+  -- Ancienneté en mois pleins depuis created_at (min 1 si compte du jour).
+  v_tenure_months := greatest(
+    1,
+    extract(year from age(now(), v_user.created_at))::integer * 12
+    + extract(month from age(now(), v_user.created_at))::integer
+  );
+
+  return jsonb_build_object(
+    'user_id',        v_user.id,
+    'first_name',     v_first_name,
+    'name',           v_user.name,
+    'rank',           v_user.current_rank,
+    'rank_label',     public.ls_rank_short_label(v_user.current_rank),
+    'bilans_count',   v_bilans_count,
+    'tenure_months',  v_tenure_months
+  );
+end;
+$$;
+
+comment on function public.get_coach_credibility(uuid) is
+  'Chantier #10 — Stats publiques d''un coach pour les pages Welcome bilan online / /business / newsletter. Lecture seule, données safe uniquement. SECURITY DEFINER pour bypass RLS sur clients/assessments.';
+
+-- ─── 4. RPC slug → credibility (utilisée par la page Welcome) ───────────────
+create or replace function public.get_coach_credibility_by_slug(p_slug text)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_slug text;
+  v_user_id uuid;
+begin
+  v_slug := public.ls_normalize_slug(p_slug);
+  if v_slug is null or length(v_slug) < 2 then
+    return null;
+  end if;
+
+  select id
+    into v_user_id
+    from public.users
+    where active = true
+      and role in ('distributor', 'admin', 'referent')
+      and public.ls_normalize_slug(split_part(coalesce(name, ''), ' ', 1)) = v_slug
+    order by created_at asc
+    limit 1;
+
+  if v_user_id is null then
+    return null;
+  end if;
+
+  return public.get_coach_credibility(v_user_id);
+end;
+$$;
+
+comment on function public.get_coach_credibility_by_slug(text) is
+  'Chantier #10 — Résout un slug coach (prénom normalisé) → user_id, puis renvoie le payload credibility. Mirror exact de la résolution de submit-online-bilan.';
+
+-- ─── 5. Permissions : lecture publique (page Welcome anonyme) ───────────────
+grant execute on function public.get_coach_credibility(uuid) to anon, authenticated;
+grant execute on function public.get_coach_credibility_by_slug(text) to anon, authenticated;
+grant execute on function public.ls_normalize_slug(text) to anon, authenticated;
+grant execute on function public.ls_rank_short_label(text) to anon, authenticated;
+
+commit;

--- a/supabase/migrations/20261112100000_announce_coach_credibility.sql.pending
+++ b/supabase/migrations/20261112100000_announce_coach_credibility.sql.pending
@@ -1,0 +1,22 @@
+-- Chantier #10 Badges coach — étape 10.4 (2026-05-17).
+-- Annonce distri : leur page Welcome bilan affiche maintenant leurs badges
+-- crédibilité (rang Herbalife + nb bilans + ancienneté).
+-- À renommer en .sql au moment du merge prod (cf. règle livrable CLAUDE.md).
+begin;
+
+insert into public.app_announcements (id, title, body, emoji, accent, link_path, link_label, audience, published_at)
+select
+  gen_random_uuid(),
+  'Tes badges coach apparaissent 🏆',
+  'Sur ton lien bilan online (/bilan-online/<ton-prénom>), tes visiteurs voient maintenant trois badges crédibilité juste sous ta carte coach : ton rang Herbalife, ton nombre de bilans réalisés et ton ancienneté. La conversion grimpe quand le prospect comprend qui tu es avant de remplir.',
+  '🏆',
+  'gold',
+  '/bilan-online',
+  'Voir ma page',
+  'all',
+  now()
+where not exists (
+  select 1 from public.app_announcements where title = 'Tes badges coach apparaissent 🏆'
+);
+
+commit;


### PR DESCRIPTION
## Summary

Chantier #10 du brainstorm Égypte — badges crédibilité coach visibles publiquement, intégrés sur la page Welcome bilan online (`/bilan-online/<slug>`).

- 🗄️ Migration SQL `get_coach_credibility(p_user_id)` + `_by_slug(p_slug)` (SECURITY DEFINER, lecture publique safe : rank + nb bilans + ancienneté, AUCUNE donnée sensible)
- 🧩 Composant `<CoachCredibilityBadges variant="welcome|business|newsletter">` aligné sur le mockup Égypte (coach-card existante) — chip pills blanches gold/teal, Syne/DM Sans, skeleton state, échec silencieux
- 🌱 Intégré sur `BilanOnlineWelcomePage` sous la coach-card (visible uniquement si slug résolu)
- 📣 Announcement distri en `.sql.pending` (à activer au merge prod, cf. règle livrable CLAUDE.md)

**Stack** : cette PR est branchée sur `feat/online-bilan` (PR #41). Les variants `business` et `newsletter` sont prêts mais non câblés car les chantiers #7 et #8 ne sont pas livrés. Les avis ⭐ sont volontairement out of scope V1 (dépendent du chantier #11 témoignages).

## Test plan

- [ ] Migration appliquée : `supabase db push --linked --include-all`
- [ ] Tester `select public.get_coach_credibility_by_slug('thomas')` en SQL → renvoie un jsonb avec rank/bilans_count/tenure_months
- [ ] Tester `select public.get_coach_credibility_by_slug('inexistant')` → renvoie `null` proprement
- [ ] Visiter `/bilan-online/thomas` (ou ton slug) en navigation privée → 3 chips visibles sous la coach-card
- [ ] Visiter `/bilan-online/zzznopecoach` → coach-card et badges absents (fallback graceful)
- [ ] Vérifier console réseau : pas d'erreur RPC, pas de PII leak (la RPC ne renvoie ni email ni téléphone)
- [ ] Responsive mobile 360px : les 3 chips wrap proprement sans casser la mise en page
- [ ] `npm run build` passe (validé localement, build OK 13s)
- [ ] Activer le `.sql.pending` (rename → `.sql`) au moment du merge prod et vérifier la cloche annonce

🤖 Generated with [Claude Code](https://claude.com/claude-code)