### PR TITLE
Welcome bilan : logo La Base 360 + pin Herbalife coach

### DIFF
--- a/src/components/public/LaBase360Logo.tsx
+++ b/src/components/public/LaBase360Logo.tsx
@@ -1,0 +1,89 @@
+// =============================================================================
+// LaBase360Logo — lecteur SVG du logo officiel La Base 360 (2026-05-18)
+// =============================================================================
+//
+// Wrapper léger autour des SVG officiels dans /public/brand/labase360/. Permet
+// d'utiliser le logo brand de manière cohérente sur les pages publiques
+// (Welcome bilan, Thank you, témoignage, business, future newsletter) sans
+// dupliquer les URLs en dur.
+//
+// Deux variants disponibles :
+//   - "mark"       → carré gradient seul (Vital Fusion emerald→cyan→violet)
+//                    avec lettre B + pastille 360. Idéal pour eyebrows, cards,
+//                    coach cards (remplace l'avatar initiales).
+//   - "horizontal" → version horizontale (logo + wordmark côte à côte).
+//                    Idéal pour headers / footers.
+//
+// Fallback gracieux : si le fichier ne charge pas (404), affiche un cercle
+// gradient teal→violet vide. Jamais d'image cassée.
+// =============================================================================
+
+import { useState } from "react";
+
+export type LaBase360LogoVariant = "mark" | "horizontal";
+
+interface Props {
+  /** Default "mark". */
+  variant?: LaBase360LogoVariant;
+  /** Taille en px (hauteur). Default 48 pour mark, 36 pour horizontal. */
+  size?: number;
+  /** Texte alternatif. Default "La Base 360". */
+  alt?: string;
+  /** className optionnel pour styling parent. */
+  className?: string;
+  /** style optionnel. */
+  style?: React.CSSProperties;
+}
+
+const FILE_BY_VARIANT: Record<LaBase360LogoVariant, string> = {
+  mark: "/brand/labase360/logo-primary.svg",
+  horizontal: "/brand/labase360/logo-horizontal.svg",
+};
+
+export function LaBase360Logo({
+  variant = "mark",
+  size,
+  alt = "La Base 360",
+  className,
+  style,
+}: Props) {
+  const [errored, setErrored] = useState(false);
+  const px = size ?? (variant === "horizontal" ? 36 : 48);
+
+  if (errored) {
+    // Fallback : cercle gradient teal→violet pour ne JAMAIS afficher
+    // d'image cassée. Respecte la palette brand publique.
+    return (
+      <div
+        className={className}
+        aria-label={alt}
+        role="img"
+        style={{
+          width: px,
+          height: px,
+          borderRadius: "50%",
+          background: "linear-gradient(135deg, #10B981 0%, #06B6D4 50%, #8B5CF6 100%)",
+          flexShrink: 0,
+          ...style,
+        }}
+      />
+    );
+  }
+
+  return (
+    <img
+      src={FILE_BY_VARIANT[variant]}
+      alt={alt}
+      className={className}
+      onError={() => setErrored(true)}
+      style={{
+        height: px,
+        width: variant === "mark" ? px : "auto",
+        objectFit: "contain",
+        display: "inline-block",
+        flexShrink: 0,
+        ...style,
+      }}
+    />
+  );
+}

--- a/src/pages/BilanOnlineWelcomePage.tsx
+++ b/src/pages/BilanOnlineWelcomePage.tsx
@@ -14,8 +14,11 @@ import {
   PUBLIC_FONTS,
   publicGradText,
 } from "../components/public/PublicShell";
-import { CoachCredibilityBadges } from "../components/bilan-online/CoachCredibilityBadges";
+import { CoachCredibilityBadges, type CoachCredibility } from "../components/bilan-online/CoachCredibilityBadges";
 import { TestimonialsCarousel } from "../components/testimonials/TestimonialsCarousel";
+import { LaBase360Logo } from "../components/public/LaBase360Logo";
+import { RankPinBadge } from "../components/rank/RankPinBadge";
+import type { HerbalifeRank } from "../types/domain";
 
 function normalizeSlug(input: string): string {
   return input
@@ -29,22 +32,27 @@ function capitalize(s: string): string {
   if (!s) return s;
   return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 }
-function getInitials(name: string): string {
-  if (!name) return "?";
-  const parts = name.trim().split(/\s+/);
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[1][0]).toUpperCase();
-}
 
 export function BilanOnlineWelcomePage() {
   const navigate = useNavigate();
   const { coachSlug } = useParams<{ coachSlug?: string }>();
   const slug = useMemo(() => normalizeSlug(coachSlug ?? ""), [coachSlug]);
-  const coachName = slug ? capitalize(slug) : "";
-  const initials = getInitials(coachName);
+  const fallbackCoachName = slug ? capitalize(slug) : "";
 
   const [inputName, setInputName] = useState("");
   const [showFreeBilan, setShowFreeBilan] = useState(false);
+  const [coachData, setCoachData] = useState<CoachCredibility | null>(null);
+
+  // Nom officiel via RPC si dispo (first_name + initiale nom), fallback slug
+  const coachDisplayName = useMemo(() => {
+    if (coachData?.first_name) {
+      const lastInit = coachData.name?.[0] ? ` ${coachData.name[0]}.` : "";
+      return `${coachData.first_name}${lastInit}`;
+    }
+    return fallbackCoachName;
+  }, [coachData, fallbackCoachName]);
+
+  const coachRank = (coachData?.rank ?? null) as HerbalifeRank | null;
 
   function startWithSlug() {
     navigate(`/bilan-online/${slug}/formulaire`);
@@ -110,7 +118,7 @@ export function BilanOnlineWelcomePage() {
           2 minutes pour comprendre ton corps, tes objectifs, et te proposer un accompagnement vraiment personnalisé.
         </p>
 
-        {/* Coach card glassmorphism pill */}
+        {/* Coach card glassmorphism pill — logo La Base 360 + nom coach + pin Herbalife */}
         {slug && (
           <div style={{ textAlign: "center", marginBottom: 28 }}>
             <div
@@ -120,31 +128,19 @@ export function BilanOnlineWelcomePage() {
                 WebkitBackdropFilter: "blur(20px)",
                 border: "1px solid var(--hair)",
                 borderRadius: 999,
-                padding: "14px 22px 14px 14px",
+                padding: "12px 22px 12px 12px",
                 display: "inline-flex",
                 alignItems: "center",
                 gap: 14,
                 boxShadow: "0 4px 24px rgba(0,0,0,0.2)",
               }}
             >
-              <div
-                style={{
-                  width: 44,
-                  height: 44,
-                  borderRadius: "50%",
-                  background: PUBLIC_TOKENS.gradCta,
-                  color: PUBLIC_TOKENS.ink,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontFamily: PUBLIC_FONTS.display,
-                  fontWeight: 700,
-                  fontSize: 15,
-                  flexShrink: 0,
-                }}
-              >
-                {initials}
-              </div>
+              <LaBase360Logo
+                variant="mark"
+                size={48}
+                alt="La Base 360"
+                style={{ borderRadius: 12 }}
+              />
               <div style={{ textAlign: "left" }}>
                 <div
                   style={{
@@ -164,16 +160,29 @@ export function BilanOnlineWelcomePage() {
                     fontSize: 15,
                     fontWeight: 600,
                     color: "var(--cream)",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    flexWrap: "wrap",
                   }}
                 >
-                  {coachName}
+                  <span>{coachDisplayName || "—"}</span>
+                  {coachRank && (
+                    <RankPinBadge rank={coachRank} size="xs" />
+                  )}
                 </div>
               </div>
             </div>
           </div>
         )}
 
-        {slug && <CoachCredibilityBadges coachSlug={slug} variant="welcome" />}
+        {slug && (
+          <CoachCredibilityBadges
+            coachSlug={slug}
+            variant="welcome"
+            onResolved={setCoachData}
+          />
+        )}
 
         {/* Pitch card glassmorphism */}
         <div


### PR DESCRIPTION
## Summary

- 🥰 **Logo La Base 360 dans la coach card** (Welcome bilan online) à la place du cercle initiales « TK ».
- 🎖️ **Pin Herbalife auto du coach** à côté de son nom, change tout seul quand le coach se qualifie à un nouveau palier.
- 🧩 **Nouveau composant** `<LaBase360Logo variant="mark"|"horizontal" size={n} />` réutilisable sur toutes les pages publiques (Welcome / ThankYou / Témoignage / Newsletter futures).

## Contexte

Règle métier 2026-05-18 validée Thomas (cf. `docs/HERBALIFE_PALIERS_REGLES.md` §Welcome bilan). La refonte design dark V2 des pages publiques est déjà livrée sur `dev/thomas-test` (commits `e48254d` + `775f1be` + `22b33de`). Ce PR finit le travail en branchant le logo brand officiel + le pin auto du coach — les deux signatures de crédibilité côté prospect.

## Détail technique

**Composant `LaBase360Logo`** :
- Lecteur SVG officiel `/brand/labase360/logo-primary.svg` (mark) et `/brand/labase360/logo-horizontal.svg`.
- Fallback gracieux : si SVG 404, affiche un cercle gradient emerald→cyan→violet — jamais d'image cassée.
- Props : `variant` ("mark" default | "horizontal"), `size` (px, default 48 mark / 36 horizontal), `alt`, `className`, `style`.

**BilanOnlineWelcomePage** :
- Coach card : `<LaBase360Logo variant="mark" size={48} />` remplace le cercle gradCta + initiales TK.
- Nom du coach : via `coachData.first_name` + initiale nom (callback `onResolved` désormais branché sur `CoachCredibilityBadges`). Fallback sur le slug capitalisé si la RPC ne répond pas.
- Pin : `<RankPinBadge rank={coachData.rank} size="xs" />` à côté du nom. Auto-update via la colonne `users.current_rank` (couplée au chantier jauge fenêtre glissante PR #68).

## Test plan

- [ ] **Vercel preview** sur `/bilan-online/thomas` → coach card affiche : logo La Base 360 (carré gradient) + « Thomas K. » + pin Success Builder (ou autre selon rang réel)
- [ ] **Slug bidon** `/bilan-online/inconnu` → CoachCredibilityBadges échoue silencieusement, coach card affiche logo + nom slug capitalisé sans pin (fallback)
- [ ] **Mobile 375×667** → coach card pill ne déborde pas
- [ ] **Toggle dark/light** → logo SVG reste lisible dans les deux modes
- [ ] **Régression** : parcours complet bilan online (welcome → formulaire 5 étapes → thank you) intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)