### PR TITLE
fix(prospection): polyfill drapeaux pays sur Windows Chrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "lor-squad-wellness",
+  "name": "labase360-app",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "lor-squad-wellness",
+      "name": "labase360-app",
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@supabase/supabase-js": "^2.101.1",
         "@types/react-signature-canvas": "^1.0.7",
+        "country-flag-emoji-polyfill": "^0.1.8",
         "html2canvas": "^1.4.1",
         "jspdf": "^4.2.1",
         "qrcode.react": "^4.2.0",
@@ -3212,6 +3213,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/country-flag-emoji-polyfill": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/country-flag-emoji-polyfill/-/country-flag-emoji-polyfill-0.1.8.tgz",
+      "integrity": "sha512-Mbah52sADS3gshUYhK5142gtUuJpHYOXlXtLFI3Ly4RqgkmPMvhX9kMZSTqDM8P7UqtSW99eHKFphhQSGXA3Cg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@supabase/supabase-js": "^2.101.1",
     "@types/react-signature-canvas": "^1.0.7",
+    "country-flag-emoji-polyfill": "^0.1.8",
     "html2canvas": "^1.4.1",
     "jspdf": "^4.2.1",
     "qrcode.react": "^4.2.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { polyfillCountryFlagEmojis } from "country-flag-emoji-polyfill";
 import App from "./App";
 import { AppProvider } from "./context/AppContext";
 import { InstallPromptProvider } from "./context/InstallPromptContext";
 import { ToastProvider } from "./context/ToastContext";
 import "./styles/globals.css";
+
+// Polyfill drapeaux Twemoji (2026-05-17) : Windows Chrome ne rend pas les
+// regional indicator emojis (les drapeaux pays apparaissent "FR/GB/MX/BR/TR/IN"
+// au lieu de 🇫🇷🇬🇧🇲🇽🇧🇷🇹🇷🇮🇳). Injecte une @font-face "Twemoji Country Flags"
+// qui mappe vers des SVG Twemoji. Aucun impact macOS/iOS/Android.
+polyfillCountryFlagEmojis();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Bug

Sur la preview Vercel ouverte dans Windows Chrome, les drapeaux pays des cards marchés (étape 1 de `/prospection`) s'affichent en **FR / GB / MX / BR / TR / IN** au lieu des drapeaux emoji 🇫🇷🇬🇧🇲🇽🇧🇷🇹🇷🇮🇳.

## Cause

Windows ne livre pas les regional indicator emojis dans ses fonts système. Chrome rend alors les deux lettres ISO 3166-1 (le glyphe brut des regional indicators).

## Fix

Lib `country-flag-emoji-polyfill` (10KB) injecte une `@font-face` "Twemoji Country Flags" qui mappe les regional indicators vers les SVG Twemoji. Aucun impact sur macOS/iOS/Android (où les drapeaux natifs s'affichent normalement via le fallback CSS).

Initialisé dans `src/main.tsx` avant le render React.

## Test plan

- [ ] Sur Windows Chrome, recharger `/prospection` → étape 1 affiche bien 🇫🇷 🇬🇧 🇲🇽 🇧🇷 🇹🇷 🇮🇳 au lieu de FR/GB/MX/BR/TR/IN
- [ ] Étape 5 (Premier contact) → banner timing affiche aussi le drapeau correctement
- [ ] Co-pilote → widget Prospecter maintenant (emoji 🌍 dans card gold, déjà OK natif)
- [ ] macOS/iOS/Android : pas de régression visuelle (drapeaux natifs respectés)

🤖 Generated with [Claude Code](https://claude.com/claude-code)