### PR TITLE
feat(distri-fiche 13A.1+A.2): 8 blocs partages + refactor modale

### DIFF
--- a/src/components/distributor-blocks/ActiviteRecenteBlock.tsx
+++ b/src/components/distributor-blocks/ActiviteRecenteBlock.tsx
@@ -1,0 +1,41 @@
+// =============================================================================
+// ActiviteRecenteBlock — Bilans 30j + RDV 30j + Messages 7j
+// =============================================================================
+// Extrait de TeamMemberDrilldownModal (Chantier #13 sous-vague A.1, 2026-05-18).
+// =============================================================================
+
+import type { TeamMemberEngagement } from "../../hooks/useTeamEngagement";
+import { MetricCard, SectionTitle, threeColGridStyle } from "./_shared";
+
+interface Props {
+  member: TeamMemberEngagement;
+  hideTitle?: boolean;
+}
+
+export function ActiviteRecenteBlock({ member, hideTitle }: Props) {
+  return (
+    <>
+      {!hideTitle && <SectionTitle>📊 Activité récente</SectionTitle>}
+      <div style={threeColGridStyle}>
+        <MetricCard
+          title="Bilans 30j"
+          primary={String(member.bilans_30d)}
+          secondary="initiaux créés"
+          color="var(--ls-teal)"
+        />
+        <MetricCard
+          title="RDV 30j"
+          primary={String(member.rdv_30d)}
+          secondary="follow-ups planifiés"
+          color="var(--ls-gold)"
+        />
+        <MetricCard
+          title="Messages 7j"
+          primary={String(member.messages_7d)}
+          secondary="envoyés aux clients"
+          color="var(--ls-coral)"
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/distributor-blocks/ApprentissageBlock.tsx
+++ b/src/components/distributor-blocks/ApprentissageBlock.tsx
@@ -1,0 +1,38 @@
+// =============================================================================
+// ApprentissageBlock — Academy + Formation pyramide
+// =============================================================================
+// Extrait de TeamMemberDrilldownModal (Chantier #13 sous-vague A.1, 2026-05-18).
+// =============================================================================
+
+import type { TeamMemberEngagement } from "../../hooks/useTeamEngagement";
+import { MetricCard, SectionTitle, twoColGridStyle } from "./_shared";
+
+interface Props {
+  member: TeamMemberEngagement;
+  hideTitle?: boolean;
+}
+
+export function ApprentissageBlock({ member, hideTitle }: Props) {
+  return (
+    <>
+      {!hideTitle && <SectionTitle>🎓 Apprentissage</SectionTitle>}
+      <div style={twoColGridStyle}>
+        <MetricCard
+          title="Academy"
+          primary={`${member.academy_step} / 12`}
+          secondary={`${member.academy_percent}% complété`}
+          color={member.academy_percent >= 100 ? "var(--ls-teal)" : "var(--ls-gold)"}
+        />
+        <MetricCard
+          title="Formation"
+          primary={`${member.formation_total_validated} validés`}
+          secondary={`N1: ${member.formation_validated_n1} · N2: ${member.formation_validated_n2} · N3: ${member.formation_validated_n3}`}
+          color="var(--ls-purple)"
+          badge={
+            member.formation_pending > 0 ? `${member.formation_pending} en attente` : undefined
+          }
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/distributor-blocks/CompteActifBlock.tsx
+++ b/src/components/distributor-blocks/CompteActifBlock.tsx
@@ -1,0 +1,135 @@
+// =============================================================================
+// CompteActifBlock — toggle Geler / Reactiver le compte distri (admin only)
+// =============================================================================
+// Extrait de TeamMemberDrilldownModal (Chantier #13 sous-vague A.1, 2026-05-18).
+// =============================================================================
+
+import { useState } from "react";
+import { useToast, buildSupabaseErrorToast } from "../../context/ToastContext";
+import { freezeUserAccount, unfreezeUserAccount } from "../../services/supabaseService";
+import type { User } from "../../types/domain";
+
+interface Props {
+  memberId: string;
+  memberName: string;
+  fullUser: User | null;
+  onApplied?: () => void | Promise<void>;
+  /** Optionnel : ferme la modale parente apres l'action. */
+  onAfterToggle?: () => void;
+}
+
+export function CompteActifBlock({
+  memberId,
+  memberName,
+  fullUser,
+  onApplied,
+  onAfterToggle,
+}: Props) {
+  const { push: pushToast } = useToast();
+  const [freezing, setFreezing] = useState(false);
+  const isFrozen = !!fullUser?.frozenAt;
+
+  async function handleToggle() {
+    if (freezing) return;
+    setFreezing(true);
+    try {
+      if (isFrozen) {
+        await unfreezeUserAccount(memberId);
+        pushToast({
+          tone: "success",
+          title: "Compte réactivé",
+          message: `${memberName} retrouve l'accès à l'app.`,
+        });
+      } else {
+        await freezeUserAccount({
+          userId: memberId,
+          reason: "Gelé manuellement par admin",
+        });
+        pushToast({
+          tone: "success",
+          title: "Compte gelé",
+          message: `${memberName} ne pourra plus accéder à l'app jusqu'à réactivation.`,
+        });
+      }
+      await onApplied?.();
+      onAfterToggle?.();
+    } catch (err) {
+      pushToast(buildSupabaseErrorToast(err, "Action impossible pour le moment."));
+    } finally {
+      setFreezing(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        marginTop: 18,
+        padding: 14,
+        borderRadius: 12,
+        background: isFrozen
+          ? "color-mix(in srgb, var(--ls-coral) 8%, var(--ls-surface2))"
+          : "var(--ls-surface2)",
+        border: isFrozen
+          ? "1px solid color-mix(in srgb, var(--ls-coral) 35%, transparent)"
+          : "1px solid var(--ls-border)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            color: isFrozen ? "var(--ls-coral)" : "var(--ls-text)",
+            letterSpacing: 0.3,
+            marginBottom: 2,
+          }}
+        >
+          {isFrozen ? "🧊 Compte gelé" : "🟢 Compte actif"}
+        </div>
+        <div style={{ fontSize: 11, color: "var(--ls-text-muted)", lineHeight: 1.4 }}>
+          {isFrozen
+            ? "L'utilisateur ne peut plus accéder à l'app et n'apparaît plus dans les stats équipe."
+            : "Geler ce compte pour qu'il ne pollue plus stats / podium / agendas."}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => void handleToggle()}
+        disabled={freezing}
+        role="switch"
+        aria-checked={!isFrozen}
+        style={{
+          position: "relative",
+          width: 56,
+          height: 30,
+          borderRadius: 999,
+          border: "none",
+          background: isFrozen ? "#475569" : "var(--ls-teal)",
+          cursor: freezing ? "wait" : "pointer",
+          transition: "background 0.2s ease",
+          opacity: freezing ? 0.6 : 1,
+          flexShrink: 0,
+        }}
+        title={isFrozen ? "Réactiver le compte" : "Geler le compte"}
+      >
+        <span
+          style={{
+            position: "absolute",
+            top: 3,
+            left: isFrozen ? 3 : 29,
+            width: 24,
+            height: 24,
+            borderRadius: "50%",
+            background: "white",
+            transition: "left 0.2s ease",
+            boxShadow: "0 2px 4px rgba(0,0,0,0.2)",
+          }}
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/components/distributor-blocks/EngagementBlock.tsx
+++ b/src/components/distributor-blocks/EngagementBlock.tsx
@@ -1,0 +1,39 @@
+// =============================================================================
+// EngagementBlock — Derniere connexion + Connexions cumulees
+// =============================================================================
+// Extrait de TeamMemberDrilldownModal (Chantier #13 sous-vague A.1, 2026-05-18).
+// =============================================================================
+
+import type { TeamMemberEngagement } from "../../hooks/useTeamEngagement";
+import { MetricCard, SectionTitle, formatRelativeFR, twoColGridStyle } from "./_shared";
+
+interface Props {
+  member: TeamMemberEngagement;
+  hideTitle?: boolean;
+}
+
+export function EngagementBlock({ member, hideTitle }: Props) {
+  return (
+    <>
+      {!hideTitle && <SectionTitle>🔥 Engagement</SectionTitle>}
+      <div style={twoColGridStyle}>
+        <MetricCard
+          title="Dernière connexion"
+          primary={formatRelativeFR(member.last_seen_at)}
+          secondary={
+            member.last_seen_at
+              ? new Date(member.last_seen_at).toLocaleDateString("fr-FR")
+              : "—"
+          }
+          color="var(--ls-text-muted)"
+        />
+        <MetricCard
+          title="Connexions cumulées"
+          primary={String(member.lifetime_login_count)}
+          secondary={`${member.lifetime_login_count * 5} XP daily`}
+          color="var(--ls-coral)"
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/distributor-blocks/EngagementTotalBlock.tsx
+++ b/src/components/distributor-blocks/EngagementTotalBlock.tsx
@@ -1,0 +1,79 @@
+// =============================================================================
+// EngagementTotalBlock — XP total + breakdown 6 categories
+// =============================================================================
+// Extrait de TeamMemberDrilldownModal (Chantier #13 sous-vague A.1, 2026-05-18).
+// Affiche : xp_total + xp_level + breakdown Academy/Bilans/RDV/Messages/
+// Formation/Connexions.
+// =============================================================================
+
+import type { CSSProperties } from "react";
+import type { TeamMemberEngagement } from "../../hooks/useTeamEngagement";
+import { BreakdownRow } from "./_shared";
+
+interface Props {
+  member: TeamMemberEngagement;
+}
+
+export function EngagementTotalBlock({ member }: Props) {
+  return (
+    <div style={xpBigCardStyle}>
+      <div
+        style={{
+          fontSize: 11,
+          color: "var(--ls-text-muted)",
+          textTransform: "uppercase",
+          letterSpacing: 0.8,
+        }}
+      >
+        Engagement total
+      </div>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginTop: 4 }}>
+        <span style={xpTotalStyle}>{member.xp_total.toLocaleString("fr-FR")}</span>
+        <span style={{ fontSize: 13, color: "var(--ls-text-muted)" }}>XP</span>
+        <span style={levelBadgeStyle}>Niveau {member.xp_level}</span>
+      </div>
+      <div style={breakdownGridStyle}>
+        <BreakdownRow emoji="🎓" label="Academy" value={member.xp_academy} />
+        <BreakdownRow emoji="📋" label="Bilans" value={member.xp_bilans} />
+        <BreakdownRow emoji="📅" label="RDV" value={member.xp_rdv} />
+        <BreakdownRow emoji="💬" label="Messages" value={member.xp_messages} />
+        <BreakdownRow emoji="📚" label="Formation" value={member.xp_formation} />
+        <BreakdownRow emoji="🔥" label="Connexions" value={member.xp_daily} />
+      </div>
+    </div>
+  );
+}
+
+const xpBigCardStyle: CSSProperties = {
+  background:
+    "linear-gradient(135deg, color-mix(in srgb, var(--ls-gold) 10%, var(--ls-surface)), var(--ls-surface))",
+  border: "0.5px solid color-mix(in srgb, var(--ls-gold) 30%, var(--ls-border))",
+  borderRadius: 14,
+  padding: "16px 18px",
+  marginBottom: 18,
+};
+
+const xpTotalStyle: CSSProperties = {
+  fontFamily: "Syne, sans-serif",
+  fontSize: 32,
+  fontWeight: 800,
+  color: "var(--ls-gold)",
+};
+
+const levelBadgeStyle: CSSProperties = {
+  marginLeft: "auto",
+  padding: "4px 10px",
+  borderRadius: 8,
+  background: "var(--ls-gold)",
+  color: "var(--ls-bg)",
+  fontSize: 11,
+  fontFamily: "Syne, sans-serif",
+  fontWeight: 700,
+};
+
+const breakdownGridStyle: CSSProperties = {
+  marginTop: 14,
+  display: "grid",
+  gridTemplateColumns: "1fr 1fr",
+  gap: 6,
+};

--- a/src/components/distributor-blocks/ProgressionRangBlock.tsx
+++ b/src/components/distributor-blocks/ProgressionRangBlock.tsx
@@ -1,0 +1,142 @@
+// =============================================================================
+// ProgressionRangBlock — jauge progression vers le prochain rang Herbalife
+// =============================================================================
+// Extrait de TeamMemberDrilldownModal (Chantier #13 sous-vague A.1, 2026-05-18).
+// Calcul PV qualifiant = perso + downline non-Supervisor (cf. herbalifeFormulas).
+// =============================================================================
+
+import { useMemo } from "react";
+import { useAppContext } from "../../context/AppContext";
+import { usePvBreakdowns } from "../../hooks/usePvBreakdowns";
+import {
+  computeQualifyingPersonalPv,
+  currentMonthIso,
+  rankProgression,
+  totalPvFromBreakdown,
+} from "../../lib/herbalifeFormulas";
+import type { User } from "../../types/domain";
+import { AdminCard, hintStyle } from "./_shared";
+
+interface Props {
+  memberId: string;
+  fullUser: User | null;
+  /** ISO YYYY-MM, default = mois en cours. */
+  monthIso?: string;
+}
+
+export function ProgressionRangBlock({ memberId, fullUser, monthIso }: Props) {
+  const { users } = useAppContext();
+  const month = monthIso ?? currentMonthIso();
+  const { getForUser, breakdowns: allBreakdowns } = usePvBreakdowns(month);
+  const existingBreakdown = getForUser(memberId);
+
+  const personalPv = useMemo(() => {
+    if (existingBreakdown) return totalPvFromBreakdown(existingBreakdown);
+    const ux = fullUser as
+      | (User & { monthlyPvOverrideMonth?: string | null; monthlyPvOverride?: number | null })
+      | null;
+    if (ux?.monthlyPvOverrideMonth === month && typeof ux?.monthlyPvOverride === "number") {
+      return ux.monthlyPvOverride;
+    }
+    return 0;
+  }, [existingBreakdown, fullUser, month]);
+
+  const qualifyingPv = useMemo(() => {
+    if (!fullUser) return personalPv;
+    return computeQualifyingPersonalPv(
+      fullUser.id,
+      users.map((u) => ({
+        id: u.id,
+        sponsorId: u.sponsorId,
+        currentRank: u.currentRank,
+        frozenAt: u.frozenAt,
+      })),
+      allBreakdowns,
+      (uid) => {
+        const u = users.find((x) => x.id === uid);
+        if (!u) return 0;
+        const ux = u as User & {
+          monthlyPvOverrideMonth?: string | null;
+          monthlyPvOverride?: number | null;
+        };
+        if (ux.monthlyPvOverrideMonth === month && typeof ux.monthlyPvOverride === "number") {
+          return ux.monthlyPvOverride;
+        }
+        return 0;
+      },
+    );
+  }, [fullUser, users, allBreakdowns, month, personalPv]);
+
+  const progression = useMemo(
+    () => rankProgression(fullUser?.currentRank, personalPv, qualifyingPv),
+    [fullUser?.currentRank, personalPv, qualifyingPv],
+  );
+
+  if (!progression) return null;
+
+  return (
+    <AdminCard style={{ marginTop: 12 }}>
+      <div
+        style={{
+          fontSize: 12,
+          fontWeight: 700,
+          color: "var(--ls-text)",
+          letterSpacing: 0.3,
+          marginBottom: 4,
+        }}
+      >
+        📈 Progression · {progression.currentLabel} → {progression.nextLabel}
+      </div>
+      <div style={hintStyle}>
+        {progression.pct >= 100
+          ? `🎉 Seuil atteint ! ${progression.pvCurrent.toLocaleString("fr-FR")} / ${progression.pvNeeded.toLocaleString("fr-FR")} PV`
+          : `${progression.pvCurrent.toLocaleString("fr-FR")} / ${progression.pvNeeded.toLocaleString("fr-FR")} PV · reste ${progression.remaining.toLocaleString("fr-FR")} PV`}
+        <span
+          style={{
+            display: "inline-block",
+            marginLeft: 6,
+            padding: "1px 6px",
+            borderRadius: 5,
+            fontSize: 9,
+            fontWeight: 700,
+            background: "color-mix(in srgb, var(--ls-teal) 14%, transparent)",
+            color: "var(--ls-teal)",
+            textTransform: "uppercase",
+            letterSpacing: 0.4,
+          }}
+        >
+          {progression.pvSource === "personal_extended"
+            ? "PV perso · ventes directes + downline non-Sup"
+            : "PV perso · ventes directes"}
+        </span>
+      </div>
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          height: 10,
+          borderRadius: 999,
+          background: "color-mix(in srgb, var(--ls-text) 8%, transparent)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            height: "100%",
+            width: `${progression.pct}%`,
+            background:
+              progression.pct >= 100
+                ? "linear-gradient(90deg, #10B981 0%, #06B6D4 50%, #8B5CF6 100%)"
+                : progression.pct >= 75
+                  ? "linear-gradient(90deg, #10B981 0%, #06B6D4 100%)"
+                  : "var(--ls-teal)",
+            transition: "width 0.4s ease",
+          }}
+        />
+      </div>
+    </AdminCard>
+  );
+}

--- a/src/components/distributor-blocks/PvBizworksBlock.tsx
+++ b/src/components/distributor-blocks/PvBizworksBlock.tsx
@@ -1,0 +1,246 @@
+// =============================================================================
+// PvBizworksBlock — saisie admin du PV Bizworks par tier de remise downline
+// =============================================================================
+// Extrait de TeamMemberDrilldownModal (Chantier #13 sous-vague A.1, 2026-05-18).
+// 5 inputs : PV15 / PV25 (toggle VIP) / PV35 (toggle VIP) / PV42 / PV Royalty.
+// Total live + override estim. EUR. Tout a 0 = clear (calcul auto via commandes).
+// =============================================================================
+
+import { useEffect, useMemo, useState } from "react";
+import { useToast, buildSupabaseErrorToast } from "../../context/ToastContext";
+import { usePvBreakdowns } from "../../hooks/usePvBreakdowns";
+import {
+  COMMISSION_PCT_BY_TIER,
+  PV_TO_EUR_RATIO,
+  ROYALTY_OVERRIDE_PCT,
+  computeOverrideEur,
+  currentMonthIso,
+  emptyBreakdown,
+  totalPvFromBreakdown,
+  type PvMonthlyBreakdown,
+} from "../../lib/herbalifeFormulas";
+import { setUserPvBreakdown } from "../../services/supabaseService";
+import { AdminCard, hintStyle, PvTierRow } from "./_shared";
+
+interface Props {
+  memberId: string;
+  memberName: string;
+  /** ISO YYYY-MM, default = mois en cours. */
+  monthIso?: string;
+  onApplied?: () => void | Promise<void>;
+}
+
+export function PvBizworksBlock({ memberId, memberName, monthIso, onApplied }: Props) {
+  const { push: pushToast } = useToast();
+  const month = monthIso ?? currentMonthIso();
+  const { getForUser, refetch } = usePvBreakdowns(month);
+  const existingBreakdown = getForUser(memberId);
+
+  const [pvDraft, setPvDraft] = useState({
+    pv15: "",
+    pv25: "",
+    pv35: "",
+    pv42: "",
+    pvRoyalty: "",
+    pv25IsVip: false,
+    pv35IsVip: false,
+  });
+  const [saving, setSaving] = useState(false);
+
+  // Hydrate inputs quand le breakdown est fetched
+  useEffect(() => {
+    if (existingBreakdown) {
+      setPvDraft({
+        pv15: existingBreakdown.pv15 ? String(existingBreakdown.pv15) : "",
+        pv25: existingBreakdown.pv25 ? String(existingBreakdown.pv25) : "",
+        pv35: existingBreakdown.pv35 ? String(existingBreakdown.pv35) : "",
+        pv42: existingBreakdown.pv42 ? String(existingBreakdown.pv42) : "",
+        pvRoyalty: existingBreakdown.pvRoyalty ? String(existingBreakdown.pvRoyalty) : "",
+        pv25IsVip: existingBreakdown.pv25IsVip,
+        pv35IsVip: existingBreakdown.pv35IsVip,
+      });
+    }
+  }, [existingBreakdown?.userId, existingBreakdown?.month, existingBreakdown]);
+
+  const draftBreakdown = useMemo<PvMonthlyBreakdown>(() => {
+    const parse = (s: string) => {
+      const n = Number(s.replace(",", "."));
+      return Number.isFinite(n) && n >= 0 ? n : 0;
+    };
+    return {
+      ...emptyBreakdown(memberId, month),
+      pv15: parse(pvDraft.pv15),
+      pv25: parse(pvDraft.pv25),
+      pv35: parse(pvDraft.pv35),
+      pv42: parse(pvDraft.pv42),
+      pvRoyalty: parse(pvDraft.pvRoyalty),
+      pv25IsVip: pvDraft.pv25IsVip,
+      pv35IsVip: pvDraft.pv35IsVip,
+    };
+  }, [pvDraft, memberId, month]);
+
+  const draftTotalPv = totalPvFromBreakdown(draftBreakdown);
+  const draftOverrideEur = computeOverrideEur(draftBreakdown);
+
+  async function handleSave() {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await setUserPvBreakdown({
+        userId: memberId,
+        month,
+        pv15: draftBreakdown.pv15,
+        pv25: draftBreakdown.pv25,
+        pv35: draftBreakdown.pv35,
+        pv42: draftBreakdown.pv42,
+        pvRoyalty: draftBreakdown.pvRoyalty,
+        pv25IsVip: draftBreakdown.pv25IsVip,
+        pv35IsVip: draftBreakdown.pv35IsVip,
+      });
+      const isCleared = draftTotalPv === 0;
+      pushToast({
+        tone: "success",
+        title: isCleared ? "Breakdown efface" : "PV Bizworks enregistres",
+        message: isCleared
+          ? `${memberName} → calcul auto (commandes app)`
+          : `${memberName} → ${draftTotalPv.toLocaleString("fr-FR")} PV · override estim. ${Math.round(draftOverrideEur).toLocaleString("fr-FR")} €`,
+      });
+      await refetch();
+      await onApplied?.();
+    } catch (err) {
+      pushToast(buildSupabaseErrorToast(err, "Impossible d'enregistrer le PV."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <AdminCard highlighted={!!existingBreakdown} style={{ marginTop: 12 }}>
+      <div
+        style={{
+          fontSize: 12,
+          fontWeight: 700,
+          color: "var(--ls-text)",
+          letterSpacing: 0.3,
+          marginBottom: 4,
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          flexWrap: "wrap",
+        }}
+      >
+        <span>📊 PV Bizworks · {month} · breakdown par tier</span>
+        {existingBreakdown ? (
+          <span
+            style={{
+              fontSize: 10,
+              padding: "2px 6px",
+              borderRadius: 6,
+              background: "color-mix(in srgb, var(--ls-teal) 18%, transparent)",
+              color: "var(--ls-teal)",
+              textTransform: "uppercase",
+              letterSpacing: 0.5,
+            }}
+          >
+            Saisi
+          </span>
+        ) : null}
+      </div>
+      <div style={hintStyle}>
+        Transcris depuis ta fiche RO Herbalife le PV de {memberName} par palier.
+        Mid-month rank-up : si le distri etait a 25% puis a 35%, repartis. Tout a 0 = clear.
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 10 }}>
+        <PvTierRow
+          label="PV à 15% (Préféré VIP)"
+          tip={`commission toi : ${Math.round(COMMISSION_PCT_BY_TIER.pv15 * 100)}%`}
+          value={pvDraft.pv15}
+          onChange={(v) => setPvDraft({ ...pvDraft, pv15: v })}
+        />
+        <PvTierRow
+          label={pvDraft.pv25IsVip ? "PV à 25% (Silver VIP)" : "PV à 25% (Distributor)"}
+          tip={`commission toi : ${Math.round(COMMISSION_PCT_BY_TIER.pv25 * 100)}% · ⭐ pour basculer VIP/Distri`}
+          value={pvDraft.pv25}
+          onChange={(v) => setPvDraft({ ...pvDraft, pv25: v })}
+          vipFlag={pvDraft.pv25IsVip}
+          onToggleVip={() => setPvDraft({ ...pvDraft, pv25IsVip: !pvDraft.pv25IsVip })}
+        />
+        <PvTierRow
+          label={pvDraft.pv35IsVip ? "PV à 35% (Gold VIP)" : "PV à 35% (Senior Consultant)"}
+          tip={`commission toi : ${Math.round(COMMISSION_PCT_BY_TIER.pv35 * 100)}% · ⭐ pour basculer VIP/Distri`}
+          value={pvDraft.pv35}
+          onChange={(v) => setPvDraft({ ...pvDraft, pv35: v })}
+          vipFlag={pvDraft.pv35IsVip}
+          onToggleVip={() => setPvDraft({ ...pvDraft, pv35IsVip: !pvDraft.pv35IsVip })}
+        />
+        <PvTierRow
+          label="PV à 42% (Success Builder)"
+          tip={`commission toi : ${Math.round(COMMISSION_PCT_BY_TIER.pv42 * 100)}%`}
+          value={pvDraft.pv42}
+          onChange={(v) => setPvDraft({ ...pvDraft, pv42: v })}
+        />
+        <PvTierRow
+          label="PV Royalty (downline Supervisor 50%)"
+          tip={`royalty toi : ${Math.round(ROYALTY_OVERRIDE_PCT * 100)}%`}
+          value={pvDraft.pvRoyalty}
+          onChange={(v) => setPvDraft({ ...pvDraft, pvRoyalty: v })}
+        />
+      </div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          padding: "8px 10px",
+          borderRadius: 8,
+          background: "var(--ls-surface)",
+          marginBottom: 10,
+          fontSize: 12,
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <span style={{ color: "var(--ls-text-muted)" }}>
+          Total :{" "}
+          <strong style={{ color: "var(--ls-text)" }}>
+            {draftTotalPv.toLocaleString("fr-FR")} PV
+          </strong>
+        </span>
+        <span style={{ color: "var(--ls-teal)", fontWeight: 700 }}>
+          Override estim. ~{Math.round(draftOverrideEur).toLocaleString("fr-FR")} €
+        </span>
+      </div>
+      <div
+        style={{
+          fontSize: 10,
+          color: "var(--ls-text-muted)",
+          fontStyle: "italic",
+          marginBottom: 8,
+        }}
+      >
+        Ratio {PV_TO_EUR_RATIO} €/PV (calibre fiche RO 2026-03)
+      </div>
+      <button
+        type="button"
+        onClick={() => void handleSave()}
+        disabled={saving}
+        style={{
+          width: "100%",
+          padding: "9px 14px",
+          borderRadius: 10,
+          border: "none",
+          background: saving
+            ? "var(--ls-surface2)"
+            : "linear-gradient(135deg, #10B981 0%, #06B6D4 50%, #8B5CF6 100%)",
+          color: saving ? "var(--ls-text-muted)" : "#FFFFFF",
+          fontSize: 12,
+          fontWeight: 700,
+          fontFamily: "Sora, system-ui, sans-serif",
+          cursor: saving ? "wait" : "pointer",
+        }}
+      >
+        {saving ? "…" : "Appliquer"}
+      </button>
+    </AdminCard>
+  );
+}

--- a/src/components/distributor-blocks/RangHerbalifeBlock.tsx
+++ b/src/components/distributor-blocks/RangHerbalifeBlock.tsx
@@ -1,0 +1,88 @@
+// =============================================================================
+// RangHerbalifeBlock — admin edition du rang Herbalife (12 paliers)
+// =============================================================================
+// Extrait de TeamMemberDrilldownModal (Chantier #13 sous-vague A.1, 2026-05-18).
+// =============================================================================
+
+import { useState } from "react";
+import { useToast, buildSupabaseErrorToast } from "../../context/ToastContext";
+import { setUserRankAdmin } from "../../services/supabaseService";
+import {
+  RANK_LABELS,
+  RANK_ORDER,
+  type HerbalifeRank,
+  type User,
+} from "../../types/domain";
+import { AdminCard, hintStyle, labelStyle, PrimaryActionButton } from "./_shared";
+
+interface Props {
+  memberId: string;
+  memberName: string;
+  fullUser: User | null;
+  onApplied?: () => void | Promise<void>;
+}
+
+export function RangHerbalifeBlock({ memberId, memberName, fullUser, onApplied }: Props) {
+  const { push: pushToast } = useToast();
+  const [rankDraft, setRankDraft] = useState<HerbalifeRank>(
+    (fullUser?.currentRank as HerbalifeRank | undefined) ?? "distributor_25",
+  );
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await setUserRankAdmin(memberId, rankDraft);
+      pushToast({
+        tone: "success",
+        title: "Rang mis a jour",
+        message: `${memberName} → ${RANK_LABELS[rankDraft]}`,
+      });
+      await onApplied?.();
+    } catch (err) {
+      pushToast(buildSupabaseErrorToast(err, "Impossible de mettre a jour le rang."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <AdminCard style={{ marginTop: 18 }}>
+      <div style={labelStyle}>🎖️ Rang Herbalife</div>
+      <div style={hintStyle}>
+        Ajuste le rang si le distri ne l'a pas fait lui-meme. Determine la marge retail
+        dans les calculs FLEX / Rentabilite.
+      </div>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <select
+          value={rankDraft}
+          onChange={(e) => setRankDraft(e.target.value as HerbalifeRank)}
+          style={{
+            flex: "1 1 200px",
+            padding: "9px 12px",
+            borderRadius: 10,
+            border: "1px solid var(--ls-border)",
+            background: "var(--ls-surface)",
+            color: "var(--ls-text)",
+            fontSize: 13,
+            fontFamily: "Inter, system-ui, sans-serif",
+            cursor: "pointer",
+          }}
+        >
+          {RANK_ORDER.map((r) => (
+            <option key={r} value={r}>
+              {RANK_LABELS[r]}
+            </option>
+          ))}
+        </select>
+        <PrimaryActionButton
+          label="Appliquer"
+          onClick={() => void handleSave()}
+          busy={saving}
+          disabled={rankDraft === fullUser?.currentRank}
+        />
+      </div>
+    </AdminCard>
+  );
+}

--- a/src/components/distributor-blocks/_shared.tsx
+++ b/src/components/distributor-blocks/_shared.tsx
@@ -1,0 +1,340 @@
+// =============================================================================
+// distributor-blocks / _shared — primitives + styles reutilisables
+// =============================================================================
+// Extrait de TeamMemberDrilldownModal (Chantier #13 sous-vague A.1, 2026-05-18).
+// Ces primitives sont utilisees par tous les blocs distri partages entre la
+// modale drill-down (/team) et la page enrichie (/distributors/:id).
+// =============================================================================
+
+import type { CSSProperties, ReactNode } from "react";
+
+// ─── Section title (h3 Syne) ──────────────────────────────────────────────────
+export function SectionTitle({ children }: { children: ReactNode }) {
+  return <h3 style={sectionTitleStyle}>{children}</h3>;
+}
+
+// ─── Breakdown row (XP card) ─────────────────────────────────────────────────
+export function BreakdownRow({
+  emoji,
+  label,
+  value,
+}: {
+  emoji: string;
+  label: string;
+  value: number;
+}) {
+  return (
+    <div style={breakdownRowStyle}>
+      <span style={{ fontSize: 14 }} aria-hidden="true">
+        {emoji}
+      </span>
+      <span
+        style={{
+          fontSize: 11,
+          color: "var(--ls-text-muted)",
+          textTransform: "uppercase",
+          letterSpacing: 0.5,
+          flex: 1,
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          fontFamily: "Syne, sans-serif",
+          fontSize: 13,
+          fontWeight: 700,
+          color: "var(--ls-text)",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ─── Metric card (Apprentissage / Activite / Engagement) ─────────────────────
+export function MetricCard({
+  title,
+  primary,
+  secondary,
+  color,
+  badge,
+}: {
+  title: string;
+  primary: string;
+  secondary?: string;
+  color: string;
+  badge?: string;
+}) {
+  return (
+    <div style={metricCardStyle(color)}>
+      <div
+        style={{
+          fontSize: 10,
+          color: "var(--ls-text-muted)",
+          textTransform: "uppercase",
+          letterSpacing: 0.6,
+          marginBottom: 4,
+        }}
+      >
+        {title}
+      </div>
+      <div
+        style={{
+          fontFamily: "Syne, sans-serif",
+          fontSize: 18,
+          fontWeight: 700,
+          color: "var(--ls-text)",
+        }}
+      >
+        {primary}
+      </div>
+      {secondary && (
+        <div style={{ fontSize: 11, color: "var(--ls-text-muted)", marginTop: 2 }}>
+          {secondary}
+        </div>
+      )}
+      {badge && <div style={badgeStyle(color)}>{badge}</div>}
+    </div>
+  );
+}
+
+// ─── PV tier row (bloc PV Bizworks, input + star toggle VIP optionnel) ──────
+export function PvTierRow({
+  label,
+  tip,
+  value,
+  onChange,
+  vipFlag,
+  onToggleVip,
+}: {
+  label: string;
+  tip: string;
+  value: string;
+  onChange: (v: string) => void;
+  vipFlag?: boolean;
+  onToggleVip?: () => void;
+}) {
+  const hasToggle = typeof onToggleVip === "function";
+  return (
+    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+      {hasToggle ? (
+        <button
+          type="button"
+          onClick={onToggleVip}
+          aria-label={
+            vipFlag
+              ? "VIP — clique pour passer en Distri"
+              : "Distri — clique pour passer en VIP"
+          }
+          title={
+            vipFlag
+              ? "VIP — clique pour passer en Distri"
+              : "Distri — clique pour passer en VIP"
+          }
+          style={{
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            fontSize: 16,
+            padding: 0,
+            width: 22,
+            opacity: vipFlag ? 1 : 0.4,
+            color: vipFlag ? "var(--ls-gold)" : "var(--ls-text-muted)",
+          }}
+        >
+          {vipFlag ? "⭐" : "☆"}
+        </button>
+      ) : (
+        <span style={{ width: 22 }} />
+      )}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontSize: 11,
+            color: "var(--ls-text)",
+            fontFamily: "Inter, system-ui, sans-serif",
+            fontWeight: 500,
+          }}
+        >
+          {label}
+        </div>
+        <div style={{ fontSize: 10, color: "var(--ls-text-muted)" }}>{tip}</div>
+      </div>
+      <input
+        type="number"
+        inputMode="decimal"
+        min={0}
+        step="0.01"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="0"
+        style={{
+          width: 90,
+          padding: "7px 10px",
+          borderRadius: 8,
+          border: "1px solid var(--ls-border)",
+          background: "var(--ls-surface)",
+          color: "var(--ls-text)",
+          fontSize: 13,
+          fontFamily: "Inter, system-ui, sans-serif",
+          textAlign: "right",
+        }}
+      />
+    </div>
+  );
+}
+
+// ─── Helpers format ──────────────────────────────────────────────────────────
+export function formatRelativeFR(iso: string | null): string {
+  if (!iso) return "Jamais connecté";
+  try {
+    const d = new Date(iso);
+    const diffMs = Date.now() - d.getTime();
+    const days = Math.floor(diffMs / (24 * 3600 * 1000));
+    if (days === 0) return "Aujourd'hui";
+    if (days === 1) return "Hier";
+    if (days < 7) return `Il y a ${days} jours`;
+    if (days < 30) return `Il y a ${Math.floor(days / 7)} semaines`;
+    if (days < 365) return `Il y a ${Math.floor(days / 30)} mois`;
+    return `Il y a ${Math.floor(days / 365)} an(s)`;
+  } catch {
+    return "—";
+  }
+}
+
+// ─── Brand gradient action button (réutilisé Rang / PV) ──────────────────────
+export function PrimaryActionButton({
+  label,
+  onClick,
+  disabled,
+  busy,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  busy?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || busy}
+      style={{
+        padding: "9px 14px",
+        borderRadius: 10,
+        border: "none",
+        background:
+          busy || disabled
+            ? "var(--ls-surface2)"
+            : "linear-gradient(135deg, #10B981 0%, #06B6D4 50%, #8B5CF6 100%)",
+        color: busy || disabled ? "var(--ls-text-muted)" : "#FFFFFF",
+        fontSize: 12,
+        fontWeight: 700,
+        fontFamily: "Sora, system-ui, sans-serif",
+        cursor: busy ? "wait" : disabled ? "default" : "pointer",
+      }}
+    >
+      {busy ? "…" : label}
+    </button>
+  );
+}
+
+// ─── Card admin standard (wrapper consistent) ────────────────────────────────
+export function AdminCard({
+  children,
+  highlighted,
+  style,
+}: {
+  children: ReactNode;
+  highlighted?: boolean;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        padding: 14,
+        borderRadius: 12,
+        background: highlighted
+          ? "color-mix(in srgb, var(--ls-teal) 6%, var(--ls-surface2))"
+          : "var(--ls-surface2)",
+        border: highlighted
+          ? "1px solid color-mix(in srgb, var(--ls-teal) 30%, transparent)"
+          : "1px solid var(--ls-border)",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ─── Styles partages ─────────────────────────────────────────────────────────
+const sectionTitleStyle: CSSProperties = {
+  margin: "0 0 10px",
+  fontFamily: "Syne, sans-serif",
+  fontSize: 14,
+  fontWeight: 700,
+  color: "var(--ls-text)",
+};
+
+const breakdownRowStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  padding: "6px 8px",
+  borderRadius: 8,
+  background: "var(--ls-surface)",
+  border: "0.5px solid var(--ls-border)",
+};
+
+const metricCardStyle = (color: string): CSSProperties => ({
+  position: "relative",
+  background: `color-mix(in srgb, ${color} 6%, var(--ls-surface))`,
+  border: `0.5px solid ${color}`,
+  borderRadius: 12,
+  padding: "12px 14px",
+});
+
+const badgeStyle = (color: string): CSSProperties => ({
+  display: "inline-block",
+  marginTop: 6,
+  fontSize: 9,
+  padding: "2px 6px",
+  borderRadius: 6,
+  background: `color-mix(in srgb, ${color} 14%, transparent)`,
+  color,
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: 0.5,
+});
+
+export const twoColGridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "1fr 1fr",
+  gap: 10,
+  marginBottom: 18,
+};
+
+export const threeColGridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "1fr 1fr 1fr",
+  gap: 8,
+  marginBottom: 18,
+};
+
+export const labelStyle: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 700,
+  color: "var(--ls-text)",
+  letterSpacing: 0.3,
+  marginBottom: 4,
+};
+
+export const hintStyle: CSSProperties = {
+  fontSize: 11,
+  color: "var(--ls-text-muted)",
+  lineHeight: 1.4,
+  marginBottom: 10,
+};

--- a/src/components/distributor-blocks/index.ts
+++ b/src/components/distributor-blocks/index.ts
@@ -1,0 +1,26 @@
+// =============================================================================
+// distributor-blocks — exports partages entre TeamMemberDrilldownModal
+// et la page enrichie /distributors/:id (Chantier #13, 2026-05-18).
+// =============================================================================
+
+export { EngagementTotalBlock } from "./EngagementTotalBlock";
+export { ApprentissageBlock } from "./ApprentissageBlock";
+export { ActiviteRecenteBlock } from "./ActiviteRecenteBlock";
+export { EngagementBlock } from "./EngagementBlock";
+export { RangHerbalifeBlock } from "./RangHerbalifeBlock";
+export { ProgressionRangBlock } from "./ProgressionRangBlock";
+export { PvBizworksBlock } from "./PvBizworksBlock";
+export { CompteActifBlock } from "./CompteActifBlock";
+
+// Primitives partagees (utilisable si la page veut composer manuellement)
+export {
+  SectionTitle,
+  BreakdownRow,
+  MetricCard,
+  PvTierRow,
+  PrimaryActionButton,
+  AdminCard,
+  formatRelativeFR,
+  twoColGridStyle,
+  threeColGridStyle,
+} from "./_shared";

--- a/src/components/team/TeamMemberDrilldownModal.tsx
+++ b/src/components/team/TeamMemberDrilldownModal.tsx
@@ -1,45 +1,30 @@
 // =============================================================================
-// TeamMemberDrilldownModal — vue détail d'un membre (2026-05-04)
+// TeamMemberDrilldownModal — vue détail d'un membre (refactor Chantier #13)
 //
 // Modale plein écran (mobile) / centrée (desktop) qui affiche TOUTES les
-// métriques d'un seul membre sur 1 vue : XP breakdown + Academy +
-// Formation pyramide + Activité 7-30j + Engagement (last_seen, streak).
-// CTA vers la fiche distri complète (DistributorPortfolioPage).
+// métriques d'un seul membre. Depuis 2026-05-18 : compose les blocs partages
+// distributor-blocks/ (reutilises egalement dans /distributors/:id enrichie).
+//
+// CTA vers la fiche distri complete (DistributorPortfolioPage).
 // =============================================================================
 
-import { useMemo, useState } from "react";
+import type { CSSProperties } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   STATUS_META,
   type TeamMemberEngagement,
 } from "../../hooks/useTeamEngagement";
 import { useAppContext } from "../../context/AppContext";
-import { useToast, buildSupabaseErrorToast } from "../../context/ToastContext";
 import {
-  freezeUserAccount,
-  unfreezeUserAccount,
-  setUserPvBreakdown,
-  setUserRankAdmin,
-} from "../../services/supabaseService";
-import {
-  RANK_LABELS,
-  RANK_ORDER,
-  type HerbalifeRank,
-  type User,
-} from "../../types/domain";
-import {
-  COMMISSION_PCT_BY_TIER,
-  PV_TO_EUR_RATIO,
-  ROYALTY_OVERRIDE_PCT,
-  computeQualifyingPersonalPv,
-  computeOverrideEur,
-  currentMonthIso,
-  emptyBreakdown,
-  rankProgression,
-  totalPvFromBreakdown,
-  type PvMonthlyBreakdown,
-} from "../../lib/herbalifeFormulas";
-import { usePvBreakdowns } from "../../hooks/usePvBreakdowns";
+  ActiviteRecenteBlock,
+  ApprentissageBlock,
+  CompteActifBlock,
+  EngagementBlock,
+  EngagementTotalBlock,
+  ProgressionRangBlock,
+  PvBizworksBlock,
+  RangHerbalifeBlock,
+} from "../distributor-blocks";
 
 interface TeamMemberDrilldownModalProps {
   member: TeamMemberEngagement | null;
@@ -53,240 +38,32 @@ function initialsOf(name: string): string {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
-function formatRelative(iso: string | null): string {
-  if (!iso) return "Jamais connecté";
-  try {
-    const d = new Date(iso);
-    const diffMs = Date.now() - d.getTime();
-    const days = Math.floor(diffMs / (24 * 3600 * 1000));
-    if (days === 0) return "Aujourd'hui";
-    if (days === 1) return "Hier";
-    if (days < 7) return `Il y a ${days} jours`;
-    if (days < 30) return `Il y a ${Math.floor(days / 7)} semaines`;
-    if (days < 365) return `Il y a ${Math.floor(days / 30)} mois`;
-    return `Il y a ${Math.floor(days / 365)} an(s)`;
-  } catch {
-    return "—";
-  }
-}
-
 export function TeamMemberDrilldownModal({ member, onClose }: TeamMemberDrilldownModalProps) {
   const navigate = useNavigate();
   const { currentUser, users, refreshAfterFreeze } = useAppContext();
-  const { push: pushToast } = useToast();
-  const [freezing, setFreezing] = useState(false);
-
-  // ─── Lookup full user (depuis context.users) ───────────────────────────────
-  // Doit etre AVANT tout return conditionnel — sinon les hooks suivants
-  // (useState, useMemo) violent les regles React si member est null.
-  const fullUser = users.find((u) => u.id === member?.user_id) ?? null;
-
-  // ─── Edit Rang Herbalife (admin only, chantier 2026-11-07) ────────────────
-  const [rankDraft, setRankDraft] = useState<HerbalifeRank>(
-    (fullUser?.currentRank as HerbalifeRank | undefined) ?? "distributor_25",
-  );
-  const [savingRank, setSavingRank] = useState(false);
-
-  // ─── Edit PV breakdown V2 (admin only, chantier 2026-11-07) ──────────────
-  // Remplace l'ancien input unique par 5 inputs par tier de remise downline.
-  // Le RPC sync automatiquement users.monthly_pv_override = somme.
-  const monthIso = useMemo(() => currentMonthIso(), []);
-  const { getForUser: getBreakdownForUser, refetch: refetchBreakdowns } =
-    usePvBreakdowns(monthIso);
-  const existingBreakdown = member ? getBreakdownForUser(member.user_id) : null;
-  const [pvDraft, setPvDraft] = useState<{
-    pv15: string; pv25: string; pv35: string; pv42: string; pvRoyalty: string;
-    pv25IsVip: boolean; pv35IsVip: boolean;
-  }>({ pv15: "", pv25: "", pv35: "", pv42: "", pvRoyalty: "", pv25IsVip: false, pv35IsVip: false });
-  const [savingPv, setSavingPv] = useState(false);
-
-  // Hydrate les inputs quand le breakdown arrive (fetch async).
-  useMemo(() => {
-    if (existingBreakdown) {
-      setPvDraft({
-        pv15: existingBreakdown.pv15 ? String(existingBreakdown.pv15) : "",
-        pv25: existingBreakdown.pv25 ? String(existingBreakdown.pv25) : "",
-        pv35: existingBreakdown.pv35 ? String(existingBreakdown.pv35) : "",
-        pv42: existingBreakdown.pv42 ? String(existingBreakdown.pv42) : "",
-        pvRoyalty: existingBreakdown.pvRoyalty ? String(existingBreakdown.pvRoyalty) : "",
-        pv25IsVip: existingBreakdown.pv25IsVip,
-        pv35IsVip: existingBreakdown.pv35IsVip,
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [existingBreakdown?.userId, existingBreakdown?.month]);
-
-  // Calcul live du total + override estime depuis les inputs
-  const draftBreakdown = useMemo<PvMonthlyBreakdown>(() => {
-    const parse = (s: string) => {
-      const n = Number(s.replace(",", "."));
-      return Number.isFinite(n) && n >= 0 ? n : 0;
-    };
-    return {
-      ...(member ? emptyBreakdown(member.user_id, monthIso) : emptyBreakdown("", monthIso)),
-      pv15: parse(pvDraft.pv15),
-      pv25: parse(pvDraft.pv25),
-      pv35: parse(pvDraft.pv35),
-      pv42: parse(pvDraft.pv42),
-      pvRoyalty: parse(pvDraft.pvRoyalty),
-      pv25IsVip: pvDraft.pv25IsVip,
-      pv35IsVip: pvDraft.pv35IsVip,
-    };
-  }, [pvDraft, member, monthIso]);
-  const draftTotalPv = totalPvFromBreakdown(draftBreakdown);
-  const draftOverrideEur = computeOverrideEur(draftBreakdown);
-
-  // Jauge progression vers prochain rang (chantier 2026-11-07)
-  // PV perso = somme breakdown courant ou monthly_pv_override
-  const personalPvForProgress = useMemo(() => {
-    if (existingBreakdown) return totalPvFromBreakdown(existingBreakdown);
-    if (
-      (fullUser as User & { monthlyPvOverrideMonth?: string | null })?.monthlyPvOverrideMonth ===
-        monthIso &&
-      typeof (fullUser as User & { monthlyPvOverride?: number | null })?.monthlyPvOverride ===
-        "number"
-    ) {
-      return (fullUser as User & { monthlyPvOverride?: number | null }).monthlyPvOverride as number;
-    }
-    return 0;
-  }, [existingBreakdown, fullUser, monthIso]);
-  // PV qualifiant = perso + downline NON-Supervisor (recursif).
-  // Tant que personne dans la chaine downstream n'est Supervisor, leurs PV
-  // comptent comme PV perso du sponsor (regle Herbalife : qualif Supervisor
-  // 4000 PV). Une branche s'arrete des qu'on rencontre un Supervisor 50%+
-  // (sa branche bascule en Royalty pour les paliers superieurs).
-  const { breakdowns: allBreakdowns } = usePvBreakdowns(monthIso);
-  const qualifyingPersonalPv = useMemo(() => {
-    if (!fullUser) return personalPvForProgress;
-    return computeQualifyingPersonalPv(
-      fullUser.id,
-      users.map((u) => ({
-        id: u.id,
-        sponsorId: u.sponsorId,
-        currentRank: u.currentRank,
-        frozenAt: u.frozenAt,
-      })),
-      allBreakdowns,
-      (uid) => {
-        const u = users.find((x) => x.id === uid);
-        if (!u) return 0;
-        const ux = u as User & {
-          monthlyPvOverrideMonth?: string | null;
-          monthlyPvOverride?: number | null;
-        };
-        if (ux.monthlyPvOverrideMonth === monthIso && typeof ux.monthlyPvOverride === "number") {
-          return ux.monthlyPvOverride;
-        }
-        return 0;
-      },
-    );
-  }, [fullUser, users, allBreakdowns, monthIso, personalPvForProgress]);
-  const progression = useMemo(
-    () => rankProgression(fullUser?.currentRank, personalPvForProgress, qualifyingPersonalPv),
-    [fullUser?.currentRank, personalPvForProgress, qualifyingPersonalPv],
-  );
 
   if (!member) return null;
+
+  const fullUser = users.find((u) => u.id === member.user_id) ?? null;
   const status = STATUS_META[member.status];
 
-  // engagement RPC ne renvoie pas frozenAt (et de toute facon les frozen
-  // sont exclus du sub_tree, donc si on les voit ici c'est qu'ils sont actifs).
-  const isFrozen = !!fullUser?.frozenAt;
   const isAdmin = currentUser?.role === "admin";
   const isSelf = currentUser?.id === member.user_id;
   const canToggleFreeze = isAdmin && !isSelf;
   const canEditRankPv = isAdmin && !isSelf;
-
-  async function handleSaveRank() {
-    if (!member || savingRank) return;
-    setSavingRank(true);
-    try {
-      await setUserRankAdmin(member.user_id, rankDraft);
-      pushToast({
-        tone: "success",
-        title: "Rang mis a jour",
-        message: `${member.name} → ${RANK_LABELS[rankDraft]}`,
-      });
-      await refreshAfterFreeze?.();
-    } catch (err) {
-      pushToast(buildSupabaseErrorToast(err, "Impossible de mettre a jour le rang."));
-    } finally {
-      setSavingRank(false);
-    }
-  }
-
-  async function handleSavePv() {
-    if (!member || savingPv) return;
-    setSavingPv(true);
-    try {
-      await setUserPvBreakdown({
-        userId: member.user_id,
-        month: monthIso,
-        pv15: draftBreakdown.pv15,
-        pv25: draftBreakdown.pv25,
-        pv35: draftBreakdown.pv35,
-        pv42: draftBreakdown.pv42,
-        pvRoyalty: draftBreakdown.pvRoyalty,
-        pv25IsVip: draftBreakdown.pv25IsVip,
-        pv35IsVip: draftBreakdown.pv35IsVip,
-      });
-      const isCleared = draftTotalPv === 0;
-      pushToast({
-        tone: "success",
-        title: isCleared ? "Breakdown efface" : "PV Bizworks enregistres",
-        message: isCleared
-          ? `${member.name} → calcul auto (commandes app)`
-          : `${member.name} → ${draftTotalPv.toLocaleString("fr-FR")} PV · override estim. ${Math.round(draftOverrideEur).toLocaleString("fr-FR")} €`,
-      });
-      await refetchBreakdowns();
-      await refreshAfterFreeze?.();
-    } catch (err) {
-      pushToast(buildSupabaseErrorToast(err, "Impossible d'enregistrer le PV."));
-    } finally {
-      setSavingPv(false);
-    }
-  }
-
-  async function handleToggleFreeze() {
-    if (!member || freezing) return;
-    setFreezing(true);
-    try {
-      if (isFrozen) {
-        await unfreezeUserAccount(member.user_id);
-        pushToast({
-          tone: "success",
-          title: "Compte réactivé",
-          message: `${member.name} retrouve l'accès à l'app.`,
-        });
-      } else {
-        await freezeUserAccount({
-          userId: member.user_id,
-          reason: "Gelé manuellement par admin",
-        });
-        pushToast({
-          tone: "success",
-          title: "Compte gelé",
-          message: `${member.name} ne pourra plus accéder à l'app jusqu'à réactivation.`,
-        });
-      }
-      await refreshAfterFreeze?.();
-      onClose();
-    } catch (err) {
-      pushToast(buildSupabaseErrorToast(err, "Action impossible pour le moment."));
-    } finally {
-      setFreezing(false);
-    }
-  }
 
   const handleOpenFiche = () => {
     onClose();
     navigate(`/distributors/${member.user_id}`);
   };
 
+  const refresh = async () => {
+    await refreshAfterFreeze?.();
+  };
+
   return (
     <div style={overlayStyle} onClick={onClose} role="dialog" aria-modal="true">
       <div style={modalStyle} onClick={(e) => e.stopPropagation()}>
-        {/* Close */}
         <button type="button" onClick={onClose} style={closeBtnStyle} aria-label="Fermer">
           ×
         </button>
@@ -296,9 +73,21 @@ export function TeamMemberDrilldownModal({ member, onClose }: TeamMemberDrilldow
           <div style={avatarBigStyle}>{initialsOf(member.name)}</div>
           <div style={{ flex: 1, minWidth: 0 }}>
             <h2 style={nameStyle}>{member.name}</h2>
-            <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 6, flexWrap: "wrap" }}>
+            <div
+              style={{
+                display: "flex",
+                gap: 8,
+                alignItems: "center",
+                marginTop: 6,
+                flexWrap: "wrap",
+              }}
+            >
               <span style={subRoleStyle}>
-                {member.role === "admin" ? "Admin" : member.role === "referent" ? "Référent" : "Distributeur"}
+                {member.role === "admin"
+                  ? "Admin"
+                  : member.role === "referent"
+                    ? "Référent"
+                    : "Distributeur"}
                 {member.current_rank && ` · ${member.current_rank}`}
               </span>
               <span style={statusPillStyle(status.color)}>
@@ -309,443 +98,38 @@ export function TeamMemberDrilldownModal({ member, onClose }: TeamMemberDrilldow
           </div>
         </div>
 
-        {/* Big XP card */}
-        <div style={xpBigCardStyle}>
-          <div style={{ fontSize: 11, color: "var(--ls-text-muted)", textTransform: "uppercase", letterSpacing: 0.8 }}>
-            Engagement total
-          </div>
-          <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginTop: 4 }}>
-            <span style={xpTotalStyle}>{member.xp_total.toLocaleString("fr-FR")}</span>
-            <span style={{ fontSize: 13, color: "var(--ls-text-muted)" }}>XP</span>
-            <span style={levelBadgeStyle}>Niveau {member.xp_level}</span>
-          </div>
+        {/* Blocs partages */}
+        <EngagementTotalBlock member={member} />
+        <ApprentissageBlock member={member} />
+        <ActiviteRecenteBlock member={member} />
+        <EngagementBlock member={member} />
 
-          {/* Breakdown XP */}
-          <div style={breakdownGridStyle}>
-            <BreakdownRow emoji="🎓" label="Academy" value={member.xp_academy} />
-            <BreakdownRow emoji="📋" label="Bilans" value={member.xp_bilans} />
-            <BreakdownRow emoji="📅" label="RDV" value={member.xp_rdv} />
-            <BreakdownRow emoji="💬" label="Messages" value={member.xp_messages} />
-            <BreakdownRow emoji="📚" label="Formation" value={member.xp_formation} />
-            <BreakdownRow emoji="🔥" label="Connexions" value={member.xp_daily} />
-          </div>
-        </div>
+        {canEditRankPv && (
+          <>
+            <RangHerbalifeBlock
+              memberId={member.user_id}
+              memberName={member.name}
+              fullUser={fullUser}
+              onApplied={refresh}
+            />
+            <ProgressionRangBlock memberId={member.user_id} fullUser={fullUser} />
+            <PvBizworksBlock
+              memberId={member.user_id}
+              memberName={member.name}
+              onApplied={refresh}
+            />
+          </>
+        )}
 
-        {/* Section Apprentissage */}
-        <SectionTitle>🎓 Apprentissage</SectionTitle>
-        <div style={twoColGrid}>
-          <MetricCard
-            title="Academy"
-            primary={`${member.academy_step} / 12`}
-            secondary={`${member.academy_percent}% complété`}
-            color={member.academy_percent >= 100 ? "var(--ls-teal)" : "var(--ls-gold)"}
+        {canToggleFreeze && (
+          <CompteActifBlock
+            memberId={member.user_id}
+            memberName={member.name}
+            fullUser={fullUser}
+            onApplied={refresh}
+            onAfterToggle={onClose}
           />
-          <MetricCard
-            title="Formation"
-            primary={`${member.formation_total_validated} validés`}
-            secondary={`N1: ${member.formation_validated_n1} · N2: ${member.formation_validated_n2} · N3: ${member.formation_validated_n3}`}
-            color="var(--ls-purple)"
-            badge={member.formation_pending > 0 ? `${member.formation_pending} en attente` : undefined}
-          />
-        </div>
-
-        {/* Section Activité */}
-        <SectionTitle>📊 Activité récente</SectionTitle>
-        <div style={threeColGrid}>
-          <MetricCard
-            title="Bilans 30j"
-            primary={String(member.bilans_30d)}
-            secondary="initiaux créés"
-            color="var(--ls-teal)"
-          />
-          <MetricCard
-            title="RDV 30j"
-            primary={String(member.rdv_30d)}
-            secondary="follow-ups planifiés"
-            color="var(--ls-gold)"
-          />
-          <MetricCard
-            title="Messages 7j"
-            primary={String(member.messages_7d)}
-            secondary="envoyés aux clients"
-            color="var(--ls-coral)"
-          />
-        </div>
-
-        {/* Section Engagement */}
-        <SectionTitle>🔥 Engagement</SectionTitle>
-        <div style={twoColGrid}>
-          <MetricCard
-            title="Dernière connexion"
-            primary={formatRelative(member.last_seen_at)}
-            secondary={member.last_seen_at ? new Date(member.last_seen_at).toLocaleDateString("fr-FR") : "—"}
-            color="var(--ls-text-muted)"
-          />
-          <MetricCard
-            title="Connexions cumulées"
-            primary={String(member.lifetime_login_count)}
-            secondary={`${member.lifetime_login_count * 5} XP daily`}
-            color="var(--ls-coral)"
-          />
-        </div>
-
-        {/* Bloc admin : Rang Herbalife (chantier 2026-11-07) */}
-        {canEditRankPv ? (
-          <div
-            style={{
-              marginTop: 18,
-              padding: 14,
-              borderRadius: 12,
-              background: "var(--ls-surface2)",
-              border: "1px solid var(--ls-border)",
-            }}
-          >
-            <div
-              style={{
-                fontSize: 12,
-                fontWeight: 700,
-                color: "var(--ls-text)",
-                letterSpacing: 0.3,
-                marginBottom: 4,
-              }}
-            >
-              🎖️ Rang Herbalife
-            </div>
-            <div style={{ fontSize: 11, color: "var(--ls-text-muted)", lineHeight: 1.4, marginBottom: 10 }}>
-              Ajuste le rang si le distri ne l'a pas fait lui-meme. Determine la marge retail
-              dans les calculs FLEX / Rentabilite.
-            </div>
-            <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-              <select
-                value={rankDraft}
-                onChange={(e) => setRankDraft(e.target.value as HerbalifeRank)}
-                style={{
-                  flex: "1 1 200px",
-                  padding: "9px 12px",
-                  borderRadius: 10,
-                  border: "1px solid var(--ls-border)",
-                  background: "var(--ls-surface)",
-                  color: "var(--ls-text)",
-                  fontSize: 13,
-                  fontFamily: "Inter, system-ui, sans-serif",
-                  cursor: "pointer",
-                }}
-              >
-                {RANK_ORDER.map((r) => (
-                  <option key={r} value={r}>
-                    {RANK_LABELS[r]}
-                  </option>
-                ))}
-              </select>
-              <button
-                type="button"
-                onClick={() => void handleSaveRank()}
-                disabled={savingRank || rankDraft === fullUser?.currentRank}
-                style={{
-                  padding: "9px 14px",
-                  borderRadius: 10,
-                  border: "none",
-                  background:
-                    savingRank || rankDraft === fullUser?.currentRank
-                      ? "var(--ls-surface2)"
-                      : "linear-gradient(135deg, #10B981 0%, #06B6D4 50%, #8B5CF6 100%)",
-                  color:
-                    savingRank || rankDraft === fullUser?.currentRank
-                      ? "var(--ls-text-muted)"
-                      : "#FFFFFF",
-                  fontSize: 12,
-                  fontWeight: 700,
-                  fontFamily: "Sora, system-ui, sans-serif",
-                  cursor:
-                    savingRank || rankDraft === fullUser?.currentRank ? "default" : "pointer",
-                }}
-              >
-                {savingRank ? "…" : "Appliquer"}
-              </button>
-            </div>
-          </div>
-        ) : null}
-
-        {/* Bloc progression vers prochain rang (chantier 2026-11-07) */}
-        {canEditRankPv && progression ? (
-          <div
-            style={{
-              marginTop: 12,
-              padding: 14,
-              borderRadius: 12,
-              background: "var(--ls-surface2)",
-              border: "1px solid var(--ls-border)",
-            }}
-          >
-            <div
-              style={{
-                fontSize: 12,
-                fontWeight: 700,
-                color: "var(--ls-text)",
-                letterSpacing: 0.3,
-                marginBottom: 4,
-              }}
-            >
-              📈 Progression · {progression.currentLabel} → {progression.nextLabel}
-            </div>
-            <div style={{ fontSize: 11, color: "var(--ls-text-muted)", lineHeight: 1.4, marginBottom: 10 }}>
-              {progression.pct >= 100
-                ? `🎉 Seuil atteint ! ${progression.pvCurrent.toLocaleString("fr-FR")} / ${progression.pvNeeded.toLocaleString("fr-FR")} PV`
-                : `${progression.pvCurrent.toLocaleString("fr-FR")} / ${progression.pvNeeded.toLocaleString("fr-FR")} PV · reste ${progression.remaining.toLocaleString("fr-FR")} PV`}
-              <span style={{
-                display: "inline-block",
-                marginLeft: 6,
-                padding: "1px 6px",
-                borderRadius: 5,
-                fontSize: 9,
-                fontWeight: 700,
-                background: progression.pvSource === "personal_extended"
-                  ? "color-mix(in srgb, var(--ls-teal) 14%, transparent)"
-                  : "color-mix(in srgb, var(--ls-teal) 14%, transparent)",
-                color: "var(--ls-teal)",
-                textTransform: "uppercase",
-                letterSpacing: 0.4,
-              }}>
-                {progression.pvSource === "personal_extended"
-                  ? "PV perso · ventes directes + downline non-Sup"
-                  : "PV perso · ventes directes"}
-              </span>
-            </div>
-            <div
-              style={{
-                position: "relative",
-                width: "100%",
-                height: 10,
-                borderRadius: 999,
-                background: "color-mix(in srgb, var(--ls-text) 8%, transparent)",
-                overflow: "hidden",
-              }}
-            >
-              <div
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  height: "100%",
-                  width: `${progression.pct}%`,
-                  background: progression.pct >= 100
-                    ? "linear-gradient(90deg, #10B981 0%, #06B6D4 50%, #8B5CF6 100%)"
-                    : progression.pct >= 75
-                      ? "linear-gradient(90deg, #10B981 0%, #06B6D4 100%)"
-                      : "var(--ls-teal)",
-                  transition: "width 0.4s ease",
-                }}
-              />
-            </div>
-          </div>
-        ) : null}
-
-        {/* Bloc admin : PV breakdown V2 par tier (chantier RO 2026-11-07) */}
-        {canEditRankPv ? (
-          <div
-            style={{
-              marginTop: 12,
-              padding: 14,
-              borderRadius: 12,
-              background: existingBreakdown
-                ? "color-mix(in srgb, var(--ls-teal) 6%, var(--ls-surface2))"
-                : "var(--ls-surface2)",
-              border: existingBreakdown
-                ? "1px solid color-mix(in srgb, var(--ls-teal) 30%, transparent)"
-                : "1px solid var(--ls-border)",
-            }}
-          >
-            <div
-              style={{
-                fontSize: 12,
-                fontWeight: 700,
-                color: "var(--ls-text)",
-                letterSpacing: 0.3,
-                marginBottom: 4,
-                display: "flex",
-                alignItems: "center",
-                gap: 6,
-                flexWrap: "wrap",
-              }}
-            >
-              <span>📊 PV Bizworks · {monthIso} · breakdown par tier</span>
-              {existingBreakdown ? (
-                <span
-                  style={{
-                    fontSize: 10,
-                    padding: "2px 6px",
-                    borderRadius: 6,
-                    background: "color-mix(in srgb, var(--ls-teal) 18%, transparent)",
-                    color: "var(--ls-teal)",
-                    textTransform: "uppercase",
-                    letterSpacing: 0.5,
-                  }}
-                >
-                  Saisi
-                </span>
-              ) : null}
-            </div>
-            <div style={{ fontSize: 11, color: "var(--ls-text-muted)", lineHeight: 1.4, marginBottom: 10 }}>
-              Transcris depuis ta fiche RO Herbalife le PV de {member.name} par palier.
-              Mid-month rank-up : si le distri etait a 25% puis a 35%, repartis. Tout a 0 = clear.
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 10 }}>
-              <PvTierRow
-                label="PV à 15% (Préféré VIP)"
-                tip={`commission toi : ${Math.round(COMMISSION_PCT_BY_TIER.pv15 * 100)}%`}
-                value={pvDraft.pv15}
-                onChange={(v) => setPvDraft({ ...pvDraft, pv15: v })}
-              />
-              <PvTierRow
-                label={pvDraft.pv25IsVip ? "PV à 25% (Silver VIP)" : "PV à 25% (Distributor)"}
-                tip={`commission toi : ${Math.round(COMMISSION_PCT_BY_TIER.pv25 * 100)}% · ⭐ pour basculer VIP/Distri`}
-                value={pvDraft.pv25}
-                onChange={(v) => setPvDraft({ ...pvDraft, pv25: v })}
-                vipFlag={pvDraft.pv25IsVip}
-                onToggleVip={() => setPvDraft({ ...pvDraft, pv25IsVip: !pvDraft.pv25IsVip })}
-              />
-              <PvTierRow
-                label={pvDraft.pv35IsVip ? "PV à 35% (Gold VIP)" : "PV à 35% (Senior Consultant)"}
-                tip={`commission toi : ${Math.round(COMMISSION_PCT_BY_TIER.pv35 * 100)}% · ⭐ pour basculer VIP/Distri`}
-                value={pvDraft.pv35}
-                onChange={(v) => setPvDraft({ ...pvDraft, pv35: v })}
-                vipFlag={pvDraft.pv35IsVip}
-                onToggleVip={() => setPvDraft({ ...pvDraft, pv35IsVip: !pvDraft.pv35IsVip })}
-              />
-              <PvTierRow
-                label="PV à 42% (Success Builder)"
-                tip={`commission toi : ${Math.round(COMMISSION_PCT_BY_TIER.pv42 * 100)}%`}
-                value={pvDraft.pv42}
-                onChange={(v) => setPvDraft({ ...pvDraft, pv42: v })}
-              />
-              <PvTierRow
-                label="PV Royalty (downline Supervisor 50%)"
-                tip={`royalty toi : ${Math.round(ROYALTY_OVERRIDE_PCT * 100)}%`}
-                value={pvDraft.pvRoyalty}
-                onChange={(v) => setPvDraft({ ...pvDraft, pvRoyalty: v })}
-              />
-            </div>
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                padding: "8px 10px",
-                borderRadius: 8,
-                background: "var(--ls-surface)",
-                marginBottom: 10,
-                fontSize: 12,
-                gap: 12,
-                flexWrap: "wrap",
-              }}
-            >
-              <span style={{ color: "var(--ls-text-muted)" }}>
-                Total : <strong style={{ color: "var(--ls-text)" }}>{draftTotalPv.toLocaleString("fr-FR")} PV</strong>
-              </span>
-              <span style={{ color: "var(--ls-teal)", fontWeight: 700 }}>
-                Override estim. ~{Math.round(draftOverrideEur).toLocaleString("fr-FR")} €
-              </span>
-            </div>
-            <div style={{ fontSize: 10, color: "var(--ls-text-muted)", fontStyle: "italic", marginBottom: 8 }}>
-              Ratio {PV_TO_EUR_RATIO} €/PV (calibre fiche RO 2026-03)
-            </div>
-            <button
-              type="button"
-              onClick={() => void handleSavePv()}
-              disabled={savingPv}
-              style={{
-                width: "100%",
-                padding: "9px 14px",
-                borderRadius: 10,
-                border: "none",
-                background: savingPv
-                  ? "var(--ls-surface2)"
-                  : "linear-gradient(135deg, #10B981 0%, #06B6D4 50%, #8B5CF6 100%)",
-                color: savingPv ? "var(--ls-text-muted)" : "#FFFFFF",
-                fontSize: 12,
-                fontWeight: 700,
-                fontFamily: "Sora, system-ui, sans-serif",
-                cursor: savingPv ? "wait" : "pointer",
-              }}
-            >
-              {savingPv ? "…" : "Appliquer"}
-            </button>
-          </div>
-        ) : null}
-
-        {/* Bloc admin : toggle Geler / Reactiver le compte */}
-        {canToggleFreeze ? (
-          <div
-            style={{
-              marginTop: 18,
-              padding: 14,
-              borderRadius: 12,
-              background: isFrozen
-                ? "color-mix(in srgb, var(--ls-coral) 8%, var(--ls-surface2))"
-                : "var(--ls-surface2)",
-              border: isFrozen
-                ? "1px solid color-mix(in srgb, var(--ls-coral) 35%, transparent)"
-                : "1px solid var(--ls-border)",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 12,
-            }}
-          >
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div
-                style={{
-                  fontSize: 12,
-                  fontWeight: 700,
-                  color: isFrozen ? "var(--ls-coral)" : "var(--ls-text)",
-                  letterSpacing: 0.3,
-                  marginBottom: 2,
-                }}
-              >
-                {isFrozen ? "🧊 Compte gelé" : "🟢 Compte actif"}
-              </div>
-              <div style={{ fontSize: 11, color: "var(--ls-text-muted)", lineHeight: 1.4 }}>
-                {isFrozen
-                  ? "L'utilisateur ne peut plus accéder à l'app et n'apparaît plus dans les stats équipe."
-                  : "Geler ce compte pour qu'il ne pollue plus stats / podium / agendas."}
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => void handleToggleFreeze()}
-              disabled={freezing}
-              role="switch"
-              aria-checked={!isFrozen}
-              style={{
-                position: "relative",
-                width: 56,
-                height: 30,
-                borderRadius: 999,
-                border: "none",
-                background: isFrozen ? "#475569" : "var(--ls-teal)",
-                cursor: freezing ? "wait" : "pointer",
-                transition: "background 0.2s ease",
-                opacity: freezing ? 0.6 : 1,
-                flexShrink: 0,
-              }}
-              title={isFrozen ? "Réactiver le compte" : "Geler le compte"}
-            >
-              <span
-                style={{
-                  position: "absolute",
-                  top: 3,
-                  left: isFrozen ? 3 : 29,
-                  width: 24,
-                  height: 24,
-                  borderRadius: "50%",
-                  background: "white",
-                  transition: "left 0.2s ease",
-                  boxShadow: "0 2px 4px rgba(0,0,0,0.2)",
-                }}
-              />
-            </button>
-          </div>
-        ) : null}
+        )}
 
         {/* Footer CTAs */}
         <div style={ctaRowStyle}>
@@ -761,126 +145,9 @@ export function TeamMemberDrilldownModal({ member, onClose }: TeamMemberDrilldow
   );
 }
 
-function SectionTitle({ children }: { children: React.ReactNode }) {
-  return <h3 style={sectionTitleStyle}>{children}</h3>;
-}
+// ─── Styles modale ────────────────────────────────────────────────────────────
 
-function PvTierRow({
-  label,
-  tip,
-  value,
-  onChange,
-  vipFlag,
-  onToggleVip,
-}: {
-  label: string;
-  tip: string;
-  value: string;
-  onChange: (v: string) => void;
-  vipFlag?: boolean;
-  onToggleVip?: () => void;
-}) {
-  const hasToggle = typeof onToggleVip === "function";
-  return (
-    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-      {hasToggle ? (
-        <button
-          type="button"
-          onClick={onToggleVip}
-          aria-label={vipFlag ? "VIP — clique pour passer en Distri" : "Distri — clique pour passer en VIP"}
-          title={vipFlag ? "VIP — clique pour passer en Distri" : "Distri — clique pour passer en VIP"}
-          style={{
-            background: "transparent",
-            border: "none",
-            cursor: "pointer",
-            fontSize: 16,
-            padding: 0,
-            width: 22,
-            opacity: vipFlag ? 1 : 0.4,
-            color: vipFlag ? "var(--ls-gold)" : "var(--ls-text-muted)",
-          }}
-        >
-          {vipFlag ? "⭐" : "☆"}
-        </button>
-      ) : (
-        <span style={{ width: 22 }} />
-      )}
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: 11, color: "var(--ls-text)", fontFamily: "Inter, system-ui, sans-serif", fontWeight: 500 }}>
-          {label}
-        </div>
-        <div style={{ fontSize: 10, color: "var(--ls-text-muted)" }}>{tip}</div>
-      </div>
-      <input
-        type="number"
-        inputMode="decimal"
-        min={0}
-        step="0.01"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder="0"
-        style={{
-          width: 90,
-          padding: "7px 10px",
-          borderRadius: 8,
-          border: "1px solid var(--ls-border)",
-          background: "var(--ls-surface)",
-          color: "var(--ls-text)",
-          fontSize: 13,
-          fontFamily: "Inter, system-ui, sans-serif",
-          textAlign: "right",
-        }}
-      />
-    </div>
-  );
-}
-
-function BreakdownRow({ emoji, label, value }: { emoji: string; label: string; value: number }) {
-  return (
-    <div style={breakdownRowStyle}>
-      <span style={{ fontSize: 14 }} aria-hidden="true">{emoji}</span>
-      <span style={{ fontSize: 11, color: "var(--ls-text-muted)", textTransform: "uppercase", letterSpacing: 0.5, flex: 1 }}>
-        {label}
-      </span>
-      <span style={{ fontFamily: "Syne, sans-serif", fontSize: 13, fontWeight: 700, color: "var(--ls-text)" }}>
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function MetricCard({
-  title,
-  primary,
-  secondary,
-  color,
-  badge,
-}: {
-  title: string;
-  primary: string;
-  secondary?: string;
-  color: string;
-  badge?: string;
-}) {
-  return (
-    <div style={metricCardStyle(color)}>
-      <div style={{ fontSize: 10, color: "var(--ls-text-muted)", textTransform: "uppercase", letterSpacing: 0.6, marginBottom: 4 }}>
-        {title}
-      </div>
-      <div style={{ fontFamily: "Syne, sans-serif", fontSize: 18, fontWeight: 700, color: "var(--ls-text)" }}>
-        {primary}
-      </div>
-      {secondary && (
-        <div style={{ fontSize: 11, color: "var(--ls-text-muted)", marginTop: 2 }}>{secondary}</div>
-      )}
-      {badge && <div style={badgeStyle(color)}>{badge}</div>}
-    </div>
-  );
-}
-
-// ─── Styles ────────────────────────────────────────────────────────────────
-
-const overlayStyle: React.CSSProperties = {
+const overlayStyle: CSSProperties = {
   position: "fixed",
   inset: 0,
   background: "color-mix(in srgb, var(--ls-bg) 80%, transparent)",
@@ -894,7 +161,7 @@ const overlayStyle: React.CSSProperties = {
   overflowY: "auto",
 };
 
-const modalStyle: React.CSSProperties = {
+const modalStyle: CSSProperties = {
   position: "relative",
   width: "100%",
   maxWidth: 600,
@@ -907,7 +174,7 @@ const modalStyle: React.CSSProperties = {
   boxShadow: "0 24px 72px color-mix(in srgb, var(--ls-text) 20%, transparent)",
 };
 
-const closeBtnStyle: React.CSSProperties = {
+const closeBtnStyle: CSSProperties = {
   position: "absolute",
   top: 12,
   right: 14,
@@ -922,7 +189,7 @@ const closeBtnStyle: React.CSSProperties = {
   lineHeight: 1,
 };
 
-const headerStyle: React.CSSProperties = {
+const headerStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
   gap: 14,
@@ -930,11 +197,12 @@ const headerStyle: React.CSSProperties = {
   paddingRight: 30,
 };
 
-const avatarBigStyle: React.CSSProperties = {
+const avatarBigStyle: CSSProperties = {
   width: 56,
   height: 56,
   borderRadius: 14,
-  background: "linear-gradient(135deg, var(--ls-gold), color-mix(in srgb, var(--ls-gold) 70%, var(--ls-coral)))",
+  background:
+    "linear-gradient(135deg, var(--ls-gold), color-mix(in srgb, var(--ls-gold) 70%, var(--ls-coral)))",
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
@@ -945,7 +213,7 @@ const avatarBigStyle: React.CSSProperties = {
   flexShrink: 0,
 };
 
-const nameStyle: React.CSSProperties = {
+const nameStyle: CSSProperties = {
   margin: 0,
   fontFamily: "Syne, sans-serif",
   fontSize: 22,
@@ -953,13 +221,13 @@ const nameStyle: React.CSSProperties = {
   color: "var(--ls-text)",
 };
 
-const subRoleStyle: React.CSSProperties = {
+const subRoleStyle: CSSProperties = {
   fontSize: 12,
   color: "var(--ls-text-muted)",
   fontFamily: "DM Sans, sans-serif",
 };
 
-const statusPillStyle = (color: string): React.CSSProperties => ({
+const statusPillStyle = (color: string): CSSProperties => ({
   display: "inline-flex",
   alignItems: "center",
   gap: 4,
@@ -973,106 +241,20 @@ const statusPillStyle = (color: string): React.CSSProperties => ({
   fontFamily: "DM Sans, sans-serif",
 });
 
-const xpBigCardStyle: React.CSSProperties = {
-  background:
-    "linear-gradient(135deg, color-mix(in srgb, var(--ls-gold) 10%, var(--ls-surface)), var(--ls-surface))",
-  border: "0.5px solid color-mix(in srgb, var(--ls-gold) 30%, var(--ls-border))",
-  borderRadius: 14,
-  padding: "16px 18px",
-  marginBottom: 18,
-};
-
-const xpTotalStyle: React.CSSProperties = {
-  fontFamily: "Syne, sans-serif",
-  fontSize: 32,
-  fontWeight: 800,
-  color: "var(--ls-gold)",
-};
-
-const levelBadgeStyle: React.CSSProperties = {
-  marginLeft: "auto",
-  padding: "4px 10px",
-  borderRadius: 8,
-  background: "var(--ls-gold)",
-  color: "var(--ls-bg)",
-  fontSize: 11,
-  fontFamily: "Syne, sans-serif",
-  fontWeight: 700,
-};
-
-const breakdownGridStyle: React.CSSProperties = {
-  marginTop: 14,
-  display: "grid",
-  gridTemplateColumns: "1fr 1fr",
-  gap: 6,
-};
-
-const breakdownRowStyle: React.CSSProperties = {
-  display: "flex",
-  alignItems: "center",
-  gap: 6,
-  padding: "6px 8px",
-  borderRadius: 8,
-  background: "var(--ls-surface)",
-  border: "0.5px solid var(--ls-border)",
-};
-
-const sectionTitleStyle: React.CSSProperties = {
-  margin: "0 0 10px",
-  fontFamily: "Syne, sans-serif",
-  fontSize: 14,
-  fontWeight: 700,
-  color: "var(--ls-text)",
-};
-
-const twoColGrid: React.CSSProperties = {
-  display: "grid",
-  gridTemplateColumns: "1fr 1fr",
-  gap: 10,
-  marginBottom: 18,
-};
-
-const threeColGrid: React.CSSProperties = {
-  display: "grid",
-  gridTemplateColumns: "1fr 1fr 1fr",
-  gap: 8,
-  marginBottom: 18,
-};
-
-const metricCardStyle = (color: string): React.CSSProperties => ({
-  position: "relative",
-  background: `color-mix(in srgb, ${color} 6%, var(--ls-surface))`,
-  border: `0.5px solid ${color}`,
-  borderRadius: 12,
-  padding: "12px 14px",
-});
-
-const badgeStyle = (color: string): React.CSSProperties => ({
-  display: "inline-block",
-  marginTop: 6,
-  fontSize: 9,
-  padding: "2px 6px",
-  borderRadius: 6,
-  background: `color-mix(in srgb, ${color} 14%, transparent)`,
-  color,
-  fontWeight: 700,
-  textTransform: "uppercase",
-  letterSpacing: 0.5,
-});
-
-const ctaRowStyle: React.CSSProperties = {
+const ctaRowStyle: CSSProperties = {
   display: "flex",
   gap: 10,
   marginTop: 16,
   flexWrap: "wrap",
 };
 
-const primaryBtnStyle: React.CSSProperties = {
+const primaryBtnStyle: CSSProperties = {
   flex: "1 1 auto",
   padding: "12px 18px",
   borderRadius: 12,
   border: "none",
-  background: "linear-gradient(135deg, var(--ls-gold), color-mix(in srgb, var(--ls-gold) 80%, var(--ls-coral)))",
+  background:
+    "linear-gradient(135deg, var(--ls-gold), color-mix(in srgb, var(--ls-gold) 80%, var(--ls-coral)))",
   color: "var(--ls-bg)",
   fontFamily: "Syne, sans-serif",
   fontSize: 13,
@@ -1080,7 +262,7 @@ const primaryBtnStyle: React.CSSProperties = {
   cursor: "pointer",
 };
 
-const ghostBtnStyle: React.CSSProperties = {
+const ghostBtnStyle: CSSProperties = {
   padding: "12px 18px",
   borderRadius: 12,
   border: "0.5px solid var(--ls-border)",


### PR DESCRIPTION
## Summary

Chantier #13 sous-vague A — étapes 13A.1 + 13A.2.

Extrait les 8 blocs de `TeamMemberDrilldownModal` (1092 → 264 lignes, -76%) en composants partagés `src/components/distributor-blocks/` :

- **Display** : EngagementTotal / Apprentissage / ActiviteRecente / Engagement
- **Admin** : RangHerbalife / ProgressionRang / PvBizworks / CompteActif (state autonome + toast + RPC)

Chaque bloc admin est autonome (embarque state + toast + appel Supabase), expose `onApplied?` pour refresh parent. Aucune régression fonctionnelle : le JSX/styles/handlers de la modale sont reproduits à l'identique.

Prochaine étape **13A.3** : page enrichie `/distributors/:id` 5 onglets qui consomme ces blocs.

## Test plan

- [x] Build OK (`npm run build` ✓)
- [ ] Recette régression modale `/team` → clic distri :
  - [ ] Header avatar + nom + role + status pill OK
  - [ ] XP total + 6 breakdowns OK
  - [ ] Sections Apprentissage / Activité / Engagement OK
  - [ ] Rang Herbalife : select + Appliquer marche + toast
  - [ ] Progression : jauge + label rang OK
  - [ ] PV Bizworks : 5 inputs + toggles VIP + total live + Appliquer
  - [ ] Geler/Réactiver compte : toggle + toast + modale ferme

🤖 Generated with [Claude Code](https://claude.com/claude-code)