### PR TITLE
feat(business): carrousel temoignages + fix V1.1 affichage

### DIFF
--- a/src/components/testimonials/TestimonialsCarousel.tsx
+++ b/src/components/testimonials/TestimonialsCarousel.tsx
@@ -11,6 +11,9 @@
 import { useEffect, useRef, useState } from "react";
 import { getSupabaseClient } from "../../services/supabaseClient";
 import { PUBLIC_TOKENS, PUBLIC_FONTS, publicGradText } from "../../styles/public-tokens";
+// Import du CSS pour que .public-shell-scope wrappers heritent des vars
+// (var(--glass), var(--hair), etc.) meme sans PublicShell parent.
+import "../../styles/public-shell.css";
 
 export interface TestimonialPublic {
   id: string;
@@ -42,6 +45,20 @@ function formatAuthor(t: TestimonialPublic): string {
   return city ? `${author}, ${city}` : author;
 }
 
+// V1.1 lien generique coach : les soumissions ont client_id=null et stockent
+// "[FROM:firstName|city] " en debut de content. On parse pour reconstituer
+// l'auteur et nettoyer la citation affichee.
+const FROM_TAG_RE = /^\[FROM:([^|\]]+)(?:\|([^\]]+))?\]\s*/;
+function parseFromTag(content: string): { firstName: string | null; city: string | null; clean: string } {
+  const m = content.match(FROM_TAG_RE);
+  if (!m) return { firstName: null, city: null, clean: content };
+  return {
+    firstName: m[1]?.trim() || null,
+    city: m[2]?.trim() || null,
+    clean: content.slice(m[0].length),
+  };
+}
+
 export function TestimonialsCarousel({
   variant = "welcome",
   language = "fr",
@@ -66,9 +83,12 @@ export function TestimonialsCarousel({
           }
           return;
         }
+        // Left join sur clients : V1.1 lien generique coach a client_id=null
+        // (auteur recupere depuis tag [FROM:...] dans le content).
+        const SELECT = "id, content, rating, language, created_at, photo_url, photo_consent, clients(first_name, last_name, city)";
         let query = sb
           .from("client_testimonials")
-          .select("id, content, rating, language, created_at, photo_url, photo_consent, clients!inner(first_name, last_name, city)")
+          .select(SELECT)
           .eq("status", "approved")
           .eq("language", language)
           .order("created_at", { ascending: false })
@@ -83,7 +103,7 @@ export function TestimonialsCarousel({
           if (language !== "fr") {
             const { data: fallback } = await sb
               .from("client_testimonials")
-              .select("id, content, rating, language, created_at, photo_url, photo_consent, clients!inner(first_name, last_name, city)")
+              .select(SELECT)
               .eq("status", "approved")
               .eq("language", "fr")
               .order("created_at", { ascending: false })
@@ -138,12 +158,18 @@ export function TestimonialsCarousel({
 }
 
 function mapRows(data: unknown): TestimonialPublic[] {
-  return (data as Array<TestimonialPublic & { clients: { first_name: string | null; last_name: string | null; city: string | null } }>).map((r) => ({
-    ...r,
-    client_first_name: r.clients?.first_name ?? null,
-    client_last_name: r.clients?.last_name ?? null,
-    client_city: r.clients?.city ?? null,
-  }));
+  return (data as Array<TestimonialPublic & { clients: { first_name: string | null; last_name: string | null; city: string | null } | null }>).map((r) => {
+    // Si pas de client lie (V1.1 lien coach generique), parser le tag [FROM:...]
+    // pour recuperer prenom + ville et nettoyer le content.
+    const tag = r.clients ? null : parseFromTag(r.content);
+    return {
+      ...r,
+      content: tag ? tag.clean : r.content,
+      client_first_name: r.clients?.first_name ?? tag?.firstName ?? null,
+      client_last_name: r.clients?.last_name ?? null,
+      client_city: r.clients?.city ?? tag?.city ?? null,
+    };
+  });
 }
 
 // ─── Welcome variant ──────────────────────────────────────────────────────────

--- a/src/pages/BusinessPage.tsx
+++ b/src/pages/BusinessPage.tsx
@@ -22,6 +22,7 @@ import {
   type SimulationResult,
 } from "../lib/businessSimulator";
 import { BIZ_STYLES } from "./BusinessPage.styles";
+import { TestimonialsCarousel } from "../components/testimonials/TestimonialsCarousel";
 
 type FormStatus = "idle" | "submitting" | "success" | "error";
 
@@ -818,10 +819,44 @@ export function BusinessPage() {
             <div className="biz-reveal biz-stories__signature">
               <span>« La seule règle : démarrer. »</span>
             </div>
+
+            {/* §5b — Carrousel temoignages clients (Chantier #11 finition) */}
+            <div className="biz-reveal" style={{ marginTop: 56, maxWidth: 880, marginInline: "auto" }}>
+              <div
+                className="public-shell-scope"
+                data-public-theme="light"
+                style={{ fontFamily: '"Inter", -apple-system, sans-serif' }}
+              >
+                <h4
+                  style={{
+                    fontFamily: '"Sora", system-ui, sans-serif',
+                    fontSize: 15,
+                    fontWeight: 500,
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                    color: "rgba(15,23,42,.55)",
+                    marginBottom: 6,
+                  }}
+                >
+                  Et les clients qui en bénéficient ?
+                </h4>
+                <p
+                  style={{
+                    fontSize: 15,
+                    color: "rgba(15,23,42,.62)",
+                    marginBottom: 12,
+                    maxWidth: 540,
+                  }}
+                >
+                  Tu as vu pourquoi les partenaires aiment ce métier. Voilà ce que disent ceux qu'on accompagne au quotidien.
+                </p>
+                <TestimonialsCarousel variant="business" />
+              </div>
+            </div>
           </div>
         </section>
 
-        {/* §5b FAQ */}
+        {/* §6 FAQ */}
         <section className="biz-section" style={{paddingTop:0}} id="faq">
           <div className="biz-container">
             <div className="biz-reveal" style={{maxWidth:680}}>

--- a/src/styles/public-shell.css
+++ b/src/styles/public-shell.css
@@ -13,7 +13,13 @@
    du Co-pilote V5 interne.
    ============================================================================ */
 
-.public-shell {
+/* Scope util : applique uniquement les CSS vars (sans background/color/font global).
+   Utile pour reutiliser le carrousel TestimonialsCarousel dans des pages au
+   namespace different (ex : BusinessPage / .biz-page light scroll narratif).
+   Pattern : <div className="public-shell-scope" data-public-theme="light">.
+   Les blocs .public-shell ci-apres HERITENT egalement de ces vars. */
+.public-shell,
+.public-shell-scope {
   --ink: #0B0D11;
   --ink-2: #131820;
   --cream: #FBF7F0;
@@ -48,7 +54,11 @@
   --accent-teal-bg: rgba(45, 212, 191, 0.12);
   --accent-violet-bg: rgba(167, 139, 250, 0.12);
   --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.20);
+}
 
+/* Styles globaux uniquement sur .public-shell (pas .public-shell-scope) :
+   le scope util ne doit pas surcharger font/background/color de la page hote. */
+.public-shell {
   font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
   background: var(--ink);
   color: var(--cream);
@@ -60,7 +70,8 @@
 }
 
 /* THEME LIGHT (toggle utilisateur) */
-.public-shell[data-public-theme="light"] {
+.public-shell[data-public-theme="light"],
+.public-shell-scope[data-public-theme="light"] {
   --ink: #FBF7F0;
   --ink-2: #F2EBDF;
   --cream: #0B0D11;


### PR DESCRIPTION
## Summary

Finition Chantier A + #11 reportee :
- **Fix critique** TestimonialsCarousel : la query `clients!inner` empechait l'affichage des temoignages V1.1 (lien generique coach, `client_id=null`). Switch en left join + parsing du tag `[FROM:firstName|city]`
- **Intégration carrousel** sur `/business` entre §5 stories partenaires et §6 FAQ
- **Scope util** `.public-shell-scope` : permet de réutiliser les vars CSS publiques sur une page au namespace différent sans casser font/background/color hôtes

Palette `--biz-*` (emerald/cyan/violet) de BusinessPage **conservée** comme assumée dans CLAUDE.md (distinction conversion vs warm). Pas de migration palette ici.

## Test plan

- [x] Build OK (`npm run build` ✓)
- [ ] Vercel preview `/business` : carrousel s'affiche entre stories et FAQ (light bg cream)
- [ ] Vercel preview `/bilan-online` : carrousel V1.1 mode coach apparaît (cards des soumissions via lien générique)
- [ ] `/admin/testimonials` : approver un témoignage V1.1 → vérifier qu'il remonte côté carrousel

🤖 Generated with [Claude Code](https://claude.com/claude-code)