### PR TITLE
feat(prospection): V3 FULL — brief méthodo + cibler enrichi + tracking + admin + Co-pilote widget

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,6 +164,11 @@ const ProspectionPage = lazy(() =>
     default: module.ProspectionPage,
   })),
 );
+const AdminProspectionPage = lazy(() =>
+  import("./pages/AdminProspectionPage").then((module) => ({
+    default: module.AdminProspectionPage,
+  })),
+);
 const AutoLoginPage = lazy(() =>
   import("./pages/AutoLoginPage").then((module) => ({
     default: module.AutoLoginPage,
@@ -548,6 +553,8 @@ export default function App() {
               {/* Chantier #3 (2026-05-17) — Module Prospection cold mobile-first.
                   4 étapes : Marché → Profil → Hashtags → Messages multi-langues. */}
               <Route path="prospection" element={<ProspectionPage />} />
+              {/* Chantier #3 étape 3.3 — CRUD admin scripts + briefs */}
+              <Route path="admin/prospection" element={<AdminProspectionPage />} />
               {/* Rentabilité Phase A (2026-05-05) — jauge €/mois + breakdown. */}
               <Route path="rentabilite" element={<RentabilitePage />} />
               {/* La Base 360 Academy Phase 1 (2026-04-26) — gated admin only

--- a/src/components/copilote/ProspectionShortcut.tsx
+++ b/src/components/copilote/ProspectionShortcut.tsx
@@ -1,0 +1,97 @@
+// Chantier #3 étape 3.6 — Lien rapide Co-pilote "Prospecter maintenant".
+// Petit widget gold/teal qui invite à lancer une session prospection,
+// affiche les stats 7j si dispo.
+
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAppContext } from "../../context/AppContext";
+import { fetchProspectionStats, type ProspectionStats } from "../../hooks/useProspectionData";
+
+export function ProspectionShortcut() {
+  const navigate = useNavigate();
+  const { currentUser } = useAppContext();
+  const [stats, setStats] = useState<ProspectionStats | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!currentUser?.id) return;
+      const s = await fetchProspectionStats(currentUser.id);
+      if (!cancelled) setStats(s);
+    })();
+    return () => { cancelled = true; };
+  }, [currentUser?.id]);
+
+  if (!currentUser) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate("/prospection")}
+      style={{
+        width: "100%",
+        background: "linear-gradient(135deg, rgba(45,212,191,0.10) 0%, rgba(201,168,76,0.10) 100%)",
+        border: "1.5px solid rgba(201,168,76,0.35)",
+        borderRadius: 16,
+        padding: "16px 18px",
+        cursor: "pointer",
+        textAlign: "left",
+        fontFamily: "inherit",
+        color: "inherit",
+        display: "flex",
+        alignItems: "center",
+        gap: 16,
+        boxShadow: "0 4px 14px rgba(11,13,17,0.06)",
+        transition: "all 0.2s",
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.transform = "translateY(-2px)";
+        e.currentTarget.style.boxShadow = "0 8px 20px rgba(11,13,17,0.10)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = "translateY(0)";
+        e.currentTarget.style.boxShadow = "0 4px 14px rgba(11,13,17,0.06)";
+      }}
+    >
+      <span style={{
+        flexShrink: 0,
+        width: 46, height: 46, borderRadius: 12,
+        background: "linear-gradient(135deg, var(--ls-gold, #C9A84C), #E5C97D)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        fontSize: 24,
+        boxShadow: "0 4px 12px rgba(201,168,76,0.35)",
+      }} aria-hidden="true">
+        🌍
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontFamily: "'Syne', serif",
+          fontSize: 16,
+          fontWeight: 700,
+          color: "var(--ls-charcoal, var(--ls-text))",
+          marginBottom: 2,
+        }}>
+          Prospecter maintenant
+        </div>
+        <div style={{
+          fontSize: 12.5,
+          color: "var(--ls-text-muted)",
+          lineHeight: 1.45,
+        }}>
+          {stats && stats.total_7d > 0
+            ? <>📊 <strong>{stats.total_7d}</strong> envois cette semaine · <strong>{stats.conversions_7d}</strong> conversion{stats.conversions_7d > 1 ? "s" : ""}</>
+            : "Module 6 étapes : marché → profil → brief → cibler → messages → relance."}
+        </div>
+      </div>
+      <span style={{
+        flexShrink: 0,
+        fontSize: 18,
+        color: "var(--ls-gold, #C9A84C)",
+        fontFamily: "'Syne', serif",
+        fontWeight: 700,
+      }}>
+        →
+      </span>
+    </button>
+  );
+}

--- a/src/hooks/useProspectionData.ts
+++ b/src/hooks/useProspectionData.ts
@@ -19,7 +19,42 @@ export interface ProspectionProfile {
   label: string;
   description: string | null;
   hashtag_advice: string | null;
+  gopro_steps: string[];
+  posture: string | null;
+  mistakes: string[];
+  local_venues_hint: string | null;
+  recommended_platforms: string[];
   position: number;
+}
+
+export type AttemptResponseStatus =
+  | "pending"
+  | "positive"
+  | "curious"
+  | "negative"
+  | "no_response";
+
+export interface ProspectionAttempt {
+  id: string;
+  coach_id: string;
+  market_code: string;
+  profile_slug: string;
+  platform: ProspectionPlatform;
+  target_label: string | null;
+  target_handle: string | null;
+  first_message_sent_at: string;
+  response_status: AttemptResponseStatus;
+  converted_to_lead_id: string | null;
+  note: string | null;
+  created_at: string;
+}
+
+export interface ProspectionStats {
+  total_7d: number;
+  responses_7d: number;
+  positive_7d: number;
+  conversions_7d: number;
+  total_30d: number;
 }
 
 export interface ProspectionMarketTip {
@@ -102,7 +137,7 @@ export function useProspectionData() {
             .eq("active", true)
             .order("position", { ascending: true }),
           sb.from("prospection_profiles")
-            .select("slug, emoji, label, description, hashtag_advice, position")
+            .select("slug, emoji, label, description, hashtag_advice, gopro_steps, posture, mistakes, local_venues_hint, recommended_platforms, position")
             .eq("active", true)
             .order("position", { ascending: true }),
           sb.from("prospection_hashtags")
@@ -199,3 +234,67 @@ export const PLATFORM_GRADIENTS: Record<ProspectionPlatform, string> = {
   linkedin: "#0A66C2",
   sms: "#6B7280",
 };
+
+// ============================================================================
+// Attempts CRUD + stats
+// ============================================================================
+
+export async function createProspectionAttempt(input: {
+  coach_id: string;
+  market_code: string;
+  profile_slug: string;
+  platform: ProspectionPlatform;
+  target_label?: string | null;
+  target_handle?: string | null;
+}): Promise<{ id: string } | null> {
+  const sb = await getSupabaseClient();
+  if (!sb) return null;
+  const { data, error } = await sb
+    .from("prospection_attempts")
+    .insert({
+      coach_id: input.coach_id,
+      market_code: input.market_code,
+      profile_slug: input.profile_slug,
+      platform: input.platform,
+      target_label: input.target_label ?? null,
+      target_handle: input.target_handle ?? null,
+    })
+    .select("id")
+    .single();
+  if (error || !data) return null;
+  return { id: (data as { id: string }).id };
+}
+
+export async function updateAttemptResponseStatus(
+  id: string,
+  status: AttemptResponseStatus,
+): Promise<boolean> {
+  const sb = await getSupabaseClient();
+  if (!sb) return false;
+  const { error } = await sb
+    .from("prospection_attempts")
+    .update({ response_status: status, updated_at: new Date().toISOString() })
+    .eq("id", id);
+  return !error;
+}
+
+export async function fetchRecentAttempts(coachId: string, limit = 10): Promise<ProspectionAttempt[]> {
+  const sb = await getSupabaseClient();
+  if (!sb) return [];
+  const { data, error } = await sb
+    .from("prospection_attempts")
+    .select("*")
+    .eq("coach_id", coachId)
+    .order("first_message_sent_at", { ascending: false })
+    .limit(limit);
+  if (error || !data) return [];
+  return data as ProspectionAttempt[];
+}
+
+export async function fetchProspectionStats(coachId: string): Promise<ProspectionStats | null> {
+  const sb = await getSupabaseClient();
+  if (!sb) return null;
+  const { data, error } = await sb.rpc("get_prospection_stats", { p_user_id: coachId });
+  if (error || !data) return null;
+  return data as ProspectionStats;
+}

--- a/src/pages/AdminProspectionPage.tsx
+++ b/src/pages/AdminProspectionPage.tsx
@@ -1,0 +1,689 @@
+// Chantier #3 étape 3.3 — Page admin CRUD Prospection (2026-05-17).
+// Route: /admin/prospection. Admin only.
+//
+// 2 onglets :
+//   - Scripts : liste + édition body/body_fr/tip/label/kind/active + delete + add
+//   - Briefs : édition GoPro / posture / erreurs / hashtag advice / venues / platforms
+//             par profil (weight / sport / business)
+
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAppContext } from "../context/AppContext";
+import { useToast } from "../context/ToastContext";
+import { getSupabaseClient } from "../services/supabaseClient";
+import {
+  useProspectionData,
+  type ProspectionPlatform,
+  type ProspectionProfile,
+  type ProspectionScript,
+  type ProspectionScriptKind,
+} from "../hooks/useProspectionData";
+
+type Tab = "scripts" | "briefs";
+
+const PLATFORMS: ProspectionPlatform[] = ["insta", "fb", "whatsapp", "telegram", "linkedin", "sms"];
+const KINDS: ProspectionScriptKind[] = ["first_contact", "j3_followup", "referral", "direct", "pitch"];
+
+export function AdminProspectionPage() {
+  const navigate = useNavigate();
+  const { currentUser } = useAppContext();
+  const data = useProspectionData();
+  const [tab, setTab] = useState<Tab>("scripts");
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  // Si pas admin → kick out
+  useEffect(() => {
+    if (currentUser && currentUser.role !== "admin") {
+      navigate("/co-pilote", { replace: true });
+    }
+  }, [currentUser, navigate]);
+
+  if (!currentUser || currentUser.role !== "admin") return null;
+
+  return (
+    <div style={{ padding: "20px", maxWidth: 980, margin: "0 auto" }}>
+      <h1 style={{
+        fontFamily: "'Syne', serif",
+        fontSize: 26, fontWeight: 700,
+        margin: 0, marginBottom: 6,
+        color: "var(--ls-text)",
+      }}>
+        🛠 Admin Prospection
+      </h1>
+      <p style={{
+        fontSize: 13, color: "var(--ls-text-muted)",
+        margin: 0, marginBottom: 18,
+      }}>
+        Édite les scripts et les briefs méthodo du module /prospection.
+        Les modifications sont visibles immédiatement par tous les distri.
+      </p>
+
+      <div style={{
+        display: "flex", gap: 6, marginBottom: 20,
+        borderBottom: "1px solid var(--ls-border)",
+      }}>
+        <TabButton active={tab === "scripts"} onClick={() => setTab("scripts")}>
+          📝 Scripts ({data.scripts.length})
+        </TabButton>
+        <TabButton active={tab === "briefs"} onClick={() => setTab("briefs")}>
+          🧭 Briefs méthodo ({data.profiles.length})
+        </TabButton>
+      </div>
+
+      {data.loading && <p>Chargement…</p>}
+      {data.error && (
+        <p style={{ color: "var(--ls-coral)" }}>⚠️ {data.error}</p>
+      )}
+
+      {tab === "scripts" && !data.loading && (
+        <ScriptsTab
+          key={`scripts-${refreshTick}`}
+          markets={data.markets}
+          profiles={data.profiles}
+          scripts={data.scripts}
+          onChanged={() => setRefreshTick((t) => t + 1)}
+        />
+      )}
+      {tab === "briefs" && !data.loading && (
+        <BriefsTab
+          key={`briefs-${refreshTick}`}
+          profiles={data.profiles}
+          onChanged={() => setRefreshTick((t) => t + 1)}
+        />
+      )}
+    </div>
+  );
+}
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        background: active ? "var(--ls-gold)" : "transparent",
+        color: active ? "var(--ls-charcoal)" : "var(--ls-text-muted)",
+        border: "none",
+        borderBottom: active ? "3px solid var(--ls-gold)" : "3px solid transparent",
+        padding: "10px 18px",
+        fontSize: 14,
+        fontWeight: 700,
+        fontFamily: "'Syne', serif",
+        cursor: "pointer",
+        borderRadius: "8px 8px 0 0",
+        transition: "all 0.15s",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ============================================================================
+// SCRIPTS TAB
+// ============================================================================
+
+function ScriptsTab({
+  markets, profiles, scripts, onChanged,
+}: {
+  markets: { code: string; flag: string; label: string }[];
+  profiles: { slug: string; label: string }[];
+  scripts: ProspectionScript[];
+  onChanged: () => void;
+}) {
+  const [editing, setEditing] = useState<ProspectionScript | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [filterMarket, setFilterMarket] = useState<string>("all");
+  const [filterProfile, setFilterProfile] = useState<string>("all");
+
+  const filtered = useMemo(() => {
+    return scripts.filter((s) => {
+      if (filterMarket !== "all" && s.market_code !== filterMarket) return false;
+      if (filterProfile !== "all" && s.profile_slug !== filterProfile) return false;
+      return true;
+    });
+  }, [scripts, filterMarket, filterProfile]);
+
+  return (
+    <div>
+      <div style={{
+        display: "flex", gap: 10, marginBottom: 14, alignItems: "center",
+        flexWrap: "wrap",
+      }}>
+        <select
+          value={filterMarket}
+          onChange={(e) => setFilterMarket(e.target.value)}
+          style={selectStyle}
+        >
+          <option value="all">Tous marchés</option>
+          {markets.map((m) => (
+            <option key={m.code} value={m.code}>{m.flag} {m.label}</option>
+          ))}
+        </select>
+        <select
+          value={filterProfile}
+          onChange={(e) => setFilterProfile(e.target.value)}
+          style={selectStyle}
+        >
+          <option value="all">Tous profils</option>
+          {profiles.map((p) => (
+            <option key={p.slug} value={p.slug}>{p.label}</option>
+          ))}
+        </select>
+        <span style={{ flex: 1, fontSize: 12, color: "var(--ls-text-muted)" }}>
+          {filtered.length} script(s)
+        </span>
+        <button
+          type="button"
+          onClick={() => setCreating(true)}
+          style={primaryBtnStyle}
+        >
+          + Nouveau script
+        </button>
+      </div>
+
+      {filtered.length === 0 && (
+        <p style={{ color: "var(--ls-text-muted)", textAlign: "center", padding: 24 }}>
+          Aucun script pour ces filtres.
+        </p>
+      )}
+
+      <div style={{ display: "grid", gap: 8 }}>
+        {filtered.map((s) => (
+          <ScriptRow
+            key={s.id}
+            script={s}
+            marketLabel={markets.find((m) => m.code === s.market_code)?.label ?? s.market_code}
+            profileLabel={profiles.find((p) => p.slug === s.profile_slug)?.label ?? s.profile_slug}
+            onEdit={() => setEditing(s)}
+            onChanged={onChanged}
+          />
+        ))}
+      </div>
+
+      {editing && (
+        <ScriptFormModal
+          script={editing}
+          markets={markets}
+          profiles={profiles}
+          onClose={() => setEditing(null)}
+          onSaved={() => { setEditing(null); onChanged(); }}
+        />
+      )}
+      {creating && (
+        <ScriptFormModal
+          script={null}
+          markets={markets}
+          profiles={profiles}
+          onClose={() => setCreating(false)}
+          onSaved={() => { setCreating(false); onChanged(); }}
+        />
+      )}
+    </div>
+  );
+}
+
+function ScriptRow({
+  script, marketLabel, profileLabel, onEdit, onChanged,
+}: {
+  script: ProspectionScript;
+  marketLabel: string;
+  profileLabel: string;
+  onEdit: () => void;
+  onChanged: () => void;
+}) {
+  const { push: pushToast } = useToast();
+  const [busy, setBusy] = useState(false);
+
+  async function del() {
+    if (!confirm(`Supprimer ce script ?\n${script.label ?? script.platform}\n${marketLabel} · ${profileLabel}`)) return;
+    setBusy(true);
+    const sb = await getSupabaseClient();
+    if (!sb) { setBusy(false); return; }
+    const { error } = await sb
+      .from("prospection_scripts")
+      .delete()
+      .eq("id", script.id);
+    setBusy(false);
+    if (error) pushToast({ tone: "warning", title: "Échec", message: error.message });
+    else { pushToast({ tone: "success", title: "Script supprimé" }); onChanged(); }
+  }
+
+  return (
+    <div style={{
+      background: "var(--ls-surface)",
+      border: "1px solid var(--ls-border)",
+      borderRadius: 10,
+      padding: "12px 14px",
+      display: "flex", gap: 12, alignItems: "center",
+    }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontSize: 13, fontWeight: 700,
+          color: "var(--ls-text)",
+          marginBottom: 4,
+          display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center",
+        }}>
+          <span style={{ fontFamily: "'Syne', serif" }}>{script.label || script.platform}</span>
+          <KindPill kind={script.kind} />
+          <span style={{ fontSize: 11, color: "var(--ls-text-muted)" }}>
+            {marketLabel} · {profileLabel}
+          </span>
+        </div>
+        <div style={{
+          fontSize: 12, color: "var(--ls-text-muted)",
+          whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+          maxWidth: "100%",
+        }}>
+          {script.body.slice(0, 100)}…
+        </div>
+      </div>
+      <button type="button" onClick={onEdit} style={iconBtnStyle} title="Éditer">✏️</button>
+      <button type="button" onClick={del} disabled={busy} style={iconBtnStyle} title="Supprimer">🗑</button>
+    </div>
+  );
+}
+
+function KindPill({ kind }: { kind: ProspectionScriptKind }) {
+  const colors: Record<ProspectionScriptKind, { bg: string; color: string; label: string }> = {
+    first_contact: { bg: "var(--ls-surface2)", color: "var(--ls-text-muted)", label: "1er contact" },
+    j3_followup:   { bg: "#FEF3C7", color: "#92400E", label: "Relance J+3" },
+    referral:      { bg: "rgba(45,212,191,0.15)", color: "#0F766E", label: "Après reco" },
+    pitch:         { bg: "rgba(139,92,246,0.15)", color: "#6D28D9", label: "Pitch" },
+    direct:        { bg: "rgba(45,212,191,0.10)", color: "#0F766E", label: "Direct" },
+  };
+  const c = colors[kind];
+  return (
+    <span style={{
+      fontSize: 10, fontWeight: 700,
+      padding: "2px 7px", borderRadius: 999,
+      background: c.bg, color: c.color,
+      letterSpacing: "0.03em",
+      textTransform: "uppercase",
+    }}>
+      {c.label}
+    </span>
+  );
+}
+
+function ScriptFormModal({
+  script, markets, profiles, onClose, onSaved,
+}: {
+  script: ProspectionScript | null;
+  markets: { code: string; flag: string; label: string }[];
+  profiles: { slug: string; label: string }[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const { push: pushToast } = useToast();
+  const [marketCode, setMarketCode] = useState(script?.market_code ?? markets[0]?.code ?? "fr");
+  const [profileSlug, setProfileSlug] = useState(script?.profile_slug ?? profiles[0]?.slug ?? "weight");
+  const [platform, setPlatform] = useState<ProspectionPlatform>(script?.platform ?? "insta");
+  const [kind, setKind] = useState<ProspectionScriptKind>(script?.kind ?? "first_contact");
+  const [label, setLabel] = useState(script?.label ?? "");
+  const [languageLabel, setLanguageLabel] = useState(script?.language_label ?? "");
+  const [body, setBody] = useState(script?.body ?? "");
+  const [bodyFr, setBodyFr] = useState(script?.body_fr ?? "");
+  const [tip, setTip] = useState(script?.tip ?? "");
+  const [position, setPosition] = useState<number>(script?.position ?? 1);
+  const [busy, setBusy] = useState(false);
+
+  async function save() {
+    if (body.trim().length < 10) {
+      pushToast({ tone: "warning", title: "Body trop court (≥ 10 chars)" });
+      return;
+    }
+    setBusy(true);
+    const sb = await getSupabaseClient();
+    if (!sb) { setBusy(false); return; }
+    const payload = {
+      market_code: marketCode,
+      profile_slug: profileSlug,
+      platform,
+      kind,
+      label: label.trim() || null,
+      language_label: languageLabel.trim() || null,
+      body: body.trim(),
+      body_fr: bodyFr.trim() || null,
+      tip: tip.trim() || null,
+      position,
+      active: true,
+    };
+    const { error } = script
+      ? await sb.from("prospection_scripts").update(payload).eq("id", script.id)
+      : await sb.from("prospection_scripts").insert(payload);
+    setBusy(false);
+    if (error) {
+      pushToast({ tone: "warning", title: "Échec", message: error.message });
+      return;
+    }
+    pushToast({ tone: "success", title: script ? "Script mis à jour" : "Script créé" });
+    onSaved();
+  }
+
+  return (
+    <ModalShell onClose={onClose} title={script ? "Éditer le script" : "Nouveau script"}>
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+          <LabelField label="Marché">
+            <select value={marketCode} onChange={(e) => setMarketCode(e.target.value)} style={inputStyle}>
+              {markets.map((m) => <option key={m.code} value={m.code}>{m.flag} {m.label}</option>)}
+            </select>
+          </LabelField>
+          <LabelField label="Profil">
+            <select value={profileSlug} onChange={(e) => setProfileSlug(e.target.value)} style={inputStyle}>
+              {profiles.map((p) => <option key={p.slug} value={p.slug}>{p.label}</option>)}
+            </select>
+          </LabelField>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 80px", gap: 10 }}>
+          <LabelField label="Plateforme">
+            <select value={platform} onChange={(e) => setPlatform(e.target.value as ProspectionPlatform)} style={inputStyle}>
+              {PLATFORMS.map((p) => <option key={p} value={p}>{p}</option>)}
+            </select>
+          </LabelField>
+          <LabelField label="Type">
+            <select value={kind} onChange={(e) => setKind(e.target.value as ProspectionScriptKind)} style={inputStyle}>
+              {KINDS.map((k) => <option key={k} value={k}>{k}</option>)}
+            </select>
+          </LabelField>
+          <LabelField label="Pos.">
+            <input type="number" min={1} value={position} onChange={(e) => setPosition(Number(e.target.value))} style={inputStyle} />
+          </LabelField>
+        </div>
+        <LabelField label='Label (ex: "Instagram DM · Premier contact")'>
+          <input value={label} onChange={(e) => setLabel(e.target.value)} style={inputStyle} />
+        </LabelField>
+        <LabelField label='Langue (ex: "🇫🇷 Français")'>
+          <input value={languageLabel} onChange={(e) => setLanguageLabel(e.target.value)} style={inputStyle} />
+        </LabelField>
+        <LabelField label="Body (le message dans la langue cible)">
+          <textarea value={body} onChange={(e) => setBody(e.target.value)} rows={6} style={{ ...inputStyle, fontFamily: "inherit", resize: "vertical" }} />
+        </LabelField>
+        <LabelField label="Body_fr (traduction française, optionnel pour scripts FR)">
+          <textarea value={bodyFr} onChange={(e) => setBodyFr(e.target.value)} rows={5} style={{ ...inputStyle, fontFamily: "inherit", resize: "vertical" }} />
+        </LabelField>
+        <LabelField label="Tip métier (court, italique sous le body)">
+          <input value={tip} onChange={(e) => setTip(e.target.value)} style={inputStyle} />
+        </LabelField>
+      </div>
+      <div style={{ display: "flex", gap: 10, marginTop: 16, justifyContent: "flex-end" }}>
+        <button type="button" onClick={onClose} style={secondaryBtnStyle}>Annuler</button>
+        <button type="button" onClick={save} disabled={busy} style={primaryBtnStyle}>
+          {busy ? "Enregistrement…" : "Enregistrer"}
+        </button>
+      </div>
+    </ModalShell>
+  );
+}
+
+// ============================================================================
+// BRIEFS TAB
+// ============================================================================
+
+function BriefsTab({
+  profiles, onChanged,
+}: {
+  profiles: ProspectionProfile[];
+  onChanged: () => void;
+}) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      {profiles.map((p) => (
+        <BriefEditor key={p.slug} profile={p} onChanged={onChanged} />
+      ))}
+    </div>
+  );
+}
+
+function BriefEditor({
+  profile, onChanged,
+}: { profile: ProspectionProfile; onChanged: () => void }) {
+  const { push: pushToast } = useToast();
+  const [goproSteps, setGoproSteps] = useState<string[]>(profile.gopro_steps.length === 3 ? profile.gopro_steps : ["", "", ""]);
+  const [posture, setPosture] = useState(profile.posture ?? "");
+  const [mistakes, setMistakes] = useState<string[]>(profile.mistakes.length === 3 ? profile.mistakes : ["", "", ""]);
+  const [hashtagAdvice, setHashtagAdvice] = useState(profile.hashtag_advice ?? "");
+  const [localVenuesHint, setLocalVenuesHint] = useState(profile.local_venues_hint ?? "");
+  const [recommendedPlatforms, setRecommendedPlatforms] = useState<string[]>(profile.recommended_platforms);
+  const [busy, setBusy] = useState(false);
+
+  async function save() {
+    setBusy(true);
+    const sb = await getSupabaseClient();
+    if (!sb) { setBusy(false); return; }
+    const { error } = await sb
+      .from("prospection_profiles")
+      .update({
+        gopro_steps: goproSteps,
+        posture: posture.trim() || null,
+        mistakes: mistakes,
+        hashtag_advice: hashtagAdvice.trim() || null,
+        local_venues_hint: localVenuesHint.trim() || null,
+        recommended_platforms: recommendedPlatforms,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("slug", profile.slug);
+    setBusy(false);
+    if (error) pushToast({ tone: "warning", title: "Échec", message: error.message });
+    else { pushToast({ tone: "success", title: `Brief ${profile.label} mis à jour` }); onChanged(); }
+  }
+
+  function togglePlatform(p: ProspectionPlatform) {
+    setRecommendedPlatforms((curr) =>
+      curr.includes(p) ? curr.filter((x) => x !== p) : [...curr, p],
+    );
+  }
+
+  return (
+    <details style={{
+      background: "var(--ls-surface)",
+      border: "1px solid var(--ls-border)",
+      borderRadius: 12,
+      padding: "14px 16px",
+    }} open>
+      <summary style={{
+        cursor: "pointer", fontFamily: "'Syne', serif",
+        fontSize: 18, fontWeight: 700,
+        color: "var(--ls-text)",
+        marginBottom: 12,
+      }}>
+        {profile.emoji} {profile.label}
+      </summary>
+
+      <div style={{ display: "grid", gap: 12, marginTop: 12 }}>
+        <LabelField label="GoPro — 3 points (1 ligne par point)">
+          {[0, 1, 2].map((i) => (
+            <input
+              key={i}
+              value={goproSteps[i] ?? ""}
+              onChange={(e) => {
+                const next = [...goproSteps];
+                next[i] = e.target.value;
+                setGoproSteps(next);
+              }}
+              placeholder={`Point ${i + 1}`}
+              style={{ ...inputStyle, marginBottom: 6 }}
+            />
+          ))}
+        </LabelField>
+
+        <LabelField label="Posture (un paragraphe)">
+          <textarea
+            value={posture}
+            onChange={(e) => setPosture(e.target.value)}
+            rows={4}
+            style={{ ...inputStyle, fontFamily: "inherit", resize: "vertical" }}
+          />
+        </LabelField>
+
+        <LabelField label="3 erreurs à éviter">
+          {[0, 1, 2].map((i) => (
+            <input
+              key={i}
+              value={mistakes[i] ?? ""}
+              onChange={(e) => {
+                const next = [...mistakes];
+                next[i] = e.target.value;
+                setMistakes(next);
+              }}
+              placeholder={`Erreur ${i + 1}`}
+              style={{ ...inputStyle, marginBottom: 6 }}
+            />
+          ))}
+        </LabelField>
+
+        <LabelField label="Astuce hashtags (affichée étape 4)">
+          <textarea
+            value={hashtagAdvice}
+            onChange={(e) => setHashtagAdvice(e.target.value)}
+            rows={2}
+            style={{ ...inputStyle, fontFamily: "inherit", resize: "vertical" }}
+          />
+        </LabelField>
+
+        <LabelField label="Lieux IRL où croiser ce profil (affiché étape 4)">
+          <textarea
+            value={localVenuesHint}
+            onChange={(e) => setLocalVenuesHint(e.target.value)}
+            rows={3}
+            style={{ ...inputStyle, fontFamily: "inherit", resize: "vertical" }}
+          />
+        </LabelField>
+
+        <LabelField label="Plateformes recommandées">
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            {PLATFORMS.map((p) => (
+              <button
+                key={p}
+                type="button"
+                onClick={() => togglePlatform(p)}
+                style={{
+                  background: recommendedPlatforms.includes(p) ? "var(--ls-gold)" : "var(--ls-surface2)",
+                  color: recommendedPlatforms.includes(p) ? "var(--ls-charcoal)" : "var(--ls-text-muted)",
+                  border: "1px solid var(--ls-border)",
+                  padding: "6px 12px",
+                  borderRadius: 999,
+                  fontSize: 12, fontWeight: 700,
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                }}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+        </LabelField>
+
+        <div style={{ display: "flex", justifyContent: "flex-end" }}>
+          <button type="button" onClick={save} disabled={busy} style={primaryBtnStyle}>
+            {busy ? "Enregistrement…" : `💾 Enregistrer ${profile.label}`}
+          </button>
+        </div>
+      </div>
+    </details>
+  );
+}
+
+// ============================================================================
+// Shared UI helpers
+// ============================================================================
+
+function LabelField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label style={{ display: "block" }}>
+      <div style={{
+        fontSize: 11, fontWeight: 700,
+        color: "var(--ls-text-muted)",
+        textTransform: "uppercase", letterSpacing: 1.2,
+        marginBottom: 6,
+        fontFamily: "'DM Sans', sans-serif",
+      }}>
+        {label}
+      </div>
+      {children}
+    </label>
+  );
+}
+
+function ModalShell({ title, onClose, children }: { title: string; onClose: () => void; children: ReactNode }) {
+  return (
+    <div style={{
+      position: "fixed", inset: 0, zIndex: 1000,
+      background: "rgba(11,13,17,0.55)",
+      display: "flex", alignItems: "flex-start", justifyContent: "center",
+      padding: "5vh 12px 24px",
+      overflowY: "auto",
+    }}>
+      <div style={{
+        background: "var(--ls-surface)",
+        borderRadius: 16,
+        width: "100%", maxWidth: 700,
+        boxShadow: "0 24px 60px rgba(11,13,17,0.4)",
+        padding: 22,
+      }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
+          <h2 style={{ fontFamily: "'Syne', serif", fontSize: 20, fontWeight: 700, margin: 0 }}>{title}</h2>
+          <button type="button" onClick={onClose} style={iconBtnStyle}>✕</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  borderRadius: 8,
+  border: "1px solid var(--ls-border)",
+  background: "var(--ls-surface2)",
+  color: "var(--ls-text)",
+  fontSize: 13,
+  outline: "none",
+  boxSizing: "border-box",
+};
+
+const selectStyle: React.CSSProperties = {
+  ...inputStyle,
+  padding: "8px 10px",
+  width: "auto",
+};
+
+const primaryBtnStyle: React.CSSProperties = {
+  background: "linear-gradient(135deg, var(--ls-gold), #E5C97D)",
+  color: "var(--ls-charcoal)",
+  border: "none",
+  padding: "10px 16px",
+  borderRadius: 10,
+  fontSize: 13,
+  fontWeight: 700,
+  fontFamily: "'Syne', serif",
+  cursor: "pointer",
+  boxShadow: "0 4px 12px rgba(201,168,76,0.30)",
+};
+
+const secondaryBtnStyle: React.CSSProperties = {
+  background: "var(--ls-surface2)",
+  color: "var(--ls-text-muted)",
+  border: "1px solid var(--ls-border)",
+  padding: "10px 16px",
+  borderRadius: 10,
+  fontSize: 13,
+  fontWeight: 700,
+  fontFamily: "'Syne', serif",
+  cursor: "pointer",
+};
+
+const iconBtnStyle: React.CSSProperties = {
+  background: "var(--ls-surface2)",
+  color: "var(--ls-text)",
+  border: "1px solid var(--ls-border)",
+  width: 34, height: 34,
+  borderRadius: 8,
+  fontSize: 14,
+  cursor: "pointer",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+};

--- a/src/pages/CoPilotePage.tsx
+++ b/src/pages/CoPilotePage.tsx
@@ -24,6 +24,7 @@ import { PendingFollowupsCard } from "../components/copilote/PendingFollowupsCar
 import { PvGaugeBand } from "../components/copilote/PvGaugeBand";
 import { PvActionPlanAlert } from "../components/copilote/PvActionPlanAlert";
 import { InboxWidget } from "../components/copilote/InboxWidget";
+import { ProspectionShortcut } from "../components/copilote/ProspectionShortcut";
 import { BirthdayBlock } from "../components/copilote/BirthdayBlock";
 import { BusinessOpportunitiesCard } from "../components/copilote/BusinessOpportunitiesCard";
 import { DistriOnboardingChecklist } from "../components/formation/DistriOnboardingChecklist";
@@ -130,6 +131,10 @@ export function CoPilotePage() {
       {/* Widget messages (chantier 5) — conservé car complémentaire : Hero
           et Duo montrent RDV/suivis, l'Inbox montre les demandes clients. */}
       <InboxWidget />
+
+      {/* Chantier #3 étape 3.6 (2026-05-17) : lien rapide vers le module
+          Prospection cold mobile-first. Affiche les stats 7j si dispo. */}
+      <ProspectionShortcut />
 
       {/* Zone 3 — Duo Agenda / Suivis */}
       <div

--- a/src/pages/DeveloppementHubPage.tsx
+++ b/src/pages/DeveloppementHubPage.tsx
@@ -123,11 +123,22 @@ const CARDS: HubCard[] = [
     emoji: "🌍",
     title: "Prospection internationale",
     description:
-      "Module mobile-first : choisis ton marché (FR/EN/ES/PT/TR/HI) + profil cible + plateforme. Scripts pré-rédigés à copier-coller avec traduction FR pour les langues étrangères. Hashtags optimisés inclus.",
+      "Module mobile-first 6 étapes : marché → profil → brief méthodo (GoPro + posture + erreurs) → cibler (hashtags + lieux IRL) → messages (scripts + traduction FR) → suivi & relances (arborescence J+3/J+7 + stats coach).",
     cta: "Lancer une session",
     path: "/prospection",
     accent: "var(--ls-teal)",
     tag: { label: "Nouveau", color: "var(--ls-coral)" },
+  },
+  {
+    id: "admin-prospection",
+    emoji: "🛠",
+    title: "Admin Prospection",
+    description:
+      "Édite les scripts et les briefs méthodo du module /prospection. Modifs visibles immédiatement par tous les distri.",
+    cta: "Ouvrir l'admin",
+    path: "/admin/prospection",
+    accent: "var(--ls-purple)",
+    requireRole: "admin",
   },
   {
     id: "bilan-online",

--- a/src/pages/ProspectionPage.tsx
+++ b/src/pages/ProspectionPage.tsx
@@ -1,34 +1,40 @@
-// Chantier #3 V2 — Module Prospection cold mobile-first (2026-05-17, polish complet).
+// Chantier #3 V3 — Module Prospection cold mobile-first FULL (2026-05-17 nuit).
 // Route: /prospection (authentifiée).
 //
-// Aligné pixel-near sur le mockup `docs/mockups/prospection-internationale.html`
-// (validé Thomas) avec TOUT le contenu :
+// Aligné sur le brainstorm Égypte complet :
 //   1. Marché (6 cards drapeau pays)
-//   2. Profil cible (3 cards + astuce hashtags par profil)
-//   3. Hashtags (chips copiables + astuce méthode)
-//   4. Messages :
-//      - Banner timing + cultural tip du marché (peach gradient)
-//      - Cards script avec label détaillé + langue + badge "Relance J+3"
-//      - Toggle "Voir FR" sur scripts non-FR
-//      - Arborescence relance (3 cards : ✅ positif / ⏳ J+3 / ❌ J+7)
-//      - Box bilan link
+//   2. Profil cible (3 cards)
+//   3. Brief méthodo (GoPro 3 points + posture + 3 erreurs à éviter)  ← NEW V3
+//   4. Cibler (hashtags + lieux IRL + plateformes recommandées)        ← enrichi V3
+//   5. Premier contact (scripts par plateforme + bouton "Marquer envoyé" → tracking)
+//   6. Suivi & relances (arborescence J+3/J+7 + stats coach + bouton bilan link)
 //
-// Animations CSS pures, palette gold/teal vive, ombres marquées.
+// Tracking via table `prospection_attempts` : chaque clic "Marquer envoyé"
+// crée une row. Stats agrégées par RPC `get_prospection_stats(user_id)`.
+//
+// Aligné pixel-near sur le mockup `docs/mockups/prospection-internationale.html`
+// (validé Thomas).
 
 import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAppContext } from "../context/AppContext";
 import {
+  createProspectionAttempt,
+  fetchProspectionStats,
   filterHashtags,
   filterScripts,
   PLATFORM_GRADIENTS,
   PLATFORM_ICONS,
   PLATFORM_LABELS,
   useProspectionData,
+  type ProspectionPlatform,
   type ProspectionScript,
+  type ProspectionStats,
 } from "../hooks/useProspectionData";
 
-type Step = 1 | 2 | 3 | 4;
+type Step = 1 | 2 | 3 | 4 | 5 | 6;
+
+const TOTAL_STEPS: Step = 6;
 
 export function ProspectionPage() {
   const navigate = useNavigate();
@@ -38,6 +44,7 @@ export function ProspectionPage() {
   const [step, setStep] = useState<Step>(1);
   const [marketCode, setMarketCode] = useState<string | null>(null);
   const [profileSlug, setProfileSlug] = useState<string | null>(null);
+  const [stats, setStats] = useState<ProspectionStats | null>(null);
 
   const market = useMemo(
     () => data.markets.find((m) => m.code === marketCode) ?? null,
@@ -72,12 +79,33 @@ export function ProspectionPage() {
     ? `${window.location.origin}/bilan-online/${coachSlug}`
     : `${window.location.origin}/bilan-online`;
 
-  // Scroll to top on step change for natural progression.
+  // Charge les stats coach au mount + après chaque "marquer envoyé".
+  const reloadStats = useMemo(
+    () => async () => {
+      if (!currentUser?.id) return;
+      const s = await fetchProspectionStats(currentUser.id);
+      if (s) setStats(s);
+    },
+    [currentUser?.id],
+  );
+  useEffect(() => { void reloadStats(); }, [reloadStats]);
+
   useEffect(() => {
     if (step > 1) {
       window.scrollTo({ top: 0, behavior: "smooth" });
     }
   }, [step]);
+
+  async function handleMarkSent(script: ProspectionScript) {
+    if (!currentUser?.id || !marketCode || !profileSlug) return;
+    await createProspectionAttempt({
+      coach_id: currentUser.id,
+      market_code: marketCode,
+      profile_slug: profileSlug,
+      platform: script.platform,
+    });
+    void reloadStats();
+  }
 
   if (data.loading) {
     return <PageShell><Skeleton /></PageShell>;
@@ -90,15 +118,18 @@ export function ProspectionPage() {
     <PageShell>
       <style>{KEYFRAMES}</style>
       <Header />
+
+      {stats && <StatsBanner stats={stats} />}
+
       <Stepper step={step} />
 
       {step === 1 && (
         <Section
-          tag="Étape 1 sur 4"
+          tag={`Étape 1 sur ${TOTAL_STEPS}`}
           title="Quel marché tu cibles ? 🌍"
           subtitle="Chaque marché a sa langue, son réseau social dominant, son timing optimal."
         >
-          <div style={gridStyle(3, 480)}>
+          <div style={gridStyle(3)}>
             {data.markets.map((m) => (
               <ChoiceCard
                 key={m.code}
@@ -121,11 +152,11 @@ export function ProspectionPage() {
 
       {step === 2 && (
         <Section
-          tag="Étape 2 sur 4"
+          tag={`Étape 2 sur ${TOTAL_STEPS}`}
           title="Quel profil tu vises ? 🎯"
-          subtitle="3 profils prioritaires La Base 360. À élargir à terme (admin pourra ajouter prof, chômeur, etc.)."
+          subtitle="3 profils prioritaires La Base 360. Admin pourra ajouter d'autres profils."
         >
-          <div style={gridStyle(3, 360)}>
+          <div style={gridStyle(3)}>
             {data.profiles.map((p) => (
               <ChoiceCard
                 key={p.slug}
@@ -149,10 +180,31 @@ export function ProspectionPage() {
 
       {step === 3 && profile && (
         <Section
-          tag="Étape 3 sur 4"
-          title="Cible avec les bons hashtags 🔍"
-          subtitle={`Recherche ces hashtags sur Instagram / Facebook / TikTok. Tap pour copier.`}
+          tag={`Étape 3 sur ${TOTAL_STEPS}`}
+          title={`Comment aborder : ${profile.label.toLowerCase()} 🧭`}
+          subtitle="Méthode GoPro résumée, posture à adopter, erreurs à éviter. Lis ça avant de copier-coller — c'est ce qui fait la différence."
         >
+          <BriefMethodSection
+            goproSteps={profile.gopro_steps}
+            posture={profile.posture}
+            mistakes={profile.mistakes}
+          />
+          <NavRow
+            onBack={() => setStep(2)}
+            onNext={() => setStep(4)}
+            nextLabel="J'ai compris, on cible →"
+          />
+        </Section>
+      )}
+
+      {step === 4 && profile && market && (
+        <Section
+          tag={`Étape 4 sur ${TOTAL_STEPS}`}
+          title="Trouve les bonnes cibles 🔍"
+          subtitle="Hashtags + lieux IRL + plateformes prioritaires pour ce profil sur ce marché."
+        >
+          {/* Hashtags */}
+          <SubsectionTitle icon="#️⃣" title="Hashtags à utiliser" />
           {hashtags.length === 0 ? (
             <EmptyState>Aucun hashtag pour cette combinaison.</EmptyState>
           ) : (
@@ -162,26 +214,55 @@ export function ProspectionPage() {
               ))}
             </div>
           )}
-
           {profile.hashtag_advice && (
             <TipBanner emoji="💡" title="Astuce méthode">
               {profile.hashtag_advice}
             </TipBanner>
           )}
 
+          {/* Plateformes recommandées */}
+          {profile.recommended_platforms.length > 0 && (
+            <>
+              <SubsectionTitle icon="📱" title="Plateformes recommandées" mt={28} />
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+                {profile.recommended_platforms.map((p) => (
+                  <PlatformBadgeChip key={p} platform={p as ProspectionPlatform} />
+                ))}
+              </div>
+            </>
+          )}
+
+          {/* Lieux IRL */}
+          {profile.local_venues_hint && (
+            <>
+              <SubsectionTitle icon="📍" title="Où croiser ce profil" mt={28} />
+              <div style={{
+                background: "linear-gradient(135deg, rgba(45,212,191,0.10), rgba(45,212,191,0.04))",
+                border: "1px solid rgba(45,212,191,0.25)",
+                borderRadius: 12,
+                padding: "14px 16px",
+                fontSize: 13.5,
+                lineHeight: 1.65,
+                color: "var(--ls-text, #1F2937)",
+              }}>
+                {profile.local_venues_hint}
+              </div>
+            </>
+          )}
+
           <NavRow
-            onBack={() => setStep(2)}
-            onNext={() => setStep(4)}
-            nextLabel="Voir mes messages →"
+            onBack={() => setStep(3)}
+            onNext={() => setStep(5)}
+            nextLabel="J'ai mes cibles, voir les messages →"
           />
         </Section>
       )}
 
-      {step === 4 && market && profile && (
+      {step === 5 && market && profile && (
         <Section
-          tag="Étape 4 sur 4"
+          tag={`Étape 5 sur ${TOTAL_STEPS}`}
           title="Tes messages prêts à copier 📨"
-          subtitle="Personnalise le [prénom] et un [détail vu sur son profil]. Authentique > Parfait."
+          subtitle="Personnalise [prénom] + [détail vu sur son profil]. Authentique > Parfait."
         >
           {marketTip && (
             <MarketTimingBanner
@@ -196,7 +277,7 @@ export function ProspectionPage() {
           {scripts.length === 0 ? (
             <EmptyState>
               🌱 <strong>Messages bientôt disponibles</strong> pour ce combo ({market.label} · {profile.label}).<br />
-              <span style={{ fontSize: 12 }}>Thomas peut en rédiger depuis Supabase.</span>
+              <span style={{ fontSize: 12 }}>Tu peux en ajouter depuis la page admin si tu es admin.</span>
             </EmptyState>
           ) : (
             <div>
@@ -205,17 +286,55 @@ export function ProspectionPage() {
                   key={s.id}
                   script={s}
                   marketCode={marketCode ?? ""}
+                  onMarkSent={() => handleMarkSent(s)}
                 />
               ))}
             </div>
           )}
 
+          <NavRow
+            onBack={() => setStep(4)}
+            onNext={() => setStep(6)}
+            nextLabel="Voir le suivi des relances →"
+          />
+        </Section>
+      )}
+
+      {step === 6 && (
+        <Section
+          tag={`Étape 6 sur ${TOTAL_STEPS}`}
+          title="Suivi & arborescence de relance 📅"
+          subtitle="Que faire après chaque envoi, selon la réponse. Et tes stats de la semaine."
+        >
           <RelanceTree bilanLink={bilanLink} />
 
           <BilanLinkBox link={bilanLink} />
 
+          {stats && (
+            <div style={{ marginTop: 28 }}>
+              <h2 style={{
+                fontFamily: "'Syne', serif",
+                fontSize: 20,
+                fontWeight: 700,
+                margin: 0,
+                marginBottom: 8,
+                color: "var(--ls-charcoal, #0B0D11)",
+              }}>
+                📊 Tes 30 derniers jours
+              </h2>
+              <p style={{
+                fontSize: 13,
+                color: "var(--ls-text-muted, #4B5563)",
+                margin: 0, marginBottom: 14,
+              }}>
+                Données privées (visibles uniquement par toi).
+              </p>
+              <StatsGrid stats={stats} />
+            </div>
+          )}
+
           <NavRow
-            onBack={() => setStep(3)}
+            onBack={() => setStep(5)}
             onNext={() => {
               setMarketCode(null);
               setProfileSlug(null);
@@ -232,7 +351,7 @@ export function ProspectionPage() {
 }
 
 // ============================================================================
-// Shell + Header + Stepper
+// Shell + Header + Stepper + Stats banner
 // ============================================================================
 
 const KEYFRAMES = `
@@ -240,16 +359,12 @@ const KEYFRAMES = `
     from { opacity: 0; transform: translateY(8px); }
     to { opacity: 1; transform: translateY(0); }
   }
-  @keyframes ls-prospec-glow {
-    0%, 100% { box-shadow: 0 0 0 0 rgba(201,168,76,0.35); }
-    50% { box-shadow: 0 0 0 8px rgba(201,168,76,0); }
-  }
   @keyframes ls-prospec-shimmer {
     0% { background-position: -200% 0; }
     100% { background-position: 200% 0; }
   }
   @media (prefers-reduced-motion: reduce) {
-    .ls-prospec-fade, .ls-prospec-glow, .ls-prospec-shimmer { animation: none !important; }
+    .ls-prospec-fade, .ls-prospec-shimmer { animation: none !important; }
   }
 `;
 
@@ -326,20 +441,48 @@ function Header() {
   );
 }
 
+function StatsBanner({ stats }: { stats: ProspectionStats }) {
+  if (stats.total_7d === 0 && stats.total_30d === 0) return null;
+  return (
+    <div style={{
+      padding: "10px 20px",
+      background: "linear-gradient(90deg, rgba(45,212,191,0.10), rgba(201,168,76,0.06))",
+      borderBottom: "1px solid var(--ls-border, rgba(11,13,17,0.10))",
+      display: "flex", alignItems: "center", justifyContent: "center",
+      gap: 18,
+      fontSize: 12,
+      fontFamily: "'DM Sans', sans-serif",
+      flexWrap: "wrap",
+    }}>
+      <span style={{ color: "var(--ls-text-muted, #4B5563)" }}>
+        📊 <strong style={{ color: "var(--ls-charcoal, #0B0D11)" }}>{stats.total_7d}</strong> envois 7j
+      </span>
+      <span style={{ color: "var(--ls-text-muted, #4B5563)" }}>
+        💬 <strong style={{ color: "var(--ls-charcoal, #0B0D11)" }}>{stats.responses_7d}</strong> réponses
+      </span>
+      <span style={{ color: "var(--ls-text-muted, #4B5563)" }}>
+        🎯 <strong style={{ color: "var(--ls-charcoal, #0B0D11)" }}>{stats.conversions_7d}</strong> leads
+      </span>
+    </div>
+  );
+}
+
 function Stepper({ step }: { step: Step }) {
+  const stepsArray: Step[] = [1, 2, 3, 4, 5, 6];
   return (
     <div style={{
       display: "flex", justifyContent: "center", alignItems: "center", gap: 0,
-      padding: "16px 20px",
+      padding: "14px 12px",
       background: "var(--ls-surface, white)",
       borderBottom: "1px solid var(--ls-border, rgba(11,13,17,0.10))",
       position: "sticky", top: 0, zIndex: 10,
       boxShadow: "0 2px 12px rgba(11,13,17,0.04)",
+      flexWrap: "wrap",
     }}>
-      {([1, 2, 3, 4] as Step[]).map((n, i) => (
+      {stepsArray.map((n, i) => (
         <span key={n} style={{ display: "inline-flex", alignItems: "center" }}>
           <span style={{
-            width: 30, height: 30, borderRadius: "50%",
+            width: 28, height: 28, borderRadius: "50%",
             display: "inline-flex", alignItems: "center", justifyContent: "center",
             fontSize: 12, fontWeight: 700,
             transition: "all 0.25s cubic-bezier(0.34, 1.56, 0.64, 1)",
@@ -365,9 +508,9 @@ function Stepper({ step }: { step: Step }) {
           }}>
             {n < step ? "✓" : n}
           </span>
-          {i < 3 && (
+          {i < stepsArray.length - 1 && (
             <span style={{
-              width: 36, height: 3,
+              width: 18, height: 3,
               borderRadius: 2,
               background: n < step
                 ? "linear-gradient(90deg, var(--ls-teal, #2DD4BF), var(--ls-border, rgba(11,13,17,0.10)))"
@@ -428,8 +571,25 @@ function Section({
   );
 }
 
+function SubsectionTitle({ icon, title, mt = 0 }: { icon: string; title: string; mt?: number }) {
+  return (
+    <div style={{
+      fontFamily: "'Syne', serif",
+      fontSize: 14, fontWeight: 700,
+      color: "var(--ls-charcoal, #0B0D11)",
+      letterSpacing: "0.02em",
+      marginTop: mt,
+      marginBottom: 10,
+      display: "flex", alignItems: "center", gap: 8,
+    }}>
+      <span style={{ fontSize: 16 }} aria-hidden="true">{icon}</span>
+      {title}
+    </div>
+  );
+}
+
 // ============================================================================
-// Choice cards (marché + profil)
+// Choice cards (étapes 1 et 2)
 // ============================================================================
 
 function ChoiceCard({
@@ -477,7 +637,7 @@ function ChoiceCard({
   );
 }
 
-const gridStyle = (cols: 2 | 3, _maxWidth: number): CSSProperties => ({
+const gridStyle = (cols: 2 | 3): CSSProperties => ({
   display: "grid",
   gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
   gap: 10,
@@ -503,7 +663,108 @@ const subStyle: CSSProperties = {
 };
 
 // ============================================================================
-// Hashtags
+// Étape 3 — Brief méthodo (GoPro + Posture + Erreurs)
+// ============================================================================
+
+function BriefMethodSection({
+  goproSteps, posture, mistakes,
+}: { goproSteps: string[]; posture: string | null; mistakes: string[] }) {
+  return (
+    <div>
+      {/* GoPro 3 points */}
+      {goproSteps.length > 0 && (
+        <div style={{ marginBottom: 24 }}>
+          <SubsectionTitle icon="🎯" title="Méthode GoPro — 3 points" />
+          <div style={{ display: "grid", gap: 10 }}>
+            {goproSteps.map((s, i) => (
+              <div key={i} style={{
+                display: "flex", gap: 14,
+                padding: "14px 16px",
+                background: "var(--ls-surface, white)",
+                border: "1px solid var(--ls-border, rgba(11,13,17,0.10))",
+                borderRadius: 12,
+                boxShadow: "0 2px 8px rgba(11,13,17,0.04)",
+              }}>
+                <span style={{
+                  flexShrink: 0,
+                  width: 36, height: 36, borderRadius: "50%",
+                  background: "linear-gradient(135deg, var(--ls-gold, #C9A84C), #E5C97D)",
+                  color: "var(--ls-charcoal, #0B0D11)",
+                  fontFamily: "'Syne', serif",
+                  fontWeight: 700, fontSize: 16,
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  boxShadow: "0 4px 10px rgba(201,168,76,0.30)",
+                }}>
+                  {i + 1}
+                </span>
+                <div style={{
+                  fontSize: 14,
+                  lineHeight: 1.55,
+                  color: "var(--ls-text, #1F2937)",
+                  paddingTop: 6,
+                }}>
+                  {s}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Posture */}
+      {posture && (
+        <div style={{ marginBottom: 24 }}>
+          <SubsectionTitle icon="🧘" title="Posture à adopter" />
+          <div style={{
+            padding: "14px 16px",
+            background: "linear-gradient(135deg, rgba(45,212,191,0.10), rgba(45,212,191,0.04))",
+            border: "1px solid rgba(45,212,191,0.25)",
+            borderRadius: 12,
+            fontSize: 13.5,
+            lineHeight: 1.65,
+            color: "var(--ls-text, #1F2937)",
+            borderLeft: "4px solid var(--ls-teal, #2DD4BF)",
+          }}>
+            {posture}
+          </div>
+        </div>
+      )}
+
+      {/* Erreurs à éviter */}
+      {mistakes.length > 0 && (
+        <div>
+          <SubsectionTitle icon="⚠️" title="Erreurs à éviter" />
+          <div style={{ display: "grid", gap: 8 }}>
+            {mistakes.map((m, i) => (
+              <div key={i} style={{
+                display: "flex", gap: 12,
+                padding: "12px 14px",
+                background: "rgba(251,113,133,0.06)",
+                border: "1px solid rgba(251,113,133,0.25)",
+                borderRadius: 10,
+              }}>
+                <span style={{
+                  flexShrink: 0,
+                  fontSize: 18, lineHeight: 1.2,
+                }} aria-hidden="true">❌</span>
+                <div style={{
+                  fontSize: 13,
+                  lineHeight: 1.55,
+                  color: "var(--ls-text, #1F2937)",
+                }}>
+                  {m}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Étape 4 — Hashtags + plateformes recommandées + lieux IRL
 // ============================================================================
 
 const hashtagsListStyle: CSSProperties = {
@@ -558,8 +819,30 @@ function HashtagChip({ value }: { value: string }) {
   );
 }
 
+function PlatformBadgeChip({ platform }: { platform: ProspectionPlatform }) {
+  const label = PLATFORM_LABELS[platform] ?? platform;
+  const icon = PLATFORM_ICONS[platform] ?? "📱";
+  const gradient = PLATFORM_GRADIENTS[platform] ?? "#6B7280";
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 8,
+      padding: "8px 14px",
+      borderRadius: 999,
+      background: gradient,
+      color: "white",
+      fontSize: 13,
+      fontWeight: 700,
+      fontFamily: "'Syne', serif",
+      boxShadow: "0 4px 12px rgba(11,13,17,0.18)",
+    }}>
+      <span aria-hidden="true">{icon}</span>
+      {label}
+    </span>
+  );
+}
+
 // ============================================================================
-// Étape 4 — Banner timing + tip culturel du marché
+// Étape 5 — Banner timing + tip culturel du marché
 // ============================================================================
 
 function MarketTimingBanner({
@@ -607,22 +890,28 @@ function MarketTimingBanner({
 }
 
 // ============================================================================
-// Étape 4 — Script card avec label + langue + badge J+3
+// Étape 5 — Script card avec label + badge + boutons Copier / Marquer envoyé
 // ============================================================================
 
 const KIND_BADGES: Record<string, { label: string; bg: string; color: string }> = {
-  j3_followup: { label: "Relance J+3",     bg: "linear-gradient(135deg, #F59E0B, #FBBF24)", color: "white" },
-  referral:    { label: "Après reco",      bg: "linear-gradient(135deg, #2DD4BF, #5EEAD4)", color: "white" },
-  pitch:       { label: "Pitch business",  bg: "linear-gradient(135deg, #8B5CF6, #A78BFA)", color: "white" },
-  direct:      { label: "Contact direct",  bg: "rgba(45,212,191,0.15)", color: "#0F766E" },
+  j3_followup: { label: "Relance J+3",    bg: "linear-gradient(135deg, #F59E0B, #FBBF24)", color: "white" },
+  referral:    { label: "Après reco",     bg: "linear-gradient(135deg, #2DD4BF, #5EEAD4)", color: "white" },
+  pitch:       { label: "Pitch business", bg: "linear-gradient(135deg, #8B5CF6, #A78BFA)", color: "white" },
+  direct:      { label: "Contact direct", bg: "rgba(45,212,191,0.15)", color: "#0F766E" },
   first_contact: { label: "", bg: "", color: "" },
 };
 
 function ScriptCard({
-  script, marketCode,
-}: { script: ProspectionScript; marketCode: string }) {
+  script, marketCode, onMarkSent,
+}: {
+  script: ProspectionScript;
+  marketCode: string;
+  onMarkSent: () => Promise<void> | void;
+}) {
   const [copied, setCopied] = useState(false);
   const [showFr, setShowFr] = useState(false);
+  const [marked, setMarked] = useState(false);
+  const [marking, setMarking] = useState(false);
   const hasTranslation = !!script.body_fr && marketCode !== "fr";
   const badge = KIND_BADGES[script.kind];
   const label = script.label || PLATFORM_LABELS[script.platform];
@@ -633,6 +922,15 @@ function ScriptCard({
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     }).catch(() => { /* silent */ });
+  }
+
+  async function markSent() {
+    if (marked || marking) return;
+    setMarking(true);
+    await onMarkSent();
+    setMarking(false);
+    setMarked(true);
+    setTimeout(() => setMarked(false), 3500);
   }
 
   const bodyHtml = useMemo(() => highlightVariables(script.body), [script.body]);
@@ -753,12 +1051,13 @@ function ScriptCard({
         gap: 8,
         alignItems: "center",
         background: "white",
+        flexWrap: "wrap",
       }}>
         <button
           type="button"
           onClick={copy}
           style={{
-            flex: 1,
+            flex: "1 1 200px",
             background: copied
               ? "linear-gradient(135deg, var(--ls-teal, #2DD4BF), #5EEAD4)"
               : "linear-gradient(135deg, var(--ls-charcoal, #0B0D11), #1F2937)",
@@ -784,6 +1083,30 @@ function ScriptCard({
           }}
         >
           {copied ? "✓ Copié !" : "📋 Copier le message"}
+        </button>
+        <button
+          type="button"
+          onClick={markSent}
+          disabled={marking}
+          style={{
+            background: marked
+              ? "linear-gradient(135deg, #16A34A, #22C55E)"
+              : "var(--ls-surface2, #F7F3EC)",
+            color: marked ? "white" : "var(--ls-text, #1F2937)",
+            border: `1.5px solid ${marked ? "#16A34A" : "var(--ls-border, rgba(11,13,17,0.10))"}`,
+            padding: "11px 14px",
+            borderRadius: 12,
+            fontSize: 12.5,
+            fontWeight: 700,
+            cursor: marking ? "wait" : "pointer",
+            fontFamily: "inherit",
+            whiteSpace: "nowrap",
+            transition: "all 0.2s",
+            boxShadow: marked ? "0 4px 12px rgba(22,163,74,0.30)" : "none",
+          }}
+          title="Compter ce message dans tes stats (privé)"
+        >
+          {marked ? "✓ Envoyé !" : marking ? "…" : "📤 Marquer envoyé"}
         </button>
         {hasTranslation && (
           <button
@@ -832,31 +1155,12 @@ function highlightVariables(body: string): string {
 }
 
 // ============================================================================
-// Étape 4 — Arborescence relance (3 cards : ✅ / ⏳ / ❌)
+// Étape 6 — Arborescence relance + bilan link + stats coach
 // ============================================================================
 
 function RelanceTree({ bilanLink }: { bilanLink: string }) {
   return (
-    <div style={{ marginTop: 28 }}>
-      <h2 style={{
-        fontFamily: "'Syne', serif",
-        fontSize: 22,
-        fontWeight: 700,
-        margin: 0,
-        marginBottom: 8,
-        color: "var(--ls-charcoal, #0B0D11)",
-      }}>
-        📅 Arborescence de relance
-      </h2>
-      <p style={{
-        fontSize: 13,
-        color: "var(--ls-text-muted, #4B5563)",
-        margin: 0, marginBottom: 16,
-        lineHeight: 1.55,
-      }}>
-        Ce que tu fais après envoi du 1er message, selon la réponse.
-      </p>
-
+    <div>
       <RelanceCard
         accent="#16A34A"
         bgGradient="linear-gradient(135deg, rgba(22,163,74,0.08), rgba(22,163,74,0.02))"
@@ -871,6 +1175,7 @@ function RelanceTree({ bilanLink }: { bilanLink: string }) {
           fontWeight: 600,
           color: "#15803D",
           fontFamily: "ui-monospace, monospace",
+          wordBreak: "break-all",
         }}>
           {bilanLink.replace(`${window.location.origin}/`, "")}
         </code>{" "}
@@ -882,7 +1187,7 @@ function RelanceTree({ bilanLink }: { bilanLink: string }) {
         bgGradient="linear-gradient(135deg, rgba(245,158,11,0.10), rgba(245,158,11,0.03))"
         trigger="⏳ Si pas de réponse à J+3"
       >
-        → Envoie un message de relance soft (voir scripts <strong>Relance J+3</strong> ci-dessus). Question ouverte, pas de pitch. <strong>Pas de pression.</strong>
+        → Envoie un message de relance soft (les scripts <strong>Relance J+3</strong> de l'étape précédente). Question ouverte, pas de pitch. <strong>Pas de pression.</strong>
       </RelanceCard>
 
       <RelanceCard
@@ -926,6 +1231,57 @@ function RelanceCard({
       }}>
         {children}
       </div>
+    </div>
+  );
+}
+
+function StatsGrid({ stats }: { stats: ProspectionStats }) {
+  const responseRate = stats.total_7d > 0
+    ? Math.round((stats.responses_7d / stats.total_7d) * 100)
+    : 0;
+  const conversionRate = stats.total_7d > 0
+    ? Math.round((stats.conversions_7d / stats.total_7d) * 100)
+    : 0;
+
+  const tiles = [
+    { label: "Envois 7 derniers jours", value: stats.total_7d, color: "var(--ls-gold, #C9A84C)" },
+    { label: "Envois 30 derniers jours", value: stats.total_30d, color: "var(--ls-teal, #2DD4BF)" },
+    { label: "Taux de réponse 7j", value: `${responseRate}%`, color: "#F59E0B" },
+    { label: "Conversions Lead 7j", value: `${conversionRate}%`, color: "#16A34A" },
+  ];
+
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+      gap: 10,
+    }}>
+      {tiles.map((t, i) => (
+        <div key={i} style={{
+          background: "var(--ls-surface, white)",
+          border: "1px solid var(--ls-border, rgba(11,13,17,0.10))",
+          borderRadius: 12,
+          padding: "14px 16px",
+          boxShadow: "0 2px 8px rgba(11,13,17,0.04)",
+        }}>
+          <div style={{
+            fontFamily: "'Syne', serif",
+            fontSize: 24, fontWeight: 700,
+            color: t.color,
+            lineHeight: 1.1,
+            marginBottom: 4,
+          }}>
+            {t.value}
+          </div>
+          <div style={{
+            fontSize: 11,
+            color: "var(--ls-text-muted, #4B5563)",
+            lineHeight: 1.35,
+          }}>
+            {t.label}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }
@@ -1026,7 +1382,7 @@ function BilanLinkBox({ link }: { link: string }) {
 }
 
 // ============================================================================
-// Tip banner générique (étape 3 astuce hashtags)
+// Tip banner générique
 // ============================================================================
 
 function TipBanner({

--- a/supabase/migrations/20261116000000_prospection_full.sql
+++ b/supabase/migrations/20261116000000_prospection_full.sql
@@ -1,0 +1,182 @@
+-- =============================================================================
+-- Chantier #3 — FULL (2026-05-17 nuit, après "tu bâcles" Thomas).
+--
+-- Ramène TOUT ce qui était dans le brainstorm Égypte chantier #3 :
+--   - Étape "Brief méthodo" : GoPro 3 points + posture + erreurs à éviter
+--   - Étape "Cibler" enrichie : suggestions de lieux IRL par profil
+--   - Tracking : table prospection_attempts (étape 3.7) + RLS coach perso
+--   - Stats simples : RPC pour agrégat 7 derniers jours
+-- =============================================================================
+
+begin;
+
+-- ─── 1. Briefs méthodo par profil ──────────────────────────────────────────
+alter table public.prospection_profiles
+  add column if not exists gopro_steps text[] not null default '{}',
+  add column if not exists posture text,
+  add column if not exists mistakes text[] not null default '{}',
+  add column if not exists local_venues_hint text,
+  add column if not exists recommended_platforms text[] not null default '{}';
+
+comment on column public.prospection_profiles.gopro_steps is
+  'Chantier #3 V3 — Méthode GoPro résumée en 3 points pour ce profil. Affiché étape Brief.';
+comment on column public.prospection_profiles.posture is
+  'Chantier #3 V3 — Posture à adopter (indirecte, qualifiante) pour ce profil.';
+comment on column public.prospection_profiles.mistakes is
+  'Chantier #3 V3 — 3 erreurs à éviter en prospection sur ce profil.';
+comment on column public.prospection_profiles.local_venues_hint is
+  'Chantier #3 V3 — Suggestions de lieux IRL où croiser ce profil (étape Cibler).';
+comment on column public.prospection_profiles.recommended_platforms is
+  'Chantier #3 V3 — Plateformes recommandées pour ce profil (insta/fb/linkedin/whatsapp/tiktok).';
+
+-- Population brief méthodo par profil
+update public.prospection_profiles set
+  gopro_steps = array[
+    'Sois Posée : pas pressée, pas vendeuse. Tu écoutes plus que tu parles.',
+    'Sois Indirecte : qualifie son envie avant de proposer quoi que ce soit.',
+    'Sois Authentique : raconte ton propre déclic, pas un argumentaire.'
+  ],
+  posture = E'Tu n''es pas une marque qui démarche. Tu es une femme/un homme qui a trouvé une approche qui marche pour la perte de poids et qui partage avec ceux à qui ça pourrait servir. Tu qualifies AVANT de proposer. Si la personne ne te dit pas explicitement "je veux perdre du poids", tu ne pitches PAS.',
+  mistakes = array[
+    'Pitcher dès le 1er message ("Salut, je vends Herbalife, ça t''intéresse ?") → grillé direct.',
+    'Demander de "voir son profil" ou de l''ajouter en ami sans contexte → flag spam.',
+    'Insister à J+1 puis J+2 puis J+3 → harcèlement perçu. Une seule relance soft à J+3 max.'
+  ],
+  local_venues_hint = E'IRL : salles de sport (cours collectifs, pas musculation), marchés bio, magasins healthy, parcs de jogging matin, sorties de crèches, écoles maternelles. Online : groupes Facebook "perte de poids [ville]", commentaires comptes coachs nutrition.',
+  recommended_platforms = array['insta', 'fb', 'whatsapp']
+where slug = 'weight';
+
+update public.prospection_profiles set
+  gopro_steps = array[
+    'Parle PERFORMANCE et RÉCUPÉRATION, jamais perte de poids ni régime.',
+    'Reconnais sa pratique : précise le sport, le niveau, le détail spécifique de son post.',
+    'Pose une question ouverte sur sa nutrition actuelle — laisse-le se livrer.'
+  ],
+  posture = E'Tu accompagnes des sportifs amateurs sur la nutrition adaptée à leur discipline. Tu connais ton sujet (récup post-effort, fenêtre métabolique, protéines, hydratation). Tu n''es PAS une coach minceur qui se déguise — c''est un autre métier. Ton angle : "souvent ce qui débloque la perf, c''est ce qu''on mange après l''entraînement".',
+  mistakes = array[
+    'Mentionner perte de poids → le sportif décroche, c''est pas son problème.',
+    'Étaler un palmarès Herbalife → il s''en fout, il veut du concret nutrition.',
+    'Proposer un programme "minceur" → mismatch total, propose un protocole RÉCUP/PERF.'
+  ],
+  local_venues_hint = E'IRL : box CrossFit, clubs de running, salles d''escalade, triathlon clubs, courses populaires (départ + arrivée), grandes surfaces sport. Online : Strava clubs, Garmin Connect, comptes Insta de coachs préparation physique.',
+  recommended_platforms = array['insta', 'whatsapp', 'fb']
+where slug = 'sport';
+
+update public.prospection_profiles set
+  gopro_steps = array[
+    'Positionne-toi entrepreneur d''abord : ton activité Herbalife est un side-business, pas un MLM 24/7.',
+    'Parle revenus complémentaires, liberté géographique, équipe internationale.',
+    'Propose un appel découverte 15-20 min, pas une réunion d''opportunité de 1h.'
+  ],
+  posture = E'Tu construis un business en parallèle de ta vie pro et tu cherches des profils ambitieux pour bâtir une équipe. Tu n''es PAS recruteur d''un réseau opaque — tu es un pair entrepreneur. Sur LinkedIn : ton corporate, vouvoiement, structure courte. Sur Insta : ton complice. Rassure : "à côté de ma vie pro", "sans engagement", "appel découverte 15 min".',
+  mistakes = array[
+    'Mentionner Herbalife dès le 1er message → biais MLM ancré, perte du prospect.',
+    'Promettre des chiffres précis ("tu peux gagner 3000€/mois") → légal-out + crédibilité grillée.',
+    'Inviter à une réunion d''opportunité Zoom de 1h → personne ne vient. Préfère un 1-to-1 15 min.'
+  ],
+  local_venues_hint = E'IRL : événements business locaux, BNI, French Tech, espaces coworking, conférences entrepreneuriat (Marseille, Lyon, Bordeaux). Online : commentaires posts entrepreneurs Insta, groupes Facebook "side hustle", LinkedIn (recherche par poste + secteur).',
+  recommended_platforms = array['insta', 'linkedin', 'whatsapp']
+where slug = 'business';
+
+-- ─── 2. Table prospection_attempts (tracking V2 réintégré) ─────────────────
+create table if not exists public.prospection_attempts (
+  id                       uuid primary key default gen_random_uuid(),
+  coach_id                 uuid not null references public.users(id) on delete cascade,
+  market_code              text not null references public.prospection_markets(code) on delete restrict,
+  profile_slug             text not null references public.prospection_profiles(slug) on delete restrict,
+  platform                 text not null check (platform in ('insta', 'fb', 'whatsapp', 'telegram', 'linkedin', 'sms', 'tiktok')),
+  target_label             text,
+  target_handle            text,
+  first_message_sent_at    timestamptz not null default now(),
+  response_status          text not null default 'pending'
+    check (response_status in ('pending', 'positive', 'curious', 'negative', 'no_response')),
+  converted_to_lead_id     uuid,
+  note                     text,
+  created_at               timestamptz not null default now(),
+  updated_at               timestamptz not null default now()
+);
+
+create index if not exists idx_prospection_attempts_coach_date
+  on public.prospection_attempts (coach_id, first_message_sent_at desc);
+
+comment on table public.prospection_attempts is
+  'Chantier #3 — Tracking des sessions de prospection cold par coach. Permet stats simples (envois 7 derniers jours, taux de réponse, conversion en Lead).';
+
+alter table public.prospection_attempts enable row level security;
+
+drop policy if exists "prospection_attempts_owner_select" on public.prospection_attempts;
+drop policy if exists "prospection_attempts_owner_insert" on public.prospection_attempts;
+drop policy if exists "prospection_attempts_owner_update" on public.prospection_attempts;
+drop policy if exists "prospection_attempts_owner_delete" on public.prospection_attempts;
+drop policy if exists "prospection_attempts_admin_all"   on public.prospection_attempts;
+
+-- Le coach voit/édite uniquement ses propres attempts.
+create policy "prospection_attempts_owner_select"
+  on public.prospection_attempts for select to authenticated
+  using (coach_id = auth.uid());
+
+create policy "prospection_attempts_owner_insert"
+  on public.prospection_attempts for insert to authenticated
+  with check (coach_id = auth.uid());
+
+create policy "prospection_attempts_owner_update"
+  on public.prospection_attempts for update to authenticated
+  using (coach_id = auth.uid()) with check (coach_id = auth.uid());
+
+create policy "prospection_attempts_owner_delete"
+  on public.prospection_attempts for delete to authenticated
+  using (coach_id = auth.uid());
+
+-- Admin voit tout (pour debug / stats globales).
+create policy "prospection_attempts_admin_all"
+  on public.prospection_attempts for all to authenticated
+  using (public.is_admin()) with check (public.is_admin());
+
+-- ─── 3. RPC stats simples (7 derniers jours pour le coach courant) ─────────
+create or replace function public.get_prospection_stats(p_user_id uuid)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_total_7d        integer;
+  v_responses_7d    integer;
+  v_positive_7d     integer;
+  v_conversions_7d  integer;
+  v_total_30d       integer;
+begin
+  if p_user_id is null then
+    return null;
+  end if;
+
+  select
+    count(*) filter (where first_message_sent_at >= now() - interval '7 days'),
+    count(*) filter (where first_message_sent_at >= now() - interval '7 days'
+                       and response_status in ('positive','curious','negative')),
+    count(*) filter (where first_message_sent_at >= now() - interval '7 days'
+                       and response_status = 'positive'),
+    count(*) filter (where first_message_sent_at >= now() - interval '7 days'
+                       and converted_to_lead_id is not null),
+    count(*) filter (where first_message_sent_at >= now() - interval '30 days')
+  into v_total_7d, v_responses_7d, v_positive_7d, v_conversions_7d, v_total_30d
+  from public.prospection_attempts
+  where coach_id = p_user_id;
+
+  return jsonb_build_object(
+    'total_7d',       coalesce(v_total_7d, 0),
+    'responses_7d',   coalesce(v_responses_7d, 0),
+    'positive_7d',    coalesce(v_positive_7d, 0),
+    'conversions_7d', coalesce(v_conversions_7d, 0),
+    'total_30d',      coalesce(v_total_30d, 0)
+  );
+end;
+$$;
+
+grant execute on function public.get_prospection_stats(uuid) to authenticated;
+
+comment on function public.get_prospection_stats(uuid) is
+  'Chantier #3 — Stats prospection cold du coach (7 et 30 derniers jours).';
+
+commit;


### PR DESCRIPTION
## Summary

Suite « tu bâcles » Thomas → **relecture du brainstorm chantier #3 complet** et implémentation TOUT ce qui était prévu sans skip.

### 6 étapes UI (au lieu de 4)

| # | Avant V2 | V3 |
|---|---|---|
| 1 | Marché | Marché (auto-advance) |
| 2 | Profil | Profil (auto-advance) |
| 3 | Hashtags | **NEW Brief méthodo** : GoPro 3 points + posture + 3 erreurs à éviter (cards numérotées gold + posture teal + erreurs coral) |
| 4 | Messages + relance | **Cibler enrichi** : hashtags + astuce + **plateformes recommandées** (badges colorés) + **lieux IRL où croiser ce profil** |
| 5 | — | Premier contact : banner timing/culturel + scripts + **bouton 📤 Marquer envoyé** |
| 6 | — | **Suivi & relances** : arborescence J+3/J+7 + box bilan link + **stats coach 30j** |

### Étapes du brainstorm jusque-là skippées, maintenant livrées

| Étape brainstorm | V1/V2 | V3 |
|---|---|---|
| **3.3 Page admin CRUD** | ❌ Skip | ✅ `/admin/prospection` avec 2 onglets (Scripts CRUD + Briefs editor) |
| **3.6 Lien rapide Co-pilote** | ❌ Skip | ✅ `ProspectionShortcut` widget gold/teal avec stats 7j |
| **3.7 Tracking attempts** | ❌ Skip (V2) | ✅ Table `prospection_attempts` + RPC `get_prospection_stats` + bouton "Marquer envoyé" + tile stats |

### DB ajouts (migration 20261116000000)

- `prospection_profiles` enrichi : `gopro_steps text[]`, `posture`, `mistakes text[]`, `local_venues_hint`, `recommended_platforms text[]`
- Population des briefs pour les 3 profils (perte de poids / sport / business)
- Table `prospection_attempts` (RLS owner-only + admin all)
- RPC `get_prospection_stats(user_id)` (jsonb avec total_7d, responses_7d, positive_7d, conversions_7d, total_30d)

### Migrations appliquées en prod ✅

```
supabase db push --linked --include-all
```

## Test plan

- [ ] `/prospection` → header impactant (radial gradients) + stepper 6 dots
- [ ] **Étape 3 Brief** : GoPro 3 cards gold numérotées + posture teal + 3 erreurs coral
- [ ] **Étape 4 Cibler** : hashtags + astuce + **plateformes recommandées** (badges Insta/FB/WA) + **lieux IRL** (card teal)
- [ ] **Étape 5 Messages** : banner timing + scripts + bouton "📤 Marquer envoyé" devient "✓ Envoyé !" vert
- [ ] **Étape 6 Suivi** : arborescence 3 cards + box bilan link + **4 tiles stats 30 jours**
- [ ] Stats banner en haut visible une fois la 1ère attempt créée
- [ ] **Co-pilote** : widget `ProspectionShortcut` après InboxWidget, click → /prospection
- [ ] **Admin** (`/admin/prospection`) :
  - [ ] Tab Scripts : filtres marché/profil + liste + clic ✏️ → modal édition (body, body_fr, tip, label, kind, position) + clic 🗑 → delete + bouton "+ Nouveau script"
  - [ ] Tab Briefs : 3 accordions ouverts (perte/sport/business) avec GoPro × 3 + posture + erreurs × 3 + astuce hashtag + lieux IRL + toggle plateformes
- [ ] `npm run build` OK (validé local 22s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)