### PR TITLE
feat(onboarding): demande coaching_since + clarifie ville à l'inscription distri

### DIFF
--- a/src/pages/BienvenueDistriPage.tsx
+++ b/src/pages/BienvenueDistriPage.tsx
@@ -68,6 +68,10 @@ export function BienvenueDistriPage() {
   const [passwordConfirm, setPasswordConfirm] = useState("");
   const [phone, setPhone] = useState("");
   const [city, setCity] = useState("");
+  // Chantier #10 V2 badges (2026-05-17) : date début activité Herbalife
+  // saisie à l'onboarding. Optionnel. Alimente le badge ancienneté sur
+  // /bilan-online/<slug>. Modifiable plus tard dans Paramètres > Profil.
+  const [coachingSince, setCoachingSince] = useState("");
   const [herbalifeId, setHerbalifeId] = useState("");
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [avatarUploading, setAvatarUploading] = useState(false);
@@ -225,6 +229,7 @@ export function BienvenueDistriPage() {
           last_name: lastName.trim(),
           phone: phone.trim(),
           city: city.trim(),
+          coaching_since: coachingSince.trim() || null,
           herbalife_id: herbalifeId.trim(),
           avatar_url: avatarUrl,
         },
@@ -263,6 +268,7 @@ export function BienvenueDistriPage() {
   }, [
     avatarUrl,
     city,
+    coachingSince,
     firstName,
     herbalifeId,
     lastName,
@@ -485,6 +491,7 @@ export function BienvenueDistriPage() {
                 lastName={lastName}
                 phone={phone}
                 city={city}
+                coachingSince={coachingSince}
                 herbalifeId={herbalifeId}
                 avatarUrl={avatarUrl}
                 avatarUploading={avatarUploading}
@@ -494,6 +501,7 @@ export function BienvenueDistriPage() {
                 onLastNameChange={setLastName}
                 onPhoneChange={setPhone}
                 onCityChange={setCity}
+                onCoachingSinceChange={setCoachingSince}
                 onHerbalifeIdChange={setHerbalifeId}
                 onUploadAvatar={handleUploadAvatar}
                 onRemoveAvatar={() => setAvatarUrl(null)}
@@ -738,6 +746,7 @@ function ProfileStep({
   lastName,
   phone,
   city,
+  coachingSince,
   herbalifeId,
   avatarUrl,
   avatarUploading,
@@ -747,6 +756,7 @@ function ProfileStep({
   onLastNameChange,
   onPhoneChange,
   onCityChange,
+  onCoachingSinceChange,
   onHerbalifeIdChange,
   onUploadAvatar,
   onRemoveAvatar,
@@ -757,6 +767,7 @@ function ProfileStep({
   lastName: string;
   phone: string;
   city: string;
+  coachingSince: string;
   herbalifeId: string;
   avatarUrl: string | null;
   avatarUploading: boolean;
@@ -766,12 +777,14 @@ function ProfileStep({
   onLastNameChange: (v: string) => void;
   onPhoneChange: (v: string) => void;
   onCityChange: (v: string) => void;
+  onCoachingSinceChange: (v: string) => void;
   onHerbalifeIdChange: (v: string) => void;
   onUploadAvatar: (file: File) => void;
   onRemoveAvatar: () => void;
   onBack: () => void;
   onSubmit: () => void;
 }) {
+  const todayStr = new Date().toISOString().slice(0, 10);
   return (
     <div>
       <p
@@ -835,6 +848,21 @@ function ProfileStep({
           placeholder="Verdun, Paris…"
           style={inputStyle}
         />
+        <div style={{ fontSize: 11, color: "#6B7280", marginTop: 4 }}>
+          Sert à la météo de ton Co-pilote et au badge sur ta page bilan online.
+        </div>
+      </LargeField>
+      <LargeField label="Coach Herbalife depuis (optionnel)">
+        <input
+          type="date"
+          value={coachingSince}
+          max={todayStr}
+          onChange={(e) => onCoachingSinceChange(e.target.value)}
+          style={{ ...inputStyle, colorScheme: "light" }}
+        />
+        <div style={{ fontSize: 11, color: "#6B7280", marginTop: 4 }}>
+          Ta vraie date de début Herbalife (pas la date d'aujourd'hui). Affichée comme badge ancienneté sur ta page bilan online. Modifiable plus tard dans Paramètres.
+        </div>
       </LargeField>
       <LargeField label="ID Herbalife">
         <input

--- a/supabase/functions/consume-distributor-invite-token/index.ts
+++ b/supabase/functions/consume-distributor-invite-token/index.ts
@@ -59,6 +59,7 @@ serve(async (req) => {
       last_name?: string;
       phone?: string;
       city?: string;
+      coaching_since?: string | null;
       herbalife_id?: string;
       avatar_url?: string;
     };
@@ -69,6 +70,18 @@ serve(async (req) => {
     const lastName = (body.last_name ?? "").trim();
     const phone = (body.phone ?? "").trim();
     const city = (body.city ?? "").trim();
+    // Chantier #10 V2 badges (2026-05-17) : date début activité Herbalife.
+    // Optionnel. Validation : format YYYY-MM-DD, pas dans le futur.
+    let coachingSince: string | null = null;
+    if (body.coaching_since && typeof body.coaching_since === "string") {
+      const trimmed = body.coaching_since.trim();
+      if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+        const parsed = new Date(trimmed + "T00:00:00Z");
+        if (!Number.isNaN(parsed.getTime()) && parsed.getTime() <= Date.now()) {
+          coachingSince = trimmed;
+        }
+      }
+    }
     const herbalifeId = (body.herbalife_id ?? "").trim();
     const avatarUrl = body.avatar_url ? String(body.avatar_url).trim() : null;
 
@@ -164,6 +177,7 @@ serve(async (req) => {
       title: "Accès distributeur",
       phone,
       city,
+      coaching_since: coachingSince,
       herbalife_id: herbalifeId,
       avatar_url: avatarUrl,
     });


### PR DESCRIPTION
## Summary

Suite du chantier #10 V2 — demande la date de début Herbalife (`coaching_since`) au moment de l'inscription d'un nouveau distri, plus clarification de l'usage du champ ville.

- ➕ Nouveau champ "Coach Herbalife depuis (optionnel)" dans le step profil de `/bienvenue-distri` (date, max = aujourd'hui)
- 🏷️ Helper texte sous Ville : "Sert à la météo de ton Co-pilote et au badge sur ta page bilan online"
- 🏷️ Helper texte sous coaching_since : précise que c'est modifiable plus tard dans Paramètres
- 🛠️ Edge function `consume-distributor-invite-token` : accepte + valide `coaching_since` (format YYYY-MM-DD, pas dans le futur) + insère dans `public.users.coaching_since`

Ville et coaching_since restent **éditables dans Paramètres > Profil** (déjà fait dans PR #43). La ville reste **source unique** pour la météo Co-pilote V5.

## Test plan

- [x] Edge function déployée prod (`supabase functions deploy consume-distributor-invite-token`)
- [x] `npm run build` OK
- [ ] Inviter un faux distri via /users → ouvrir le lien → step profil affiche Ville + Coach depuis + ID Herbalife
- [ ] Soumettre avec date renseignée → `select coaching_since from users where id = <new>` → date posée
- [ ] Soumettre sans date → `coaching_since` null en base (pas d'erreur)
- [ ] Paramètres > Profil du nouveau distri : champ pré-rempli avec la date saisie à l'onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)