### PR TITLE
feat(distri-fiche 13C): announcement + carte hub (cloture #13)

### DIFF
--- a/src/pages/DeveloppementHubPage.tsx
+++ b/src/pages/DeveloppementHubPage.tsx
@@ -163,6 +163,18 @@ const CARDS: HubCard[] = [
     tag: { label: "Nouveau", color: "var(--ls-coral)" },
     requireRole: "admin",
   },
+  {
+    id: "fiche-distri",
+    emoji: "👥",
+    title: "Fiche distri enrichie",
+    description:
+      "Tout ce qu'il faut pour piloter ton équipe : engagement, apprentissage, activité, rang Herbalife, PV Bizworks mois par mois, gel de compte. Accessible en cliquant sur la carte d'un distri depuis Paramètres > Équipe, /pv/team ou /flex/equipe.",
+    cta: "Voir l'équipe",
+    path: "/parametres?tab=equipe",
+    accent: "var(--ls-gold)",
+    tag: { label: "Nouveau", color: "var(--ls-coral)" },
+    requireRole: "admin",
+  },
 ];
 
 export function DeveloppementHubPage() {

--- a/supabase/migrations/20260518160000_announce_distri_fiche.sql
+++ b/supabase/migrations/20260518160000_announce_distri_fiche.sql
@@ -1,0 +1,20 @@
+-- Chantier #13 sous-vague C (2026-05-18) — Annonce admin fiche distri unifiee.
+-- Audience admin only : la refonte profite a Thomas + Melanie (gestion equipe).
+begin;
+
+insert into public.app_announcements (id, title, body, emoji, accent, link_path, link_label, audience, published_at)
+select
+  gen_random_uuid(),
+  'Fiche distri enrichie 👥',
+  'Tu peux maintenant ouvrir la fiche complete d''un distri en cliquant n''importe ou sur sa carte depuis Parametres > Equipe, /pv/team ou /flex/equipe. Tu y trouves son engagement, son apprentissage, son activite, son rang Herbalife, ses PV Bizworks mois par mois, et tu peux geler son compte si besoin. Plus rapide pour piloter ton equipe.',
+  '👥',
+  'gold',
+  '/parametres?tab=equipe',
+  'Explorer',
+  'admin',
+  now()
+where not exists (
+  select 1 from public.app_announcements where title = 'Fiche distri enrichie 👥'
+);
+
+commit;


### PR DESCRIPTION
## Summary

Chantier #13 sous-vague C — clôture.

- **13C.2** Migration `app_announcements` audience=admin (copy distri-friendly conforme règle 2026-05-18)
- **13C.3** Carte hub \"Fiche distri enrichie\" sur `/developpement` (admin only, tag Nouveau)

## ⚠️ Action manuelle requise

La migration **n'est pas encore appliquée** côté Supabase (worktree non lié). À lancer depuis ton worktree principal après merge :

```bash
supabase db push --linked --include-all
```

## Recette 13C.1 (sur Vercel preview)

- [x] Build OK (`npm run build` ✓)
- [ ] `/parametres?tab=equipe` → clic carte distri → fiche enrichie 5 onglets
- [ ] `/team` modale drilldown → identique à avant (régression zéro)
- [ ] `/pv/team` ligne distri → fiche enrichie
- [ ] `/flex/equipe` → toggle expand préservé + bouton \"Fiche →\" OK
- [ ] Popup announcement admin spotlight au prochain mount Co-pilote (après migration appliquée)
- [ ] Carte hub visible `/developpement` (admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)