### PR TITLE
fix(coach-badges): V2 — retire bilans + ancienneté app, ajoute ville + coaching_since

### DIFF
--- a/src/components/bilan-online/CoachCredibilityBadges.tsx
+++ b/src/components/bilan-online/CoachCredibilityBadges.tsx
@@ -26,8 +26,9 @@ export interface CoachCredibility {
   name: string | null;
   rank: string;
   rank_label: string;
-  bilans_count: number;
-  tenure_months: number;
+  city: string | null;
+  coaching_since: string | null;
+  tenure_months: number | null;
 }
 
 type Variant = "welcome" | "business" | "newsletter";
@@ -47,10 +48,6 @@ function formatTenure(months: number): string {
     return `${months} mois d'expérience`;
   }
   const years = Math.floor(months / 12);
-  const rest = months % 12;
-  if (rest === 0) {
-    return `${years} an${years > 1 ? "s" : ""} d'expérience`;
-  }
   return `${years} an${years > 1 ? "s" : ""} d'expérience`;
 }
 
@@ -114,11 +111,15 @@ export function CoachCredibilityBadges({
   }
   if (!data) return null;
 
-  const items = [
+  const items: Array<{ icon: string; label: string; key: string }> = [
     { icon: "🏆", label: data.rank_label, key: "rank" },
-    { icon: "📋", label: `${data.bilans_count} bilan${data.bilans_count > 1 ? "s" : ""} réalisé${data.bilans_count > 1 ? "s" : ""}`, key: "bilans" },
-    { icon: "🗓", label: formatTenure(data.tenure_months), key: "tenure" },
   ];
+  if (data.city && data.city.trim().length > 0) {
+    items.push({ icon: "📍", label: data.city.trim(), key: "city" });
+  }
+  if (typeof data.tenure_months === "number" && data.tenure_months >= 1) {
+    items.push({ icon: "🗓", label: formatTenure(data.tenure_months), key: "tenure" });
+  }
 
   if (variant === "newsletter") {
     return (

--- a/src/components/settings/ProfilTab.tsx
+++ b/src/components/settings/ProfilTab.tsx
@@ -66,6 +66,12 @@ export function ProfilTab() {
   // Ville (Chantier D météo 2026-05-05). Source pour la pill météo Co-pilote V5.
   const [city, setCity] = useState<string>(currentUser?.city ?? "");
   const [geoLoading, setGeoLoading] = useState(false);
+  // Date début activité coaching Herbalife (chantier #10 V2 badges).
+  // Format ISO "YYYY-MM-DD" pour l'input type="date". Null/vide = pas de
+  // chip ancienneté sur la Welcome bilan.
+  const [coachingSince, setCoachingSince] = useState<string>(
+    currentUser?.coachingSince ?? "",
+  );
   // Rang Herbalife (FLEX rank-aware, 2026-11-05). Détermine la marge retail
   // utilisée pour calculer les cibles FLEX. Modifiable ici par le distri lui-même.
   const [currentRank, setCurrentRank] = useState<HerbalifeRank>(
@@ -152,7 +158,11 @@ export function ProfilTab() {
           // V2 (2026-04-30) : bio (avatar_url est save par AvatarUploader directement)
           bio: bio.trim() || null,
           // Chantier D météo (2026-05-05) : ville pour Co-pilote V5
+          // Aussi affichée sur la Welcome bilan (chantier #10 V2 badges).
           city: city.trim() || null,
+          // Chantier #10 V2 badges (2026-05-17) : date début coaching
+          // Herbalife → badge ancienneté Welcome bilan. Null si vide.
+          coaching_since: coachingSince.trim() || null,
           // FLEX rank-aware (2026-11-05) : update rank + set rank_set_at
           // (peut être déjà rempli, on le maintient en sync à chaque save).
           current_rank: currentRank,
@@ -419,7 +429,56 @@ export function ProfilTab() {
               fontFamily: "DM Sans, sans-serif",
             }}
           >
-            Utilisée par la météo 5 jours sur le Co-pilote.
+            Utilisée par la météo 5 jours sur le Co-pilote et affichée sur ta page bilan online publique.
+          </div>
+        </div>
+
+        {/* Coaching depuis (chantier #10 V2 badges) — alimente le chip
+            ancienneté de la page /bilan-online/<slug>. Optionnel : vide
+            = pas de chip ancienneté affiché. */}
+        <div>
+          <label
+            style={{
+              display: "block",
+              fontSize: 11,
+              fontWeight: 700,
+              color: "var(--ls-text-muted)",
+              textTransform: "uppercase",
+              letterSpacing: 1.2,
+              marginBottom: 6,
+              fontFamily: "DM Sans, sans-serif",
+            }}
+          >
+            Coach Herbalife depuis (optionnel)
+          </label>
+          <input
+            type="date"
+            value={coachingSince}
+            onChange={(e) => setCoachingSince(e.target.value)}
+            max={new Date().toISOString().slice(0, 10)}
+            style={{
+              width: "100%",
+              padding: "10px 12px",
+              borderRadius: 10,
+              border: "1px solid var(--ls-border)",
+              background: "var(--ls-surface2)",
+              color: "var(--ls-text)",
+              fontSize: 14,
+              fontFamily: "DM Sans, sans-serif",
+              outline: "none",
+              colorScheme: "light",
+              boxSizing: "border-box",
+            }}
+          />
+          <div
+            style={{
+              fontSize: 10.5,
+              color: "var(--ls-text-hint)",
+              marginTop: 4,
+              fontFamily: "DM Sans, sans-serif",
+            }}
+          >
+            Ta vraie date de début d'activité Herbalife (pas la date d'arrivée sur l'app). Affichée comme badge ancienneté sur ta page bilan online. Laisse vide pour ne rien afficher.
           </div>
         </div>
 

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -56,6 +56,7 @@ type UserRow = {
   rank_set_at?: string | null;
   formation_beta_access?: boolean | null;
   city?: string | null;
+  coaching_since?: string | null;
   frozen_at?: string | null;
   frozen_by?: string | null;
   frozen_reason?: string | null;
@@ -341,6 +342,7 @@ function mapUser(row: UserRow): User {
     rankSetAt: row.rank_set_at ?? null,
     formationBetaAccess: row.formation_beta_access ?? false,
     city: row.city ?? null,
+    coachingSince: row.coaching_since ?? null,
     frozenAt: row.frozen_at ?? null,
     frozenBy: row.frozen_by ?? null,
     frozenReason: row.frozen_reason ?? null,

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -142,8 +142,13 @@ export interface User {
    *  le user voit /formation même s'il n'est pas admin. */
   formationBetaAccess?: boolean;
   /** Ville du distri (saisie /bienvenue-distri ou /parametres).
-   *  Source de vérité pour la météo Co-pilote V5. Chantier D 2026-05-05. */
+   *  Source de vérité pour la météo Co-pilote V5. Chantier D 2026-05-05.
+   *  Aussi affichée sur les badges crédibilité Welcome bilan (chantier #10 V2). */
   city?: string | null;
+  /** Date début activité coaching Herbalife (saisie manuelle /parametres).
+   *  Sert au badge ancienneté Welcome bilan. NULL = pas affiché.
+   *  Chantier #10 V2 — 2026-05-17. */
+  coachingSince?: string | null;
   /** Compte gelé par admin. NULL = actif, ISO timestamp = gelé.
    *  Effets : redirige sur /frozen + exclu des stats XP/team.
    *  Chantier freeze 2026-05-06. */

--- a/supabase/migrations/20261113000000_coach_credibility_v2.sql
+++ b/supabase/migrations/20261113000000_coach_credibility_v2.sql
@@ -1,0 +1,93 @@
+-- =============================================================================
+-- Chantier #10 V2 — badges coach (2026-05-17, après feedback Thomas)
+--
+-- V1 affichait : 🏆 rang + 📋 bilans réalisés + 🗓 ancienneté app.
+-- Problèmes :
+--   - "X bilans réalisés" décrédibilise les nouveaux distri (0-5 bilans).
+--   - "X mois d'expérience" basé sur users.created_at = ancienneté DANS
+--     l'app, pas ancienneté coaching Herbalife → fausse pour tous les
+--     coachs experts qui arrivent sur La Base 360.
+--
+-- V2 :
+--   - DROP du chip "bilans réalisés".
+--   - Ancienneté basée sur un nouveau champ `users.coaching_since` (date),
+--     saisi manuellement par chaque distri dans Paramètres > Profil.
+--     NULL = pas de chip ancienneté affiché.
+--   - Nouveau chip "📍 ville" (réutilise `users.city` déjà existant).
+--     NULL = pas de chip ville affiché.
+--
+-- Logique d'affichage finale :
+--   - Rang : toujours affiché (au pire "Distributor (25%)" si défaut).
+--   - Ville : affichée si `city` non null.
+--   - Ancienneté : affichée si `coaching_since` non null.
+-- =============================================================================
+
+begin;
+
+-- 1. Nouveau champ coaching_since
+alter table public.users
+  add column if not exists coaching_since date;
+
+comment on column public.users.coaching_since is
+  'Chantier #10 V2 — Date à laquelle le distri a commencé son activité Herbalife (saisi manuellement Paramètres > Profil). Sert à calculer le badge ancienneté visible sur la page Welcome bilan online. NULL = pas affiché.';
+
+-- 2. Remplace get_coach_credibility (drop bilans_count, add city + coaching_since)
+create or replace function public.get_coach_credibility(p_user_id uuid)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_user record;
+  v_tenure_months integer;
+  v_first_name text;
+begin
+  if p_user_id is null then
+    return null;
+  end if;
+
+  select id, name, current_rank, coaching_since, city, role, active
+    into v_user
+    from public.users
+    where id = p_user_id
+      and active = true
+      and role in ('distributor', 'admin', 'referent')
+    limit 1;
+
+  if not found then
+    return null;
+  end if;
+
+  v_first_name := nullif(split_part(coalesce(v_user.name, ''), ' ', 1), '');
+
+  -- Ancienneté basée sur coaching_since (et non users.created_at). Si null,
+  -- on renvoie null → le front ne montre pas le chip.
+  if v_user.coaching_since is null then
+    v_tenure_months := null;
+  else
+    v_tenure_months := greatest(
+      1,
+      extract(year from age(now(), v_user.coaching_since::timestamptz))::integer * 12
+      + extract(month from age(now(), v_user.coaching_since::timestamptz))::integer
+    );
+  end if;
+
+  return jsonb_build_object(
+    'user_id',        v_user.id,
+    'first_name',     v_first_name,
+    'name',           v_user.name,
+    'rank',           v_user.current_rank,
+    'rank_label',     public.ls_rank_short_label(v_user.current_rank),
+    'city',           v_user.city,
+    'coaching_since', v_user.coaching_since,
+    'tenure_months',  v_tenure_months
+  );
+end;
+$$;
+
+comment on function public.get_coach_credibility(uuid) is
+  'Chantier #10 V2 — Stats publiques coach (rang + ville + ancienneté coaching Herbalife). Lecture seule, données safe. SECURITY DEFINER pour bypass RLS users.';
+
+commit;


### PR DESCRIPTION
## Summary

V1 (PR #42) affichait 3 chips dont 2 **anti-signaux** identifiés par Thomas :
- 📋 *X bilans réalisés* → décrédibilise les nouveaux distri (0-5 bilans)
- 🗓 *X mois d'expérience* basé sur `users.created_at` → c'est l'ancienneté **dans l'app**, pas l'ancienneté **coaching Herbalife**. Faux pour tous les coachs experts qui arrivent sur La Base 360.

V2 :
- ❌ DROP chip *bilans réalisés*
- ➕ Nouveau chip **📍 ville** (réutilise `users.city` existant, hide si null)
- ➕ Nouveau champ `users.coaching_since` (date) saisi par le distri dans Paramètres > Profil. Le chip ancienneté utilise CETTE date (vraie ancienneté Herbalife). Hide si null.
- ✅ Rang Herbalife toujours visible (signal solide pour tous)

## Test plan

- [ ] Migration appliquée : `supabase db push --linked --include-all`
- [ ] Paramètres > Profil : le champ "Coach Herbalife depuis" est visible + sauvegardable
- [ ] Sans `coaching_since` ni `city` → uniquement le chip 🏆 rang affiché
- [ ] Avec `city` renseignée → chip 📍 ville s'ajoute
- [ ] Avec `coaching_since` renseigné → chip 🗓 X ans/mois s'ajoute
- [ ] `npm run build` passe (validé local 22s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)