### PR TITLE
feat(distri-fiche 13B): resurfacer flux d'acces vers fiche distri

### DIFF
--- a/src/components/distributor-blocks/DistriQuickLink.tsx
+++ b/src/components/distributor-blocks/DistriQuickLink.tsx
@@ -1,0 +1,77 @@
+// =============================================================================
+// DistriQuickLink — pill cliquable cohérent vers /distributors/:id
+// =============================================================================
+// Chantier #13 sous-vague B.4 (2026-05-18). Style/comportement clic unifies
+// pour les surfaces qui listent des distri sans pouvoir wrapper toute la
+// ligne dans un Link (FlexTeamPage MemberRow = button toggle).
+//
+// Pour les surfaces ou toute la ligne PEUT etre cliquable, on prefere wrap
+// dans un Link (cf. EquipeTab MemberCard, PvTeamPage PvDistriRow).
+// =============================================================================
+
+import { Link } from "react-router-dom";
+import type { MouseEvent } from "react";
+
+interface Props {
+  userId: string;
+  /** Comportement par defaut : navigate. Si true, ouvre dans un nouvel onglet. */
+  newTab?: boolean;
+  /** Texte court a cote du chevron. Default "Fiche". */
+  label?: string;
+  /** Compact (sans label, juste icone). Default false. */
+  iconOnly?: boolean;
+}
+
+export function DistriQuickLink({ userId, newTab, label = "Fiche", iconOnly }: Props) {
+  // stopPropagation pour eviter de declencher un toggle/onClick parent
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <Link
+      to={`/distributors/${userId}`}
+      target={newTab ? "_blank" : undefined}
+      rel={newTab ? "noopener noreferrer" : undefined}
+      onClick={handleClick}
+      title="Ouvrir la fiche distri"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        padding: iconOnly ? 6 : "5px 10px",
+        borderRadius: 8,
+        background: "var(--ls-surface)",
+        border: "0.5px solid var(--ls-border)",
+        color: "var(--ls-text-muted)",
+        fontSize: 11,
+        fontFamily: "DM Sans, sans-serif",
+        fontWeight: 500,
+        textDecoration: "none",
+        flexShrink: 0,
+        transition: "color 0.15s, border-color 0.15s, background 0.15s",
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.color = "var(--ls-teal)";
+        e.currentTarget.style.borderColor = "color-mix(in srgb, var(--ls-teal) 40%, transparent)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.color = "var(--ls-text-muted)";
+        e.currentTarget.style.borderColor = "var(--ls-border)";
+      }}
+    >
+      {!iconOnly && label}
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        aria-hidden="true"
+      >
+        <polyline points="9 18 15 12 9 6" />
+      </svg>
+    </Link>
+  );
+}

--- a/src/components/distributor-blocks/index.ts
+++ b/src/components/distributor-blocks/index.ts
@@ -11,6 +11,7 @@ export { RangHerbalifeBlock } from "./RangHerbalifeBlock";
 export { ProgressionRangBlock } from "./ProgressionRangBlock";
 export { PvBizworksBlock } from "./PvBizworksBlock";
 export { CompteActifBlock } from "./CompteActifBlock";
+export { DistriQuickLink } from "./DistriQuickLink";
 
 // Primitives partagees (utilisable si la page veut composer manuellement)
 export {

--- a/src/components/settings/EquipeTab.tsx
+++ b/src/components/settings/EquipeTab.tsx
@@ -129,8 +129,10 @@ function MemberCard({
     .slice(0, 2)
     .toUpperCase();
 
+  // 13B.1 — toute la carte est cliquable vers /distributors/:id
   return (
-    <div
+    <Link
+      to={`/distributors/${user.id}`}
       style={{
         padding: 14,
         borderRadius: 12,
@@ -140,6 +142,21 @@ function MemberCard({
         alignItems: "center",
         gap: 12,
         opacity: user.active ? 1 : 0.55,
+        textDecoration: "none",
+        cursor: "pointer",
+        transition: "transform 0.15s, border-color 0.15s, box-shadow 0.15s",
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.transform = "translateY(-1px)";
+        e.currentTarget.style.borderColor =
+          "color-mix(in srgb, var(--ls-teal) 40%, var(--ls-border))";
+        e.currentTarget.style.boxShadow =
+          "0 6px 18px -8px color-mix(in srgb, var(--ls-teal) 30%, transparent)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = "none";
+        e.currentTarget.style.borderColor = "var(--ls-border)";
+        e.currentTarget.style.boxShadow = "none";
       }}
     >
       <div
@@ -173,35 +190,45 @@ function MemberCard({
             {user.name}
           </span>
           {!user.active ? (
-            <span style={{ fontSize: 9, padding: "1px 6px", borderRadius: 8, background: "rgba(220,38,38,0.08)", color: "#DC2626" }}>
+            <span
+              style={{
+                fontSize: 9,
+                padding: "1px 6px",
+                borderRadius: 8,
+                background: "rgba(220,38,38,0.08)",
+                color: "#DC2626",
+              }}
+            >
               Inactif
             </span>
           ) : null}
         </div>
         <div style={{ fontSize: 11, color: "var(--ls-text-hint)", marginTop: 2 }}>
-          {user.role === "admin" ? "Admin" : user.role === "referent" ? "Référent" : "Distributeur"}
+          {user.role === "admin"
+            ? "Admin"
+            : user.role === "referent"
+              ? "Référent"
+              : "Distributeur"}
           {user.sponsorName ? ` · Parrain : ${user.sponsorName}` : ""}
         </div>
         <div style={{ fontSize: 11, color: "var(--ls-text-hint)", marginTop: 2 }}>
-          {clientCount} client{clientCount > 1 ? "s" : ""} · {pvMonth.toLocaleString("fr-FR")} PV mois
+          {clientCount} client{clientCount > 1 ? "s" : ""} ·{" "}
+          {pvMonth.toLocaleString("fr-FR")} PV mois
         </div>
       </div>
-      <Link
-        to={`/distributors/${user.id}`}
-        style={{
-          fontSize: 11,
-          padding: "5px 10px",
-          borderRadius: 8,
-          background: "var(--ls-surface)",
-          border: "1px solid var(--ls-border)",
-          color: "var(--ls-text-muted)",
-          textDecoration: "none",
-          flexShrink: 0,
-        }}
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        style={{ color: "var(--ls-text-muted)", flexShrink: 0 }}
+        aria-hidden="true"
       >
-        Fiche
-      </Link>
-    </div>
+        <polyline points="9 18 15 12 9 6" />
+      </svg>
+    </Link>
   );
 }
 

--- a/src/pages/FlexTeamPage.tsx
+++ b/src/pages/FlexTeamPage.tsx
@@ -24,6 +24,7 @@ import { PageHeading } from "../components/ui/PageHeading";
 import { useAppContext } from "../context/AppContext";
 import { getSupabaseClient } from "../services/supabaseClient";
 import { FlexHistoryCard } from "../components/flex/FlexHistoryCard";
+import { DistriQuickLink } from "../components/distributor-blocks";
 import type {
   DistributorActionPlan,
   FlexDriftDistri,
@@ -278,49 +279,65 @@ function MemberRow({
         transition: "all 0.15s",
       }}
     >
-      <button
-        type="button"
-        onClick={onToggle}
+      <div
         style={{
-          width: "100%",
-          background: "transparent",
-          border: "none",
           padding: "14px 16px",
-          textAlign: "left",
-          cursor: "pointer",
           display: "flex",
           alignItems: "center",
-          justifyContent: "space-between",
-          color: "var(--ls-text)",
-          fontFamily: "DM Sans, sans-serif",
-          gap: 12,
+          gap: 10,
         }}
       >
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontFamily: "Syne, sans-serif", fontSize: 15, fontWeight: 700 }}>
-            {member.name}
+        <button
+          type="button"
+          onClick={onToggle}
+          style={{
+            flex: 1,
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            textAlign: "left",
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            color: "var(--ls-text)",
+            fontFamily: "DM Sans, sans-serif",
+            gap: 12,
+            minWidth: 0,
+          }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontFamily: "Syne, sans-serif", fontSize: 15, fontWeight: 700 }}>
+              {member.name}
+            </div>
+            <div style={{ fontSize: 11, color: "var(--ls-text-muted)", marginTop: 2 }}>
+              {RANK_LABELS[member.currentRank]} ·{" "}
+              {member.hasPlan ? (
+                "Plan FLEX actif"
+              ) : (
+                <span style={{ color: "var(--ls-coral)" }}>Pas de plan FLEX</span>
+              )}
+            </div>
           </div>
-          <div style={{ fontSize: 11, color: "var(--ls-text-muted)", marginTop: 2 }}>
-            {RANK_LABELS[member.currentRank]} ·{" "}
-            {member.hasPlan ? "Plan FLEX actif" : <span style={{ color: "var(--ls-coral)" }}>Pas de plan FLEX</span>}
-          </div>
-        </div>
-        {recap ? (
-          <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
-            <MiniDot label="Inv" ratio={recap.ratios.invitations} />
-            <MiniDot label="Conv" ratio={recap.ratios.conversations} />
-            <MiniDot label="Bilans" ratio={recap.ratios.bilans} />
-            <MiniDot label="Clos" ratio={recap.ratios.closings} />
-            <span style={{ fontSize: 11, color: "var(--ls-text-muted)", marginLeft: 6 }}>
-              {recap.days_filled}/7
+          {recap ? (
+            <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+              <MiniDot label="Inv" ratio={recap.ratios.invitations} />
+              <MiniDot label="Conv" ratio={recap.ratios.conversations} />
+              <MiniDot label="Bilans" ratio={recap.ratios.bilans} />
+              <MiniDot label="Clos" ratio={recap.ratios.closings} />
+              <span style={{ fontSize: 11, color: "var(--ls-text-muted)", marginLeft: 6 }}>
+                {recap.days_filled}/7
+              </span>
+            </div>
+          ) : (
+            <span style={{ fontSize: 11, color: "var(--ls-text-muted)" }}>
+              {member.hasPlan ? "Pas de check-in cette sem." : ""}
             </span>
-          </div>
-        ) : (
-          <span style={{ fontSize: 11, color: "var(--ls-text-muted)" }}>
-            {member.hasPlan ? "Pas de check-in cette sem." : ""}
-          </span>
-        )}
-      </button>
+          )}
+        </button>
+        {/* 13B.3 — DistriQuickLink dedie : ouvre la fiche distri sans toggle */}
+        <DistriQuickLink userId={member.userId} />
+      </div>
       {expanded && member.hasPlan && (
         <div style={{ padding: 16, borderTop: "0.5px solid var(--ls-border)" }}>
           <FlexHistoryCard userId={member.userId} />

--- a/src/pages/PvTeamPage.tsx
+++ b/src/pages/PvTeamPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { Link } from "react-router-dom";
 import { buildPvTrackingRecords } from "../data/pvCatalog";
 import { Card } from "../components/ui/Card";
 import { MetricTile } from "../components/ui/MetricTile";
@@ -86,9 +87,12 @@ export function PvTeamPage() {
 
           <div className="space-y-3">
             {pvByDistributor.map((row) => (
-              <div
+              // 13B.2 — Ligne cliquable vers la fiche distri enrichie
+              <Link
                 key={row.id}
-                className="grid gap-3 rounded-[22px] border border-white/8 bg-[var(--ls-surface2)] px-4 py-4 md:grid-cols-[1.2fr_0.7fr_0.7fr]"
+                to={`/distributors/${row.id}`}
+                className="grid gap-3 rounded-[22px] border border-white/8 bg-[var(--ls-surface2)] px-4 py-4 no-underline transition-all md:grid-cols-[1.2fr_0.7fr_0.7fr_auto] hover:border-[var(--ls-teal)]/40 hover:-translate-y-[1px]"
+                title="Ouvrir la fiche distri"
               >
                 <div>
                   <p className="text-lg font-semibold text-white">{row.name}</p>
@@ -96,7 +100,19 @@ export function PvTeamPage() {
                 </div>
                 <div className="text-sm text-[var(--ls-text-muted)]">{row.pv} PV ce mois</div>
                 <div className="text-sm text-[var(--ls-text-muted)]">{row.clients} dossiers suivis</div>
-              </div>
+                <svg
+                  className="self-center text-[var(--ls-text-muted)]"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  aria-hidden="true"
+                >
+                  <polyline points="9 18 15 12 9 6" />
+                </svg>
+              </Link>
             ))}
           </div>
         </Card>


### PR DESCRIPTION
## Summary

Chantier #13 sous-vague B (4 étapes B.1 → B.4). Connecte 3 surfaces qui listaient des distri sans lien (ou avec lien anecdotique) vers la fiche enrichie de la sous-vague A.

| Étape | Surface | Avant | Après |
|---|---|---|---|
| B.1 | `/parametres?tab=equipe` | Petit bouton \"Fiche\" en bout de ligne | Toute la carte cliquable + hover effect + chevron |
| B.2 | `/pv/team` | `<div>` non-cliquable | `<Link>` Tailwind + hover + chevron |
| B.3 | `/flex/equipe` MemberRow | Toggle expand only, aucun lien fiche | Toggle préservé + `<DistriQuickLink>` à droite (stopPropagation) |
| B.4 | Composant partagé | — | Nouveau `<DistriQuickLink userId={} />` cohérent |

## Test plan

- [x] Build OK (`npm run build` ✓)
- [ ] Recette `/parametres?tab=equipe` : clic n'importe où sur carte Mandy → fiche enrichie
- [ ] Recette `/pv/team` : clic ligne Mandy section \"PV par distributeur\" → fiche enrichie
- [ ] Recette `/flex/equipe` : 
  - [ ] Clic n'importe où sauf bouton → expand recap (comportement existant intact)
  - [ ] Clic bouton \"Fiche →\" à droite → fiche enrichie (toggle ne se déclenche pas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)