### PR TITLE
Push prod 2026-05-18 — jauge fenêtre glissante + welcome logo + testimonials quality

### DIFF
--- a/src/components/distributor-blocks/ProgressionRangBlock.tsx
+++ b/src/components/distributor-blocks/ProgressionRangBlock.tsx
@@ -1,23 +1,16 @@
 // =============================================================================
 // ProgressionRangBlock — jauge progression vers le prochain rang Herbalife
 // =============================================================================
-// Refactor 2026-05-18 (feat/jauge-fenetre-glissante) :
-//   - Calcul PV désormais sur FENÊTRES GLISSANTES (2/3/12 mois) via RPC
-//     get_distributor_qualifications, plus jamais sur mois courant seul.
-//   - Le calcul "PV étendu" (perso + downline non-Supervisor) du mois courant
-//     reste calculé en JS et MAJORE la fenêtre 12m pour qualif Supervisor.
+// V2 2026-05-18 (feat/jauge-fenetre-glissante) :
+//   - Source unique : RPC SQL `get_distributor_qualifications` qui retourne
+//     pv_2m / pv_3m / pv_12m_extended (self + downline non-Sup, 12 mois
+//     glissants). Plus aucun calcul JS de fenêtre — tout côté DB.
 //   - Le libellé jauge mentionne explicitement la fenêtre glissante.
 // =============================================================================
 
 import { useMemo } from "react";
-import { useAppContext } from "../../context/AppContext";
 import { useDistributorQualifications } from "../../hooks/useDistributorQualifications";
-import { usePvBreakdowns } from "../../hooks/usePvBreakdowns";
-import {
-  computeQualifyingPersonalPv,
-  currentMonthIso,
-  rankProgressionFromWindows,
-} from "../../lib/herbalifeFormulas";
+import { currentMonthIso, rankProgressionFromWindows } from "../../lib/herbalifeFormulas";
 import type { User } from "../../types/domain";
 import { AdminCard, hintStyle } from "./_shared";
 
@@ -29,54 +22,18 @@ interface Props {
 }
 
 export function ProgressionRangBlock({ memberId, fullUser, monthIso }: Props) {
-  const { users } = useAppContext();
   const month = monthIso ?? currentMonthIso();
-
-  // Fenêtres glissantes 2/3/6/12 mois via RPC SQL (PV perso uniquement).
   const { qualifications, loading } = useDistributorQualifications(memberId, month);
-
-  // Mois courant : pour majorer la fenêtre 12m avec le downline non-Sup
-  // (règle Herbalife "PV personnel étendu").
-  const { breakdowns: allBreakdowns } = usePvBreakdowns(month);
-
-  const qualifyingPvCurrentMonth = useMemo(() => {
-    if (!fullUser) return 0;
-    return computeQualifyingPersonalPv(
-      fullUser.id,
-      users.map((u) => ({
-        id: u.id,
-        sponsorId: u.sponsorId,
-        currentRank: u.currentRank,
-        frozenAt: u.frozenAt,
-      })),
-      allBreakdowns,
-      (uid) => {
-        const u = users.find((x) => x.id === uid);
-        if (!u) return 0;
-        const ux = u as User & {
-          monthlyPvOverrideMonth?: string | null;
-          monthlyPvOverride?: number | null;
-        };
-        if (ux.monthlyPvOverrideMonth === month && typeof ux.monthlyPvOverride === "number") {
-          return ux.monthlyPvOverride;
-        }
-        return 0;
-      },
-    );
-  }, [fullUser, users, allBreakdowns, month]);
 
   const progression = useMemo(() => {
     if (!qualifications) return null;
-    return rankProgressionFromWindows(
-      fullUser?.currentRank,
-      {
-        pv_2m: qualifications.pv_2m,
-        pv_3m: qualifications.pv_3m,
-        pv_12m: qualifications.pv_12m,
-      },
-      qualifyingPvCurrentMonth,
-    );
-  }, [fullUser?.currentRank, qualifications, qualifyingPvCurrentMonth]);
+    return rankProgressionFromWindows(fullUser?.currentRank, {
+      pv_2m: qualifications.pv_2m,
+      pv_3m: qualifications.pv_3m,
+      pv_12m: qualifications.pv_12m,
+      pv_12m_extended: qualifications.pv_12m_extended,
+    });
+  }, [fullUser?.currentRank, qualifications]);
 
   if (loading && !qualifications) {
     return (

--- a/src/components/distributor-blocks/ProgressionRangBlock.tsx
+++ b/src/components/distributor-blocks/ProgressionRangBlock.tsx
@@ -1,18 +1,22 @@
 // =============================================================================
 // ProgressionRangBlock — jauge progression vers le prochain rang Herbalife
 // =============================================================================
-// Extrait de TeamMemberDrilldownModal (Chantier #13 sous-vague A.1, 2026-05-18).
-// Calcul PV qualifiant = perso + downline non-Supervisor (cf. herbalifeFormulas).
+// Refactor 2026-05-18 (feat/jauge-fenetre-glissante) :
+//   - Calcul PV désormais sur FENÊTRES GLISSANTES (2/3/12 mois) via RPC
+//     get_distributor_qualifications, plus jamais sur mois courant seul.
+//   - Le calcul "PV étendu" (perso + downline non-Supervisor) du mois courant
+//     reste calculé en JS et MAJORE la fenêtre 12m pour qualif Supervisor.
+//   - Le libellé jauge mentionne explicitement la fenêtre glissante.
 // =============================================================================
 
 import { useMemo } from "react";
 import { useAppContext } from "../../context/AppContext";
+import { useDistributorQualifications } from "../../hooks/useDistributorQualifications";
 import { usePvBreakdowns } from "../../hooks/usePvBreakdowns";
 import {
   computeQualifyingPersonalPv,
   currentMonthIso,
-  rankProgression,
-  totalPvFromBreakdown,
+  rankProgressionFromWindows,
 } from "../../lib/herbalifeFormulas";
 import type { User } from "../../types/domain";
 import { AdminCard, hintStyle } from "./_shared";
@@ -27,22 +31,16 @@ interface Props {
 export function ProgressionRangBlock({ memberId, fullUser, monthIso }: Props) {
   const { users } = useAppContext();
   const month = monthIso ?? currentMonthIso();
-  const { getForUser, breakdowns: allBreakdowns } = usePvBreakdowns(month);
-  const existingBreakdown = getForUser(memberId);
 
-  const personalPv = useMemo(() => {
-    if (existingBreakdown) return totalPvFromBreakdown(existingBreakdown);
-    const ux = fullUser as
-      | (User & { monthlyPvOverrideMonth?: string | null; monthlyPvOverride?: number | null })
-      | null;
-    if (ux?.monthlyPvOverrideMonth === month && typeof ux?.monthlyPvOverride === "number") {
-      return ux.monthlyPvOverride;
-    }
-    return 0;
-  }, [existingBreakdown, fullUser, month]);
+  // Fenêtres glissantes 2/3/6/12 mois via RPC SQL (PV perso uniquement).
+  const { qualifications, loading } = useDistributorQualifications(memberId, month);
 
-  const qualifyingPv = useMemo(() => {
-    if (!fullUser) return personalPv;
+  // Mois courant : pour majorer la fenêtre 12m avec le downline non-Sup
+  // (règle Herbalife "PV personnel étendu").
+  const { breakdowns: allBreakdowns } = usePvBreakdowns(month);
+
+  const qualifyingPvCurrentMonth = useMemo(() => {
+    if (!fullUser) return 0;
     return computeQualifyingPersonalPv(
       fullUser.id,
       users.map((u) => ({
@@ -65,14 +63,31 @@ export function ProgressionRangBlock({ memberId, fullUser, monthIso }: Props) {
         return 0;
       },
     );
-  }, [fullUser, users, allBreakdowns, month, personalPv]);
+  }, [fullUser, users, allBreakdowns, month]);
 
-  const progression = useMemo(
-    () => rankProgression(fullUser?.currentRank, personalPv, qualifyingPv),
-    [fullUser?.currentRank, personalPv, qualifyingPv],
-  );
+  const progression = useMemo(() => {
+    if (!qualifications) return null;
+    return rankProgressionFromWindows(
+      fullUser?.currentRank,
+      {
+        pv_2m: qualifications.pv_2m,
+        pv_3m: qualifications.pv_3m,
+        pv_12m: qualifications.pv_12m,
+      },
+      qualifyingPvCurrentMonth,
+    );
+  }, [fullUser?.currentRank, qualifications, qualifyingPvCurrentMonth]);
 
+  if (loading && !qualifications) {
+    return (
+      <AdminCard style={{ marginTop: 12 }}>
+        <div style={{ ...hintStyle, opacity: 0.6 }}>Calcul des PV glissants…</div>
+      </AdminCard>
+    );
+  }
   if (!progression) return null;
+
+  const windowLabel = `${progression.windowMonths} mois glissants`;
 
   return (
     <AdminCard style={{ marginTop: 12 }}>
@@ -89,8 +104,8 @@ export function ProgressionRangBlock({ memberId, fullUser, monthIso }: Props) {
       </div>
       <div style={hintStyle}>
         {progression.pct >= 100
-          ? `🎉 Seuil atteint ! ${progression.pvCurrent.toLocaleString("fr-FR")} / ${progression.pvNeeded.toLocaleString("fr-FR")} PV`
-          : `${progression.pvCurrent.toLocaleString("fr-FR")} / ${progression.pvNeeded.toLocaleString("fr-FR")} PV · reste ${progression.remaining.toLocaleString("fr-FR")} PV`}
+          ? `🎉 Seuil atteint ! ${progression.pvCurrent.toLocaleString("fr-FR")} / ${progression.pvNeeded.toLocaleString("fr-FR")} PV · ${windowLabel}`
+          : `${progression.pvCurrent.toLocaleString("fr-FR")} / ${progression.pvNeeded.toLocaleString("fr-FR")} PV · ${windowLabel} · reste ${progression.remaining.toLocaleString("fr-FR")} PV`}
         <span
           style={{
             display: "inline-block",

--- a/src/components/public/LaBase360Logo.tsx
+++ b/src/components/public/LaBase360Logo.tsx
@@ -1,0 +1,89 @@
+// =============================================================================
+// LaBase360Logo — lecteur SVG du logo officiel La Base 360 (2026-05-18)
+// =============================================================================
+//
+// Wrapper léger autour des SVG officiels dans /public/brand/labase360/. Permet
+// d'utiliser le logo brand de manière cohérente sur les pages publiques
+// (Welcome bilan, Thank you, témoignage, business, future newsletter) sans
+// dupliquer les URLs en dur.
+//
+// Deux variants disponibles :
+//   - "mark"       → carré gradient seul (Vital Fusion emerald→cyan→violet)
+//                    avec lettre B + pastille 360. Idéal pour eyebrows, cards,
+//                    coach cards (remplace l'avatar initiales).
+//   - "horizontal" → version horizontale (logo + wordmark côte à côte).
+//                    Idéal pour headers / footers.
+//
+// Fallback gracieux : si le fichier ne charge pas (404), affiche un cercle
+// gradient teal→violet vide. Jamais d'image cassée.
+// =============================================================================
+
+import { useState } from "react";
+
+export type LaBase360LogoVariant = "mark" | "horizontal";
+
+interface Props {
+  /** Default "mark". */
+  variant?: LaBase360LogoVariant;
+  /** Taille en px (hauteur). Default 48 pour mark, 36 pour horizontal. */
+  size?: number;
+  /** Texte alternatif. Default "La Base 360". */
+  alt?: string;
+  /** className optionnel pour styling parent. */
+  className?: string;
+  /** style optionnel. */
+  style?: React.CSSProperties;
+}
+
+const FILE_BY_VARIANT: Record<LaBase360LogoVariant, string> = {
+  mark: "/brand/labase360/logo-primary.svg",
+  horizontal: "/brand/labase360/logo-horizontal.svg",
+};
+
+export function LaBase360Logo({
+  variant = "mark",
+  size,
+  alt = "La Base 360",
+  className,
+  style,
+}: Props) {
+  const [errored, setErrored] = useState(false);
+  const px = size ?? (variant === "horizontal" ? 36 : 48);
+
+  if (errored) {
+    // Fallback : cercle gradient teal→violet pour ne JAMAIS afficher
+    // d'image cassée. Respecte la palette brand publique.
+    return (
+      <div
+        className={className}
+        aria-label={alt}
+        role="img"
+        style={{
+          width: px,
+          height: px,
+          borderRadius: "50%",
+          background: "linear-gradient(135deg, #10B981 0%, #06B6D4 50%, #8B5CF6 100%)",
+          flexShrink: 0,
+          ...style,
+        }}
+      />
+    );
+  }
+
+  return (
+    <img
+      src={FILE_BY_VARIANT[variant]}
+      alt={alt}
+      className={className}
+      onError={() => setErrored(true)}
+      style={{
+        height: px,
+        width: variant === "mark" ? px : "auto",
+        objectFit: "contain",
+        display: "inline-block",
+        flexShrink: 0,
+        ...style,
+      }}
+    />
+  );
+}

--- a/src/components/team/EngagementTable.tsx
+++ b/src/components/team/EngagementTable.tsx
@@ -7,6 +7,8 @@
 // =============================================================================
 
 import { useMemo, useState } from "react";
+import { RankPinBadge } from "../rank/RankPinBadge";
+import type { HerbalifeRank } from "../../types/domain";
 import {
   STATUS_META,
   type TeamMemberEngagement,
@@ -183,10 +185,14 @@ export function EngagementTable({ members, excludeRootId, onMemberClick }: Engag
                       <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
                         <div style={miniAvatarStyle}>{initialsOf(m.name)}</div>
                         <div>
-                          <div style={{ fontWeight: 600, color: "var(--ls-text)", fontSize: 13 }}>{m.name}</div>
+                          <div style={{ fontWeight: 600, color: "var(--ls-text)", fontSize: 13, display: "flex", alignItems: "center", gap: 6 }}>
+                            <span>{m.name}</span>
+                            {m.current_rank && (
+                              <RankPinBadge rank={m.current_rank as HerbalifeRank} size="xs" />
+                            )}
+                          </div>
                           <div style={{ fontSize: 10, color: "var(--ls-text-muted)" }}>
                             {m.role === "admin" ? "Admin" : m.role === "referent" ? "Référent" : "Distri"}
-                            {m.current_rank && ` · ${m.current_rank}`}
                           </div>
                         </div>
                       </div>

--- a/src/components/team/TeamMemberDrilldownModal.tsx
+++ b/src/components/team/TeamMemberDrilldownModal.tsx
@@ -25,6 +25,8 @@ import {
   PvBizworksBlock,
   RangHerbalifeBlock,
 } from "../distributor-blocks";
+import { RankPinBadge } from "../rank/RankPinBadge";
+import type { HerbalifeRank } from "../../types/domain";
 
 interface TeamMemberDrilldownModalProps {
   member: TeamMemberEngagement | null;
@@ -88,8 +90,14 @@ export function TeamMemberDrilldownModal({ member, onClose }: TeamMemberDrilldow
                   : member.role === "referent"
                     ? "Référent"
                     : "Distributeur"}
-                {member.current_rank && ` · ${member.current_rank}`}
               </span>
+              {member.current_rank && (
+                <RankPinBadge
+                  rank={member.current_rank as HerbalifeRank}
+                  size="xs"
+                  showLabel
+                />
+              )}
               <span style={statusPillStyle(status.color)}>
                 <span aria-hidden="true">{status.emoji}</span>
                 {status.label}

--- a/src/components/team/XpPodium.tsx
+++ b/src/components/team/XpPodium.tsx
@@ -7,6 +7,8 @@
 // =============================================================================
 
 import type { TeamMemberEngagement } from "../../hooks/useTeamEngagement";
+import { RankPinBadge } from "../rank/RankPinBadge";
+import type { HerbalifeRank } from "../../types/domain";
 
 interface XpPodiumProps {
   members: TeamMemberEngagement[];
@@ -110,12 +112,17 @@ function PodiumSlot({ member, rank, onClick }: PodiumSlotProps) {
         </div>
       </div>
 
-      {/* Nom + role */}
+      {/* Nom + role + pin */}
       <div style={{ marginTop: 10, textAlign: "center" }}>
         <div style={nameStyle}>{member.name}</div>
         <div style={roleStyle}>
           {member.role === "admin" ? "Admin" : member.role === "referent" ? "Référent" : "Distributeur"}
         </div>
+        {member.current_rank && (
+          <div style={{ marginTop: 4, display: "flex", justifyContent: "center" }}>
+            <RankPinBadge rank={member.current_rank as HerbalifeRank} size="xs" />
+          </div>
+        )}
       </div>
 
       {/* Marche du podium */}

--- a/src/hooks/useDistributorQualifications.ts
+++ b/src/hooks/useDistributorQualifications.ts
@@ -1,0 +1,83 @@
+// =============================================================================
+// useDistributorQualifications — fenêtres glissantes Herbalife (2026-05-18)
+// =============================================================================
+//
+// Appelle la RPC `get_distributor_qualifications(user_id, as_of_month)` pour
+// récupérer les PV personnels d'un distri sur les 4 fenêtres glissantes
+// pertinentes (2 / 3 / 6 / 12 mois) et les booleans qualif associés.
+//
+// Source unique pour la jauge Progression (ProgressionRangBlock) et tout
+// composant qui veut afficher la qualif d'un distri à un mois donné.
+//
+// Refetch automatique sur l'event `lor-squad:pv-breakdown-updated` (déjà
+// dispatché par les composants de saisie PV).
+// =============================================================================
+
+import { useCallback, useEffect, useState } from "react";
+import { PV_BREAKDOWN_UPDATED_EVENT } from "./usePvBreakdowns";
+import { fetchDistributorQualifications } from "../services/supabaseService";
+import { currentMonthIso } from "../lib/herbalifeFormulas";
+
+export interface DistributorQualifications {
+  pv_2m: number;
+  pv_3m: number;
+  pv_6m: number;
+  pv_12m: number;
+  qualified_senior_consultant: boolean;
+  qualified_success_builder: boolean;
+  qualified_qp: boolean;
+  qualified_supervisor: boolean;
+  /** Rang max calculé d'après les PV perso sur les fenêtres. Parmi :
+   *  distributor_25 / senior_consultant_35 / success_builder_42 / supervisor_50.
+   *  Les paliers structurels (world_team_50+) ne sont jamais calculés ici. */
+  rank_calculated: string;
+}
+
+interface UseDistributorQualificationsResult {
+  qualifications: DistributorQualifications | null;
+  loading: boolean;
+  refetch: () => Promise<void>;
+}
+
+export function useDistributorQualifications(
+  userId: string | null | undefined,
+  asOfMonth?: string,
+): UseDistributorQualificationsResult {
+  const month = asOfMonth ?? currentMonthIso();
+  const [qualifications, setQualifications] =
+    useState<DistributorQualifications | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetch = useCallback(async () => {
+    if (!userId) {
+      setQualifications(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const row = await fetchDistributorQualifications(userId, month);
+      setQualifications(row);
+    } catch (err) {
+      console.warn("[useDistributorQualifications] fetch failed", err);
+      setQualifications(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, month]);
+
+  useEffect(() => {
+    void fetch();
+  }, [fetch]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = () => {
+      void fetch();
+    };
+    window.addEventListener(PV_BREAKDOWN_UPDATED_EVENT, handler);
+    return () => window.removeEventListener(PV_BREAKDOWN_UPDATED_EVENT, handler);
+  }, [fetch]);
+
+  return { qualifications, loading, refetch: fetch };
+}

--- a/src/hooks/useDistributorQualifications.ts
+++ b/src/hooks/useDistributorQualifications.ts
@@ -22,12 +22,18 @@ export interface DistributorQualifications {
   pv_2m: number;
   pv_3m: number;
   pv_6m: number;
+  /** PV PERSO sur fenêtre 12 mois glissants (sans downline). */
   pv_12m: number;
+  /** PV ÉTENDU sur fenêtre 12 mois glissants : self + descendants
+   *  non-Supervisor (règle breakaway Herbalife). C'est ce nombre qui
+   *  qualifie pour le palier Supervisor 4000 PV. Source : helper SQL
+   *  `_pv_window_extended_total` (migration V2 20261118200000). */
+  pv_12m_extended: number;
   qualified_senior_consultant: boolean;
   qualified_success_builder: boolean;
   qualified_qp: boolean;
   qualified_supervisor: boolean;
-  /** Rang max calculé d'après les PV perso sur les fenêtres. Parmi :
+  /** Rang max calculé d'après les fenêtres. Parmi :
    *  distributor_25 / senior_consultant_35 / success_builder_42 / supervisor_50.
    *  Les paliers structurels (world_team_50+) ne sont jamais calculés ici. */
   rank_calculated: string;

--- a/src/lib/herbalifeFormulas.ts
+++ b/src/lib/herbalifeFormulas.ts
@@ -505,13 +505,18 @@ export function rankProgression(
 export interface PvWindows {
   pv_2m: number;
   pv_3m: number;
+  /** PV perso 12 mois glissants (sans downline). Conservé pour debug / autres
+   *  usages mais NON utilisé par la jauge — voir pv_12m_extended. */
   pv_12m: number;
+  /** PV ÉTENDU 12 mois glissants = self + descendants non-Supervisor (règle
+   *  breakaway Herbalife). C'est ce nombre qui qualifie pour Supervisor.
+   *  Source : RPC SQL `get_distributor_qualifications` V2. */
+  pv_12m_extended: number;
 }
 
 export function rankProgressionFromWindows(
   currentRank: string | null | undefined,
   windows: PvWindows,
-  qualifyingPersonalPv?: number,
 ): (RankProgression & { windowMonths: number }) | null {
   const rank = currentRank ?? "distributor_25";
   const threshold = RANK_PROGRESSION_THRESHOLDS[rank];
@@ -527,8 +532,8 @@ export function rankProgressionFromWindows(
     windowMonths = 3;
   } else {
     // success_builder_42 → supervisor_50 : 4000 PV / 12 mois glissants.
-    // On majore avec le calcul étendu mois courant si fourni (downline non-Sup).
-    pvCurrent = Math.max(windows.pv_12m, qualifyingPersonalPv ?? 0);
+    // PV étendu (self + downline non-Sup) calculé côté SQL, source unique.
+    pvCurrent = windows.pv_12m_extended;
     windowMonths = 12;
   }
 

--- a/src/lib/herbalifeFormulas.ts
+++ b/src/lib/herbalifeFormulas.ts
@@ -484,3 +484,64 @@ export function rankProgression(
     pvSource: threshold.source as "personal" | "personal_extended",
   };
 }
+
+// =============================================================================
+// Variante fenêtre glissante (règle Herbalife officielle 2026-05-18)
+// =============================================================================
+//
+// Les qualifs Herbalife sont sur fenêtre GLISSANTE, pas mois isolé :
+//   - Senior Consultant 35% : 500  PV / 2  mois glissants
+//   - Success Builder 42%   : 1000 PV / 3  mois glissants
+//   - Supervisor 50%        : 4000 PV / 1-12 mois glissants
+//
+// `rankProgressionFromWindows` accepte les sommes pré-calculées des fenêtres
+// glissantes (typiquement issues de la RPC get_distributor_qualifications)
+// + optionnellement le `qualifyingPersonalPv` étendu (perso + downline non-Sup
+// du mois courant) qui peut majorer la fenêtre 12m pour Supervisor.
+//
+// Pour Supervisor on prend le MAX entre la fenêtre 12m perso et l'extended
+// mois courant : la stratégie qui qualifie en premier l'emporte.
+
+export interface PvWindows {
+  pv_2m: number;
+  pv_3m: number;
+  pv_12m: number;
+}
+
+export function rankProgressionFromWindows(
+  currentRank: string | null | undefined,
+  windows: PvWindows,
+  qualifyingPersonalPv?: number,
+): (RankProgression & { windowMonths: number }) | null {
+  const rank = currentRank ?? "distributor_25";
+  const threshold = RANK_PROGRESSION_THRESHOLDS[rank];
+  if (!threshold) return null;
+
+  let pvCurrent: number;
+  let windowMonths: number;
+  if (rank === "distributor_25") {
+    pvCurrent = windows.pv_2m;
+    windowMonths = 2;
+  } else if (rank === "senior_consultant_35") {
+    pvCurrent = windows.pv_3m;
+    windowMonths = 3;
+  } else {
+    // success_builder_42 → supervisor_50 : 4000 PV / 12 mois glissants.
+    // On majore avec le calcul étendu mois courant si fourni (downline non-Sup).
+    pvCurrent = Math.max(windows.pv_12m, qualifyingPersonalPv ?? 0);
+    windowMonths = 12;
+  }
+
+  const pct = Math.min(100, Math.round((pvCurrent / threshold.pvNeeded) * 100));
+  return {
+    currentLabel: RANK_LABEL_FALLBACK[rank] ?? rank,
+    nextRank: threshold.nextKey,
+    nextLabel: RANK_LABEL_FALLBACK[threshold.nextKey] ?? threshold.nextKey,
+    pvNeeded: threshold.pvNeeded,
+    pvCurrent: Math.max(0, pvCurrent),
+    pct,
+    remaining: Math.max(0, threshold.pvNeeded - pvCurrent),
+    pvSource: threshold.source as "personal" | "personal_extended",
+    windowMonths,
+  };
+}

--- a/src/pages/AdminTestimonialsPage.tsx
+++ b/src/pages/AdminTestimonialsPage.tsx
@@ -94,6 +94,17 @@ export function AdminTestimonialsPage() {
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
 
+  // Quality fix F (2026-05-18) : saisie manuelle "seed" pour démarrer le
+  // carrousel avec les vrais retours clients déjà reçus (WhatsApp, verbal).
+  const [manualOpen, setManualOpen] = useState(false);
+  const [manualForm, setManualForm] = useState({
+    firstName: "",
+    city: "",
+    content: "",
+    rating: 5,
+  });
+  const [manualSaving, setManualSaving] = useState(false);
+
   useEffect(() => {
     if (currentUser && currentUser.role !== "admin") {
       navigate("/co-pilote", { replace: true });
@@ -188,6 +199,46 @@ export function AdminTestimonialsPage() {
       alert(e instanceof Error ? e.message : "Erreur inconnue.");
     } finally {
       setBusyId(null);
+    }
+  }
+
+  async function createManual() {
+    const fn = manualForm.firstName.trim();
+    const ci = manualForm.city.trim();
+    const ct = manualForm.content.trim();
+    if (fn.length < 2 || ci.length < 2 || ct.length < 10) {
+      alert("Prénom + ville (2 char mini) et témoignage (10 char mini) obligatoires.");
+      return;
+    }
+    setManualSaving(true);
+    try {
+      const sb = await getSupabaseClient();
+      if (!sb) throw new Error("Service indisponible.");
+      const submitterMeta = `[FROM:${fn}|${ci}]`;
+      const contentWithMeta = `${submitterMeta}\n\n${ct}`;
+      const { error } = await sb.from("client_testimonials").insert({
+        client_id: null,
+        client_token: null,
+        coach_user_id: currentUser?.id ?? null,
+        coach_slug: coachSlug,
+        content: contentWithMeta,
+        rating: manualForm.rating,
+        photo_consent: false,
+        photo_url: null,
+        language: "fr",
+        status: "approved",
+        approved_at: new Date().toISOString(),
+        approved_by: currentUser?.id ?? null,
+      });
+      if (error) throw error;
+      setManualOpen(false);
+      setManualForm({ firstName: "", city: "", content: "", rating: 5 });
+      pushToast({ tone: "success", title: `✅ Témoignage ajouté · ${fn} de ${ci} · ${manualForm.rating}/5` });
+      await load();
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Erreur inconnue.");
+    } finally {
+      setManualSaving(false);
     }
   }
 
@@ -312,6 +363,133 @@ export function AdminTestimonialsPage() {
           </p>
         )}
       </div>
+
+      {/* ─── Ajouter manuellement (seed) ──────────────────────────────────── */}
+      <div style={{ marginBottom: 20, textAlign: "right" }}>
+        <button
+          type="button"
+          onClick={() => setManualOpen(true)}
+          style={{
+            padding: "10px 16px",
+            background: "var(--ls-surface)",
+            border: "1px solid var(--ls-border)",
+            borderRadius: 10,
+            color: "var(--ls-text)",
+            fontWeight: 600,
+            fontSize: 13,
+            cursor: "pointer",
+          }}
+        >
+          ➕ Ajouter un témoignage manuel
+        </button>
+      </div>
+
+      {manualOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          style={{
+            position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)",
+            display: "flex", alignItems: "center", justifyContent: "center",
+            padding: 16, zIndex: 1000,
+          }}
+          onClick={() => !manualSaving && setManualOpen(false)}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: "var(--ls-surface)",
+              border: "1px solid var(--ls-border)",
+              borderRadius: 16,
+              padding: 22,
+              maxWidth: 480,
+              width: "100%",
+              maxHeight: "90vh",
+              overflowY: "auto",
+            }}
+          >
+            <h3 style={{ margin: 0, marginBottom: 6, fontSize: 18, fontWeight: 700, color: "var(--ls-text)" }}>
+              Ajouter un témoignage manuel
+            </h3>
+            <p style={{ margin: 0, marginBottom: 16, fontSize: 12, color: "var(--ls-text-muted)", lineHeight: 1.5 }}>
+              Pour seeder le carrousel avec un vrai retour client que tu as déjà reçu (WhatsApp, verbal). Sera publié immédiatement (status approved).
+            </p>
+
+            <label style={labelStyle}>Prénom *</label>
+            <input
+              type="text"
+              value={manualForm.firstName}
+              onChange={(e) => setManualForm((f) => ({ ...f, firstName: e.target.value }))}
+              placeholder="Marie"
+              style={inputStyle}
+            />
+
+            <label style={labelStyle}>Ville *</label>
+            <input
+              type="text"
+              value={manualForm.city}
+              onChange={(e) => setManualForm((f) => ({ ...f, city: e.target.value }))}
+              placeholder="Metz"
+              style={inputStyle}
+            />
+
+            <label style={labelStyle}>Note *</label>
+            <div style={{ display: "flex", gap: 6, marginBottom: 14 }}>
+              {[1, 2, 3, 4, 5].map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  onClick={() => setManualForm((f) => ({ ...f, rating: n }))}
+                  style={{
+                    flex: 1,
+                    padding: "10px 0",
+                    border: "1px solid var(--ls-border)",
+                    background: manualForm.rating === n ? "var(--ls-gold)" : "var(--ls-surface)",
+                    color: manualForm.rating === n ? "var(--ls-charcoal)" : "var(--ls-text)",
+                    borderRadius: 8,
+                    cursor: "pointer",
+                    fontWeight: 700,
+                  }}
+                >
+                  {"⭐".repeat(n)}
+                </button>
+              ))}
+            </div>
+
+            <label style={labelStyle}>Témoignage * (10–1000 caractères)</label>
+            <textarea
+              value={manualForm.content}
+              onChange={(e) => setManualForm((f) => ({ ...f, content: e.target.value }))}
+              rows={6}
+              maxLength={1000}
+              placeholder="Ce que le client t'a dit, retranscrit avec ses mots."
+              style={{ ...inputStyle, fontFamily: "inherit", resize: "vertical" }}
+            />
+            <div style={{ fontSize: 11, color: "var(--ls-text-muted)", textAlign: "right", marginTop: -8, marginBottom: 14 }}>
+              {manualForm.content.length} / 1000
+            </div>
+
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+              <button
+                type="button"
+                onClick={() => !manualSaving && setManualOpen(false)}
+                disabled={manualSaving}
+                style={{ ...btnGhostStyle, opacity: manualSaving ? 0.5 : 1 }}
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                onClick={createManual}
+                disabled={manualSaving}
+                style={{ ...btnPrimaryStyle, opacity: manualSaving ? 0.6 : 1 }}
+              >
+                {manualSaving ? "Enregistrement…" : "Publier"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* ─── Filtres + liste ──────────────────────────────────────────────── */}
       <div style={{ display: "flex", gap: 6, marginBottom: 18, flexWrap: "wrap" }}>
@@ -527,5 +705,47 @@ function AdminButton({ variant, onClick, disabled, children }: {
     </button>
   );
 }
+
+// Styles partagés modale manuelle (quality fix F)
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: 11,
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+  color: "var(--ls-text-muted)",
+  marginBottom: 6,
+};
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "10px 12px",
+  background: "var(--ls-bg)",
+  border: "1px solid var(--ls-border)",
+  borderRadius: 10,
+  color: "var(--ls-text)",
+  fontSize: 14,
+  marginBottom: 14,
+  boxSizing: "border-box",
+};
+const btnGhostStyle: React.CSSProperties = {
+  padding: "10px 16px",
+  background: "transparent",
+  border: "1px solid var(--ls-border)",
+  borderRadius: 10,
+  color: "var(--ls-text)",
+  fontWeight: 600,
+  fontSize: 13,
+  cursor: "pointer",
+};
+const btnPrimaryStyle: React.CSSProperties = {
+  padding: "10px 18px",
+  background: "var(--ls-gold)",
+  border: "none",
+  borderRadius: 10,
+  color: "var(--ls-charcoal)",
+  fontWeight: 700,
+  fontSize: 13,
+  cursor: "pointer",
+};
 
 export default AdminTestimonialsPage;

--- a/src/pages/BilanOnlineWelcomePage.tsx
+++ b/src/pages/BilanOnlineWelcomePage.tsx
@@ -14,8 +14,11 @@ import {
   PUBLIC_FONTS,
   publicGradText,
 } from "../components/public/PublicShell";
-import { CoachCredibilityBadges } from "../components/bilan-online/CoachCredibilityBadges";
+import { CoachCredibilityBadges, type CoachCredibility } from "../components/bilan-online/CoachCredibilityBadges";
 import { TestimonialsCarousel } from "../components/testimonials/TestimonialsCarousel";
+import { LaBase360Logo } from "../components/public/LaBase360Logo";
+import { RankPinBadge } from "../components/rank/RankPinBadge";
+import type { HerbalifeRank } from "../types/domain";
 
 function normalizeSlug(input: string): string {
   return input
@@ -29,22 +32,27 @@ function capitalize(s: string): string {
   if (!s) return s;
   return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 }
-function getInitials(name: string): string {
-  if (!name) return "?";
-  const parts = name.trim().split(/\s+/);
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[1][0]).toUpperCase();
-}
 
 export function BilanOnlineWelcomePage() {
   const navigate = useNavigate();
   const { coachSlug } = useParams<{ coachSlug?: string }>();
   const slug = useMemo(() => normalizeSlug(coachSlug ?? ""), [coachSlug]);
-  const coachName = slug ? capitalize(slug) : "";
-  const initials = getInitials(coachName);
+  const fallbackCoachName = slug ? capitalize(slug) : "";
 
   const [inputName, setInputName] = useState("");
   const [showFreeBilan, setShowFreeBilan] = useState(false);
+  const [coachData, setCoachData] = useState<CoachCredibility | null>(null);
+
+  // Nom officiel via RPC si dispo (first_name + initiale nom), fallback slug
+  const coachDisplayName = useMemo(() => {
+    if (coachData?.first_name) {
+      const lastInit = coachData.name?.[0] ? ` ${coachData.name[0]}.` : "";
+      return `${coachData.first_name}${lastInit}`;
+    }
+    return fallbackCoachName;
+  }, [coachData, fallbackCoachName]);
+
+  const coachRank = (coachData?.rank ?? null) as HerbalifeRank | null;
 
   function startWithSlug() {
     navigate(`/bilan-online/${slug}/formulaire`);
@@ -110,7 +118,7 @@ export function BilanOnlineWelcomePage() {
           2 minutes pour comprendre ton corps, tes objectifs, et te proposer un accompagnement vraiment personnalisé.
         </p>
 
-        {/* Coach card glassmorphism pill */}
+        {/* Coach card glassmorphism pill — logo La Base 360 + nom coach + pin Herbalife */}
         {slug && (
           <div style={{ textAlign: "center", marginBottom: 28 }}>
             <div
@@ -120,31 +128,19 @@ export function BilanOnlineWelcomePage() {
                 WebkitBackdropFilter: "blur(20px)",
                 border: "1px solid var(--hair)",
                 borderRadius: 999,
-                padding: "14px 22px 14px 14px",
+                padding: "12px 22px 12px 12px",
                 display: "inline-flex",
                 alignItems: "center",
                 gap: 14,
                 boxShadow: "0 4px 24px rgba(0,0,0,0.2)",
               }}
             >
-              <div
-                style={{
-                  width: 44,
-                  height: 44,
-                  borderRadius: "50%",
-                  background: PUBLIC_TOKENS.gradCta,
-                  color: PUBLIC_TOKENS.ink,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontFamily: PUBLIC_FONTS.display,
-                  fontWeight: 700,
-                  fontSize: 15,
-                  flexShrink: 0,
-                }}
-              >
-                {initials}
-              </div>
+              <LaBase360Logo
+                variant="mark"
+                size={48}
+                alt="La Base 360"
+                style={{ borderRadius: 12 }}
+              />
               <div style={{ textAlign: "left" }}>
                 <div
                   style={{
@@ -164,16 +160,29 @@ export function BilanOnlineWelcomePage() {
                     fontSize: 15,
                     fontWeight: 600,
                     color: "var(--cream)",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    flexWrap: "wrap",
                   }}
                 >
-                  {coachName}
+                  <span>{coachDisplayName || "—"}</span>
+                  {coachRank && (
+                    <RankPinBadge rank={coachRank} size="xs" />
+                  )}
                 </div>
               </div>
             </div>
           </div>
         )}
 
-        {slug && <CoachCredibilityBadges coachSlug={slug} variant="welcome" />}
+        {slug && (
+          <CoachCredibilityBadges
+            coachSlug={slug}
+            variant="welcome"
+            onResolved={setCoachData}
+          />
+        )}
 
         {/* Pitch card glassmorphism */}
         <div

--- a/src/pages/BusinessPage.styles.ts
+++ b/src/pages/BusinessPage.styles.ts
@@ -284,6 +284,14 @@ export const BIZ_STYLES = `
 .biz-story__since { font-size: 13px; color: var(--biz-graphite-soft); margin-top: 2px; }
 .biz-story__hook { font-family: var(--biz-display); font-size: 22px; font-weight: 600; letter-spacing: -0.02em; line-height: 1.2; }
 .biz-story__body { font-size: 15px; color: var(--biz-graphite); line-height: 1.6; }
+/* §5 — Bloc fondateurs riche (chapitres) */
+.biz-story--founders { padding: 36px; gap: 12px; }
+.biz-story__chapters { display: flex; flex-direction: column; gap: 14px; }
+.biz-story__chapter-title { font-family: var(--biz-display); font-size: 18px; font-weight: 700; letter-spacing: -0.01em; color: var(--biz-ink); margin: 14px 0 4px 0; }
+.biz-story__chapter-title:first-child { margin-top: 0; }
+.biz-story__chapter-p { font-size: 15px; color: var(--biz-graphite); line-height: 1.65; margin: 0; }
+.biz-story__chapter-list { margin: 0; padding-left: 22px; display: flex; flex-direction: column; gap: 8px; }
+.biz-story__chapter-list li { font-size: 15px; color: var(--biz-graphite); line-height: 1.55; }
 .biz-stories__signature { margin: 40px auto 0; text-align: center; max-width: 640px; }
 .biz-stories__signature span { font-family: var(--biz-italic); font-style: italic; font-weight: 500; color: var(--biz-gold); font-size: clamp(22px, 3vw, 28px); letter-spacing: -0.005em; }
 .biz-stories__signature::before, .biz-stories__signature::after { content: ""; display: block; width: 40px; height: 1px; background: var(--biz-gold-soft); margin: 18px auto; }

--- a/src/pages/BusinessPage.tsx
+++ b/src/pages/BusinessPage.tsx
@@ -31,13 +31,6 @@ type FormStatus = "idle" | "submitting" | "success" | "error";
 // slots partenaires additionnels (textes Thomas en cours). Plus de récits
 // inventés.
 
-interface FoundersStory {
-  hook: string;            // une-ligne accroche entre « ... »
-  body: string;            // récit complet partagé
-  thomas_avatar_url: string | null;
-  melanie_avatar_url: string | null;
-}
-
 interface PartnerStory {
   name: string;            // ex « Sophie M. »
   since: string;           // ex « Partenaire · démarrée en avril 2024 »
@@ -46,10 +39,17 @@ interface PartnerStory {
   avatar_url: string | null;
 }
 
-// TODO Thomas (envoie textes + URLs photos) : remplir FOUNDERS_STORY et
-// PARTNER_STORIES. Tant que null/vides, la section §05 ne rend que le
-// carrousel témoignages clients en-dessous (pas de placeholder visible).
-const FOUNDERS_STORY: FoundersStory | null = null;
+// Histoire fondateurs fusionnée (Thomas + Mélanie). Les avatars sont fetched
+// dynamiquement depuis users.avatar_url via la RPC publique
+// `get_founders_avatars` (cf. migration 20261118400000). Textes ci-dessous à
+// corriger par Thomas si écart avec les vrais parcours.
+const FOUNDERS_STORY_TEXT = {
+  hook: "On a démarré à 2, le soir et les week-ends. Aujourd'hui on en a fait notre métier.",
+  body:
+    "Thomas était dans le marketing digital, Mélanie prof de SVT. En 2022, on a démarré La Base 360 en parallèle de nos jobs. À 6 mois Thomas était Success Builder, à 18 mois il avait quitté son CDI. Mélanie a démarré à temps partiel, juste avec ses copines proches au début — à 1 an elle gagnait déjà plus en coaching qu'en enseignement. Aujourd'hui on accompagne l'équipe qui forme les nouveaux partenaires. Ce qu'on aime ? Construire un revenu une fois et le voir revenir mois après mois.",
+};
+
+// Partenaires additionnels (textes Thomas en cours).
 const PARTNER_STORIES: PartnerStory[] = [];
 
 const FAQ_ITEMS = [
@@ -108,6 +108,33 @@ export function BusinessPage() {
   const [params] = useSearchParams();
   const referrerId = params.get("ref");
   const wantsLeadCapture = params.get("leadcapture") === "1";
+
+  // ─── Fondateurs avatars (RPC publique) ────────────────────────────────────
+  const [foundersAvatars, setFoundersAvatars] = useState<{
+    thomas_avatar_url: string | null;
+    melanie_avatar_url: string | null;
+  }>({ thomas_avatar_url: null, melanie_avatar_url: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = await getSupabaseClient();
+        if (!sb) return;
+        const { data, error } = await sb.rpc("get_founders_avatars");
+        if (cancelled || error || !data) return;
+        const row = Array.isArray(data) ? data[0] : data;
+        if (!row) return;
+        setFoundersAvatars({
+          thomas_avatar_url: row.thomas_avatar_url ?? null,
+          melanie_avatar_url: row.melanie_avatar_url ?? null,
+        });
+      } catch {
+        /* silent : avatars optionnels, fallback gradient initiales */
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   // ─── Simulateur state ─────────────────────────────────────────────────────
   const [target, setTarget] = useState<number>(500);
@@ -820,48 +847,43 @@ export function BusinessPage() {
             </div>
             <div className="biz-stories">
               {/* Bloc fondateurs fusionné — Thomas + Mélanie en 1 récit
-                  partagé. Photos auto via users.avatar_url (à brancher
-                  quand IDs en DB confirmés). */}
-              {FOUNDERS_STORY && (
-                <article className="biz-story biz-story--founders biz-reveal">
-                  <div className="biz-story__head">
-                    <div
-                      className="biz-story__photo biz-story__photo--couple"
-                      aria-hidden="true"
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: -10,
-                      }}
-                    >
-                      {FOUNDERS_STORY.thomas_avatar_url ? (
-                        <img
-                          src={FOUNDERS_STORY.thomas_avatar_url}
-                          alt=""
-                          style={{ width: 56, height: 56, borderRadius: "50%", objectFit: "cover", border: "2px solid #fff" }}
-                        />
-                      ) : (
-                        <div style={{ width: 56, height: 56, borderRadius: "50%", background: "linear-gradient(135deg,#10B981,#06B6D4)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 18 }}>T</div>
-                      )}
-                      {FOUNDERS_STORY.melanie_avatar_url ? (
-                        <img
-                          src={FOUNDERS_STORY.melanie_avatar_url}
-                          alt=""
-                          style={{ width: 56, height: 56, borderRadius: "50%", objectFit: "cover", border: "2px solid #fff", marginLeft: -14 }}
-                        />
-                      ) : (
-                        <div style={{ width: 56, height: 56, borderRadius: "50%", background: "linear-gradient(135deg,#A78BFA,#FB7185)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 18, marginLeft: -14 }}>M</div>
-                      )}
-                    </div>
-                    <div>
-                      <div className="biz-story__name">Thomas &amp; Mélanie</div>
-                      <div className="biz-story__since">Fondateurs La Base 360</div>
-                    </div>
+                  partagé. Avatars auto via RPC get_founders_avatars
+                  (lit users.avatar_url uploadé via Paramètres > Profil).
+                  Fallback gradient initiales si avatar absent. */}
+              <article className="biz-story biz-story--founders biz-reveal">
+                <div className="biz-story__head">
+                  <div
+                    className="biz-story__photo biz-story__photo--couple"
+                    aria-hidden="true"
+                    style={{ display: "flex", alignItems: "center" }}
+                  >
+                    {foundersAvatars.thomas_avatar_url ? (
+                      <img
+                        src={foundersAvatars.thomas_avatar_url}
+                        alt=""
+                        style={{ width: 56, height: 56, borderRadius: "50%", objectFit: "cover", border: "2px solid #fff", boxShadow: "0 2px 8px rgba(0,0,0,0.15)" }}
+                      />
+                    ) : (
+                      <div style={{ width: 56, height: 56, borderRadius: "50%", background: "linear-gradient(135deg,#10B981,#06B6D4)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 20, border: "2px solid #fff" }}>T</div>
+                    )}
+                    {foundersAvatars.melanie_avatar_url ? (
+                      <img
+                        src={foundersAvatars.melanie_avatar_url}
+                        alt=""
+                        style={{ width: 56, height: 56, borderRadius: "50%", objectFit: "cover", border: "2px solid #fff", marginLeft: -14, boxShadow: "0 2px 8px rgba(0,0,0,0.15)" }}
+                      />
+                    ) : (
+                      <div style={{ width: 56, height: 56, borderRadius: "50%", background: "linear-gradient(135deg,#A78BFA,#FB7185)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 20, marginLeft: -14, border: "2px solid #fff" }}>M</div>
+                    )}
                   </div>
-                  <div className="biz-story__hook">« {FOUNDERS_STORY.hook} »</div>
-                  <p className="biz-story__body">{FOUNDERS_STORY.body}</p>
-                </article>
-              )}
+                  <div>
+                    <div className="biz-story__name">Thomas &amp; Mélanie</div>
+                    <div className="biz-story__since">Fondateurs La Base 360 · démarré en 2022</div>
+                  </div>
+                </div>
+                <div className="biz-story__hook">« {FOUNDERS_STORY_TEXT.hook} »</div>
+                <p className="biz-story__body">{FOUNDERS_STORY_TEXT.body}</p>
+              </article>
 
               {/* Partenaires additionnels — textes envoyés par Thomas */}
               {PARTNER_STORIES.map((s, i) => (

--- a/src/pages/BusinessPage.tsx
+++ b/src/pages/BusinessPage.tsx
@@ -39,15 +39,81 @@ interface PartnerStory {
   avatar_url: string | null;
 }
 
-// Histoire fondateurs fusionnée (Thomas + Mélanie). Les avatars sont fetched
-// dynamiquement depuis users.avatar_url via la RPC publique
-// `get_founders_avatars` (cf. migration 20261118400000). Textes ci-dessous à
-// corriger par Thomas si écart avec les vrais parcours.
-const FOUNDERS_STORY_TEXT = {
-  hook: "On a démarré à 2, le soir et les week-ends. Aujourd'hui on en a fait notre métier.",
-  body:
-    "Thomas était dans le marketing digital, Mélanie prof de SVT. En 2022, on a démarré La Base 360 en parallèle de nos jobs. À 6 mois Thomas était Success Builder, à 18 mois il avait quitté son CDI. Mélanie a démarré à temps partiel, juste avec ses copines proches au début — à 1 an elle gagnait déjà plus en coaching qu'en enseignement. Aujourd'hui on accompagne l'équipe qui forme les nouveaux partenaires. Ce qu'on aime ? Construire un revenu une fois et le voir revenir mois après mois.",
-};
+// Histoire fondateurs Tom + Mélanie. Avatars auto via RPC publique
+// `get_founders_avatars` (lit users.avatar_url, migration 20261118400000).
+// Texte officiel envoyé par Thomas 2026-05-18.
+
+type FounderChapter =
+  | { kind: "heading"; text: string }
+  | { kind: "paragraph"; text: string }
+  | { kind: "bullets"; items: string[] };
+
+const FOUNDERS_STORY_TITLE = "Notre histoire";
+
+const FOUNDERS_STORY_CHAPTERS: FounderChapter[] = [
+  { kind: "heading", text: "Avant Herbalife" },
+  {
+    kind: "paragraph",
+    text:
+      "Tom, 15 ans conducteur d'engins sur chantier. Debout à 5h, rentré à 19h. Une routine qui lui prenait tout : le temps avec ses enfants, le sport, la vie. Il faisait déjà du sport, mais les résultats n'étaient pas au rendez-vous. Fatigué. En attente du week-end. En attente des vacances. Il cherchait autre chose — plus de temps, mieux gagner sa vie, offrir une vraie vie à ses enfants. Sans véhicule, sans plan B.",
+  },
+  {
+    kind: "paragraph",
+    text:
+      "Mélanie, 11 ans dans le complément alimentaire pour animaux. Maman de 2 enfants en bas âge, elle vivait ce que beaucoup de mamans vivent : la fatigue qui s'accumule, quelques kilos de grossesse qui ne partaient pas, l'impression de tenir mais de ne plus se reconnaître. Un métier stable, mais sans le sens qu'elle cherchait au fond.",
+  },
+  {
+    kind: "paragraph",
+    text: "Deux parcours différents. Une même envie : retrouver de l'énergie, du temps, et construire quelque chose à eux.",
+  },
+
+  { kind: "heading", text: "Le déclic — mai 2022" },
+  {
+    kind: "paragraph",
+    text:
+      "On leur présente Herbalife. Ils disent oui. Pas parce que c'était facile. Parce qu'ils voyaient pour la première fois un vrai projet : santé, sens, et liberté.",
+  },
+  {
+    kind: "paragraph",
+    text: "Tom démarre sur un protocole de 21 jours. Le résultat tombe vite :",
+  },
+  {
+    kind: "bullets",
+    items: [
+      "–4 kg en 1 mois",
+      "18 personnes accompagnées sur leur remise en forme",
+      "3 partenaires qui rejoignent l'équipe",
+      "1 800 € de revenu complémentaire dès le 1ᵉʳ mois — à côté de son job",
+    ],
+  },
+  {
+    kind: "paragraph",
+    text:
+      "Un an plus tard, Mélanie le rejoint à temps plein. La nutrition la change complètement : elle perd les derniers kilos de grossesse, retrouve une énergie qu'elle avait oubliée, et redevient pleinement elle-même. Plus dynamique. Plus épanouie. Maman, femme, entrepreneure — sur ses propres termes.",
+  },
+
+  { kind: "heading", text: "Aujourd'hui — 4 ans plus tard" },
+  {
+    kind: "bullets",
+    items: [
+      "+ de 250 personnes accompagnées chaque mois avec toute l'équipe",
+      "Des revenus jamais en dessous de 4 000 €/mois",
+      "Plusieurs voyages à travers le monde",
+      "Un agenda qu'on gère nous-mêmes",
+      "La Base Shakes & Drinks à Verdun, notre QG depuis juin 2025",
+    ],
+  },
+
+  { kind: "heading", text: "Demain" },
+  {
+    kind: "paragraph",
+    text: "Doubler, tripler le nombre de personnes accompagnées. Ouvrir les 100 prochains clubs en France — et pourquoi pas à l'international.",
+  },
+  {
+    kind: "paragraph",
+    text: "Ce n'est pas un business. C'est un mouvement. Et on a besoin de toi pour le construire.",
+  },
+];
 
 // Partenaires additionnels (textes Thomas en cours).
 const PARTNER_STORIES: PartnerStory[] = [];
@@ -846,11 +912,10 @@ export function BusinessPage() {
               <p className="biz-section__lead">Deux histoires vraies. Tu peux en écrire une autre.</p>
             </div>
             <div className="biz-stories">
-              {/* Bloc fondateurs fusionné — Thomas + Mélanie en 1 récit
-                  partagé. Avatars auto via RPC get_founders_avatars
-                  (lit users.avatar_url uploadé via Paramètres > Profil).
-                  Fallback gradient initiales si avatar absent. */}
-              <article className="biz-story biz-story--founders biz-reveal">
+              {/* Bloc fondateurs fusionné — Tom + Mélanie en 1 récit en
+                  4 chapitres. Avatars auto via RPC get_founders_avatars
+                  (lit users.avatar_url). Texte officiel Thomas 2026-05-18. */}
+              <article className="biz-story biz-story--founders biz-reveal" style={{ gridColumn: "1 / -1" }}>
                 <div className="biz-story__head">
                   <div
                     className="biz-story__photo biz-story__photo--couple"
@@ -861,28 +926,51 @@ export function BusinessPage() {
                       <img
                         src={foundersAvatars.thomas_avatar_url}
                         alt=""
-                        style={{ width: 56, height: 56, borderRadius: "50%", objectFit: "cover", border: "2px solid #fff", boxShadow: "0 2px 8px rgba(0,0,0,0.15)" }}
+                        style={{ width: 64, height: 64, borderRadius: "50%", objectFit: "cover", border: "3px solid #fff", boxShadow: "0 2px 8px rgba(0,0,0,0.15)" }}
                       />
                     ) : (
-                      <div style={{ width: 56, height: 56, borderRadius: "50%", background: "linear-gradient(135deg,#10B981,#06B6D4)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 20, border: "2px solid #fff" }}>T</div>
+                      <div style={{ width: 64, height: 64, borderRadius: "50%", background: "linear-gradient(135deg,#10B981,#06B6D4)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 22, border: "3px solid #fff" }}>T</div>
                     )}
                     {foundersAvatars.melanie_avatar_url ? (
                       <img
                         src={foundersAvatars.melanie_avatar_url}
                         alt=""
-                        style={{ width: 56, height: 56, borderRadius: "50%", objectFit: "cover", border: "2px solid #fff", marginLeft: -14, boxShadow: "0 2px 8px rgba(0,0,0,0.15)" }}
+                        style={{ width: 64, height: 64, borderRadius: "50%", objectFit: "cover", border: "3px solid #fff", marginLeft: -16, boxShadow: "0 2px 8px rgba(0,0,0,0.15)" }}
                       />
                     ) : (
-                      <div style={{ width: 56, height: 56, borderRadius: "50%", background: "linear-gradient(135deg,#A78BFA,#FB7185)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 20, marginLeft: -14, border: "2px solid #fff" }}>M</div>
+                      <div style={{ width: 64, height: 64, borderRadius: "50%", background: "linear-gradient(135deg,#A78BFA,#FB7185)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 22, marginLeft: -16, border: "3px solid #fff" }}>M</div>
                     )}
                   </div>
                   <div>
-                    <div className="biz-story__name">Thomas &amp; Mélanie</div>
-                    <div className="biz-story__since">Fondateurs La Base 360 · démarré en 2022</div>
+                    <div className="biz-story__name">{FOUNDERS_STORY_TITLE}</div>
+                    <div className="biz-story__since">Tom &amp; Mélanie · fondateurs La Base 360</div>
                   </div>
                 </div>
-                <div className="biz-story__hook">« {FOUNDERS_STORY_TEXT.hook} »</div>
-                <p className="biz-story__body">{FOUNDERS_STORY_TEXT.body}</p>
+                <div className="biz-story__chapters">
+                  {FOUNDERS_STORY_CHAPTERS.map((c, i) => {
+                    if (c.kind === "heading") {
+                      return (
+                        <h4 key={i} className="biz-story__chapter-title">
+                          {c.text}
+                        </h4>
+                      );
+                    }
+                    if (c.kind === "paragraph") {
+                      return (
+                        <p key={i} className="biz-story__chapter-p">
+                          {c.text}
+                        </p>
+                      );
+                    }
+                    return (
+                      <ul key={i} className="biz-story__chapter-list">
+                        {c.items.map((it, j) => (
+                          <li key={j}>{it}</li>
+                        ))}
+                      </ul>
+                    );
+                  })}
+                </div>
               </article>
 
               {/* Partenaires additionnels — textes envoyés par Thomas */}

--- a/src/pages/BusinessPage.tsx
+++ b/src/pages/BusinessPage.tsx
@@ -26,6 +26,32 @@ import { TestimonialsCarousel } from "../components/testimonials/TestimonialsCar
 
 type FormStatus = "idle" | "submitting" | "success" | "error";
 
+// ─── §05 Témoignages partenaires ─────────────────────────────────────────────
+// Refonte 2026-05-18 : 1 seul bloc fondateurs (Thomas + Mélanie ensemble) +
+// slots partenaires additionnels (textes Thomas en cours). Plus de récits
+// inventés.
+
+interface FoundersStory {
+  hook: string;            // une-ligne accroche entre « ... »
+  body: string;            // récit complet partagé
+  thomas_avatar_url: string | null;
+  melanie_avatar_url: string | null;
+}
+
+interface PartnerStory {
+  name: string;            // ex « Sophie M. »
+  since: string;           // ex « Partenaire · démarrée en avril 2024 »
+  hook: string;            // une-ligne accroche entre « ... »
+  body: string;            // récit complet
+  avatar_url: string | null;
+}
+
+// TODO Thomas (envoie textes + URLs photos) : remplir FOUNDERS_STORY et
+// PARTNER_STORIES. Tant que null/vides, la section §05 ne rend que le
+// carrousel témoignages clients en-dessous (pas de placeholder visible).
+const FOUNDERS_STORY: FoundersStory | null = null;
+const PARTNER_STORIES: PartnerStory[] = [];
+
 const FAQ_ITEMS = [
   {
     q: "Combien de temps par semaine je dois y consacrer ?",
@@ -793,28 +819,70 @@ export function BusinessPage() {
               <p className="biz-section__lead">Deux histoires vraies. Tu peux en écrire une autre.</p>
             </div>
             <div className="biz-stories">
-              <article className="biz-story biz-reveal">
-                <div className="biz-story__head">
-                  <div className="biz-story__photo" aria-hidden="true">photo</div>
-                  <div>
-                    <div className="biz-story__name">Thomas K.</div>
-                    <div className="biz-story__since">Fondateur La Base 360 · démarré en mars 2022</div>
+              {/* Bloc fondateurs fusionné — Thomas + Mélanie en 1 récit
+                  partagé. Photos auto via users.avatar_url (à brancher
+                  quand IDs en DB confirmés). */}
+              {FOUNDERS_STORY && (
+                <article className="biz-story biz-story--founders biz-reveal">
+                  <div className="biz-story__head">
+                    <div
+                      className="biz-story__photo biz-story__photo--couple"
+                      aria-hidden="true"
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: -10,
+                      }}
+                    >
+                      {FOUNDERS_STORY.thomas_avatar_url ? (
+                        <img
+                          src={FOUNDERS_STORY.thomas_avatar_url}
+                          alt=""
+                          style={{ width: 56, height: 56, borderRadius: "50%", objectFit: "cover", border: "2px solid #fff" }}
+                        />
+                      ) : (
+                        <div style={{ width: 56, height: 56, borderRadius: "50%", background: "linear-gradient(135deg,#10B981,#06B6D4)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 18 }}>T</div>
+                      )}
+                      {FOUNDERS_STORY.melanie_avatar_url ? (
+                        <img
+                          src={FOUNDERS_STORY.melanie_avatar_url}
+                          alt=""
+                          style={{ width: 56, height: 56, borderRadius: "50%", objectFit: "cover", border: "2px solid #fff", marginLeft: -14 }}
+                        />
+                      ) : (
+                        <div style={{ width: 56, height: 56, borderRadius: "50%", background: "linear-gradient(135deg,#A78BFA,#FB7185)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", fontWeight: 700, fontSize: 18, marginLeft: -14 }}>M</div>
+                      )}
+                    </div>
+                    <div>
+                      <div className="biz-story__name">Thomas &amp; Mélanie</div>
+                      <div className="biz-story__since">Fondateurs La Base 360</div>
+                    </div>
                   </div>
-                </div>
-                <div className="biz-story__hook">« De salarié bureau à 6 chiffres en 18 mois. »</div>
-                <p className="biz-story__body">J'étais dans le marketing digital, salarié confortable mais sans goût. En mars 2022, j'ai démarré La Base 360 le soir et les weekends. À 6 mois j'étais Success Builder. À 18 mois j'ai quitté mon CDI, dépassé les 6 chiffres net sur l'année, et monté l'équipe qui forme aujourd'hui les nouveaux partenaires. Ce que j'aime ? Tu construis ton revenu une fois et il revient mois après mois.</p>
-              </article>
-              <article className="biz-story biz-reveal">
-                <div className="biz-story__head">
-                  <div className="biz-story__photo" aria-hidden="true">photo</div>
-                  <div>
-                    <div className="biz-story__name">Mélanie L.</div>
-                    <div className="biz-story__since">Co-fondatrice · démarrée en juillet 2022</div>
+                  <div className="biz-story__hook">« {FOUNDERS_STORY.hook} »</div>
+                  <p className="biz-story__body">{FOUNDERS_STORY.body}</p>
+                </article>
+              )}
+
+              {/* Partenaires additionnels — textes envoyés par Thomas */}
+              {PARTNER_STORIES.map((s, i) => (
+                <article key={i} className="biz-story biz-reveal">
+                  <div className="biz-story__head">
+                    <div className="biz-story__photo" aria-hidden="true">
+                      {s.avatar_url ? (
+                        <img src={s.avatar_url} alt="" style={{ width: "100%", height: "100%", borderRadius: "50%", objectFit: "cover" }} />
+                      ) : (
+                        s.name?.[0]?.toUpperCase() ?? "?"
+                      )}
+                    </div>
+                    <div>
+                      <div className="biz-story__name">{s.name}</div>
+                      <div className="biz-story__since">{s.since}</div>
+                    </div>
                   </div>
-                </div>
-                <div className="biz-story__hook">« De prof à coach indépendante, sans jamais rien forcer. »</div>
-                <p className="biz-story__body">J'étais prof de SVT en collège. J'aimais le contact, j'étouffais dans le cadre. En juillet 2022, j'ai démarré à temps partiel — uniquement avec mes copines proches au début. À 4 mois, mes premiers clients m'amenaient leurs amis. À 1 an, j'ai posé une dispo, gardé un mi-temps par sécurité, et je gagne aujourd'hui plus en coaching qu'en enseignement. Et surtout : j'aime mes journées.</p>
-              </article>
+                  <div className="biz-story__hook">« {s.hook} »</div>
+                  <p className="biz-story__body">{s.body}</p>
+                </article>
+              ))}
             </div>
             <div className="biz-reveal biz-stories__signature">
               <span>« La seule règle : démarrer. »</span>

--- a/src/pages/BusinessPage.tsx
+++ b/src/pages/BusinessPage.tsx
@@ -32,11 +32,11 @@ type FormStatus = "idle" | "submitting" | "success" | "error";
 // inventés.
 
 interface PartnerStory {
-  name: string;            // ex « Sophie M. »
-  since: string;           // ex « Partenaire · démarrée en avril 2024 »
-  hook: string;            // une-ligne accroche entre « ... »
+  slug: string;            // prénom normalisé (lookup users.avatar_url côté DB)
+  name: string;            // ex « Ambre »
+  since: string;           // ex « Partenaire · Divona Center (Lot 46) »
+  hook: string;            // accroche entre « ... »
   body: string;            // récit complet
-  avatar_url: string | null;
 }
 
 // Histoire fondateurs Tom + Mélanie. Avatars auto via RPC publique
@@ -115,8 +115,35 @@ const FOUNDERS_STORY_CHAPTERS: FounderChapter[] = [
   },
 ];
 
-// Partenaires additionnels (textes Thomas en cours).
-const PARTNER_STORIES: PartnerStory[] = [];
+// Partenaires additionnels (textes Thomas 2026-05-18). Les avatars sont
+// récupérés en batch via RPC `get_avatars_by_slugs` (lit users.avatar_url
+// avec lookup ls_normalize_slug(first_name)).
+const PARTNER_STORIES: PartnerStory[] = [
+  {
+    slug: "ambre",
+    name: "Ambre",
+    since: "Partenaire · Divona Center (Lot 46) · ouvert en juillet",
+    hook: "Digestion retrouvée, +8 kg de muscle, –10 % de masse grasse en 2 ans.",
+    body:
+      "Ambre, 35 ans, maman d'une fille de 4 ans, problème de digestion depuis toute petite. J'ai toujours mangé équilibré et fait du sport, aucune perte de poids. En 2 ans j'ai pris 8 kg de masse musculaire et j'ai perdu 10 % de masse grasse. J'ai retrouvé une digestion normale, de l'énergie et une meilleure hydratation. Pour l'activité, on aide entre 35 et 40 personnes dans le Lot (46), mon meilleur revenu c'est 1 262 € le mois dernier et on a ouvert le Divona Center en juillet.",
+  },
+  {
+    slug: "laura",
+    name: "Laura",
+    since: "Partenaire · ex-responsable salon de coiffure",
+    hook: "+9 kg de muscle en 7 mois, et l'envie d'aider 2 000 personnes en 3 ans.",
+    body:
+      "Laura, 25 ans. J'étais responsable d'un salon de coiffure. J'ai voulu démarrer pour reprendre de la masse musculaire, chose faite : plus de 9 kg de masse musculaire en 7 mois. Au début j'ai commencé l'activité à temps choisi pour faire des compléments de revenus. Maintenant c'est plus de 150 personnes aidées, 2 500 € de revenus avec une vision claire d'aider 2 000 personnes sur les 3 prochaines années.",
+  },
+  {
+    slug: "valentin",
+    name: "Valentin",
+    since: "Partenaire · à temps plein depuis janvier 2023",
+    hook: "–30 kg en 1 an, +12 kg de muscle, le sport retrouvé.",
+    body:
+      "Pour ma part, Valentin, j'ai connu le concept en démarrant sur ma nutrition. Je faisais pas mal de sport, mais une mauvaise nutrition. Suite à des blessures successives, j'ai ralenti sur le sport. Je suis passé de 76 kg à 109 kg. En 1 an j'ai séché 30 kg et repris 12 kg de masse musculaire. Depuis janvier 2023 je développe l'activité à temps plein avec une équipe en construction.",
+  },
+];
 
 const FAQ_ITEMS = [
   {
@@ -175,11 +202,12 @@ export function BusinessPage() {
   const referrerId = params.get("ref");
   const wantsLeadCapture = params.get("leadcapture") === "1";
 
-  // ─── Fondateurs avatars (RPC publique) ────────────────────────────────────
+  // ─── Avatars §05 (fondateurs + partenaires) via RPC publiques ─────────────
   const [foundersAvatars, setFoundersAvatars] = useState<{
     thomas_avatar_url: string | null;
     melanie_avatar_url: string | null;
   }>({ thomas_avatar_url: null, melanie_avatar_url: null });
+  const [partnerAvatars, setPartnerAvatars] = useState<Record<string, string | null>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -187,14 +215,31 @@ export function BusinessPage() {
       try {
         const sb = await getSupabaseClient();
         if (!sb) return;
-        const { data, error } = await sb.rpc("get_founders_avatars");
-        if (cancelled || error || !data) return;
-        const row = Array.isArray(data) ? data[0] : data;
-        if (!row) return;
-        setFoundersAvatars({
-          thomas_avatar_url: row.thomas_avatar_url ?? null,
-          melanie_avatar_url: row.melanie_avatar_url ?? null,
-        });
+
+        // Fondateurs : Thomas + Mélanie
+        const { data: f } = await sb.rpc("get_founders_avatars");
+        if (!cancelled && f) {
+          const row = Array.isArray(f) ? f[0] : f;
+          if (row) {
+            setFoundersAvatars({
+              thomas_avatar_url: row.thomas_avatar_url ?? null,
+              melanie_avatar_url: row.melanie_avatar_url ?? null,
+            });
+          }
+        }
+
+        // Partenaires : batch par slug
+        const slugs = PARTNER_STORIES.map((p) => p.slug);
+        if (slugs.length > 0) {
+          const { data: p } = await sb.rpc("get_avatars_by_slugs", { p_slugs: slugs });
+          if (!cancelled && Array.isArray(p)) {
+            const map: Record<string, string | null> = {};
+            for (const r of p as Array<{ slug: string; avatar_url: string | null }>) {
+              map[r.slug] = r.avatar_url ?? null;
+            }
+            setPartnerAvatars(map);
+          }
+        }
       } catch {
         /* silent : avatars optionnels, fallback gradient initiales */
       }
@@ -973,26 +1018,33 @@ export function BusinessPage() {
                 </div>
               </article>
 
-              {/* Partenaires additionnels — textes envoyés par Thomas */}
-              {PARTNER_STORIES.map((s, i) => (
-                <article key={i} className="biz-story biz-reveal">
-                  <div className="biz-story__head">
-                    <div className="biz-story__photo" aria-hidden="true">
-                      {s.avatar_url ? (
-                        <img src={s.avatar_url} alt="" style={{ width: "100%", height: "100%", borderRadius: "50%", objectFit: "cover" }} />
-                      ) : (
-                        s.name?.[0]?.toUpperCase() ?? "?"
-                      )}
+              {/* Partenaires additionnels — textes Thomas 2026-05-18.
+                  Avatars auto via RPC get_avatars_by_slugs (lookup
+                  ls_normalize_slug(users.first_name)). */}
+              {PARTNER_STORIES.map((s, i) => {
+                const av = partnerAvatars[s.slug] ?? null;
+                return (
+                  <article key={i} className="biz-story biz-reveal">
+                    <div className="biz-story__head">
+                      <div className="biz-story__photo" aria-hidden="true" style={{ overflow: "hidden", padding: 0 }}>
+                        {av ? (
+                          <img src={av} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                        ) : (
+                          <div style={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center", background: "linear-gradient(135deg,#10B981,#06B6D4)", color: "#fff", fontWeight: 700, fontSize: 22 }}>
+                            {s.name?.[0]?.toUpperCase() ?? "?"}
+                          </div>
+                        )}
+                      </div>
+                      <div>
+                        <div className="biz-story__name">{s.name}</div>
+                        <div className="biz-story__since">{s.since}</div>
+                      </div>
                     </div>
-                    <div>
-                      <div className="biz-story__name">{s.name}</div>
-                      <div className="biz-story__since">{s.since}</div>
-                    </div>
-                  </div>
-                  <div className="biz-story__hook">« {s.hook} »</div>
-                  <p className="biz-story__body">{s.body}</p>
-                </article>
-              ))}
+                    <div className="biz-story__hook">« {s.hook} »</div>
+                    <p className="biz-story__body">{s.body}</p>
+                  </article>
+                );
+              })}
             </div>
             <div className="biz-reveal biz-stories__signature">
               <span>« La seule règle : démarrer. »</span>

--- a/src/pages/ClientDetailPage.tsx
+++ b/src/pages/ClientDetailPage.tsx
@@ -343,6 +343,38 @@ export function ClientDetailPage() {
             >
               📋 Suivi
             </Link>
+            {/* Quality fix C (2026-05-18) : bouton demander un témoignage.
+                Copie l'URL générique du coach + ouvre WhatsApp pré-rempli
+                avec un message au prénom du client. */}
+            <button
+              type="button"
+              onClick={() => {
+                const slugSource = (currentUser?.name ?? "").split(/\s+/)[0] ?? "";
+                const slug = slugSource
+                  .toLowerCase()
+                  .normalize("NFD")
+                  .replace(/[̀-ͯ]/g, "")
+                  .replace(/[^a-z0-9]/g, "")
+                  .trim();
+                if (!slug) {
+                  alert("Impossible de générer ton slug coach. Vérifie ton prénom dans les paramètres.");
+                  return;
+                }
+                const url = `${window.location.origin}/temoignage/coach/${slug}`;
+                const firstName = client.firstName || "toi";
+                const message = `Salut ${firstName} 👋\n\nEst-ce que tu pourrais m'aider à grandir en partageant ton ressenti sur notre accompagnement ? Ça prend 30 secondes : ${url}\n\nMerci infiniment 🙏`;
+                navigator.clipboard?.writeText(url).catch(() => {});
+                const waPhone = (client.phone ?? "").replace(/[^0-9]/g, "");
+                const waUrl = waPhone
+                  ? `https://wa.me/${waPhone}?text=${encodeURIComponent(message)}`
+                  : `https://wa.me/?text=${encodeURIComponent(message)}`;
+                window.open(waUrl, "_blank", "noopener");
+              }}
+              className="inline-flex min-h-[40px] items-center gap-2 rounded-[12px] border border-[var(--ls-border2)] bg-[var(--ls-surface2)] px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/[0.08]"
+              title="Copie le lien témoignage + ouvre WhatsApp avec un message pré-rempli"
+            >
+              💬 Demander un témoignage
+            </button>
             <Link
               to="/assessments/new"
               className="inline-flex min-h-[40px] items-center gap-2 rounded-[12px] bg-[#C9A84C] px-4 py-2 text-sm font-bold text-[#0B0D11] transition hover:brightness-105"

--- a/src/pages/DistributorPortfolioPage.tsx
+++ b/src/pages/DistributorPortfolioPage.tsx
@@ -39,6 +39,8 @@ import {
 } from "../components/distributor-blocks";
 import { TeamMemberDrilldownModal } from "../components/team/TeamMemberDrilldownModal";
 import { currentMonthIso } from "../lib/herbalifeFormulas";
+import { RankPinBadge } from "../components/rank/RankPinBadge";
+import type { HerbalifeRank } from "../types/domain";
 
 const statusTone: Record<string, { label: string; tone: "active" | "pending" | "follow-up" }> = {
   active: { label: "Actif", tone: "active" },
@@ -187,7 +189,16 @@ export function DistributorPortfolioPage() {
           <DistributorBadge user={portfolioUser} compact />
           <div>
             <span className="ls-portfolio-header-row__eyebrow">Responsable</span>
-            <h2>{portfolioUser.name}</h2>
+            <h2 style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+              <span>{portfolioUser.name}</span>
+              {portfolioUser.currentRank && (
+                <RankPinBadge
+                  rank={portfolioUser.currentRank as HerbalifeRank}
+                  size="sm"
+                  showLabel
+                />
+              )}
+            </h2>
             <div className="ls-portfolio-hero__meta">
               <RoleBadge role={portfolioUser.role} />
               <span>{portfolioUser.title || "La Base 360"}</span>

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -1638,6 +1638,50 @@ export async function loadPvBreakdownsForMonth(
   }));
 }
 
+// ─── Distributor qualifications (fenêtres glissantes 2/3/6/12 mois) ──────
+/**
+ * Appelle la RPC `get_distributor_qualifications` qui retourne les PV perso
+ * du distri sur les 4 fenêtres glissantes Herbalife + les booleans qualifs.
+ * Voir migration 20261118000000_distributor_qualifications.sql.
+ */
+export async function fetchDistributorQualifications(
+  userId: string,
+  asOfMonth: string,
+): Promise<{
+  pv_2m: number;
+  pv_3m: number;
+  pv_6m: number;
+  pv_12m: number;
+  qualified_senior_consultant: boolean;
+  qualified_success_builder: boolean;
+  qualified_qp: boolean;
+  qualified_supervisor: boolean;
+  rank_calculated: string;
+} | null> {
+  const client = await requireSupabase();
+  const { data, error } = await client.rpc("get_distributor_qualifications", {
+    p_user_id: userId,
+    p_as_of_month: asOfMonth,
+  });
+  if (error || !data) {
+    if (error) console.warn("[fetchDistributorQualifications] rpc error", error);
+    return null;
+  }
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) return null;
+  return {
+    pv_2m: Number(row.pv_2m ?? 0),
+    pv_3m: Number(row.pv_3m ?? 0),
+    pv_6m: Number(row.pv_6m ?? 0),
+    pv_12m: Number(row.pv_12m ?? 0),
+    qualified_senior_consultant: !!row.qualified_senior_consultant,
+    qualified_success_builder: !!row.qualified_success_builder,
+    qualified_qp: !!row.qualified_qp,
+    qualified_supervisor: !!row.qualified_supervisor,
+    rank_calculated: String(row.rank_calculated ?? "distributor_25"),
+  };
+}
+
 // ─── Manual PV entries V3 (distri hors-app) ───────────────────────────────
 export async function upsertManualPvEntry(params: {
   id: string | null;

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -1652,6 +1652,7 @@ export async function fetchDistributorQualifications(
   pv_3m: number;
   pv_6m: number;
   pv_12m: number;
+  pv_12m_extended: number;
   qualified_senior_consultant: boolean;
   qualified_success_builder: boolean;
   qualified_qp: boolean;
@@ -1674,6 +1675,10 @@ export async function fetchDistributorQualifications(
     pv_3m: Number(row.pv_3m ?? 0),
     pv_6m: Number(row.pv_6m ?? 0),
     pv_12m: Number(row.pv_12m ?? 0),
+    // V2 (migration 20261118200000) : si la RPC vieille version est encore
+    // en place (avant apply), pv_12m_extended sera undefined → fallback
+    // sur pv_12m pour ne pas casser l'UI le temps de l'apply.
+    pv_12m_extended: Number(row.pv_12m_extended ?? row.pv_12m ?? 0),
     qualified_senior_consultant: !!row.qualified_senior_consultant,
     qualified_success_builder: !!row.qualified_success_builder,
     qualified_qp: !!row.qualified_qp,

--- a/supabase/functions/submit-testimonial/index.ts
+++ b/supabase/functions/submit-testimonial/index.ts
@@ -33,19 +33,31 @@ function json(payload: unknown, status = 200): Response {
   });
 }
 
-const RATE_BUCKET = new Map<string, number[]>();
-const RATE_WINDOW_MS = 60 * 60 * 1000; // 1h pour mode token, plus restrictif mode generique
+// Rate limit persisté en DB depuis le quality fix D (2026-05-18). On délègue
+// à la RPC `check_testimonial_rate` qui résiste aux redeploy de l'edge fn.
+const RATE_WINDOW_SECONDS = 60 * 60; // 1h
 const RATE_MAX_TOKEN = 3;
-const RATE_MAX_SLUG = 2; // 2 par heure par IP en mode generique
-function checkRateLimit(ip: string, max: number): { ok: true } | { ok: false; retry_after: number } {
-  const now = Date.now();
-  const history = (RATE_BUCKET.get(ip) ?? []).filter((t) => now - t < RATE_WINDOW_MS);
-  if (history.length >= max) {
-    return { ok: false, retry_after: Math.ceil((history[0] + RATE_WINDOW_MS - now) / 1000) };
-  }
-  history.push(now);
-  RATE_BUCKET.set(ip, history);
-  return { ok: true };
+const RATE_MAX_SLUG = 2;
+
+async function checkRateLimit(
+  sb: ReturnType<typeof createClient>,
+  ip: string,
+  mode: "token" | "slug",
+  max: number,
+): Promise<{ ok: true } | { ok: false; retry_after: number }> {
+  const { data, error } = await sb.rpc("check_testimonial_rate", {
+    p_ip: ip,
+    p_mode: mode,
+    p_max: max,
+    p_window_seconds: RATE_WINDOW_SECONDS,
+  });
+  // Fail-open si la RPC plante : on laisse passer pour ne jamais bloquer une
+  // soumission légitime. La sécurité reste assurée par anti-doublon + auth.
+  if (error || !data) return { ok: true };
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) return { ok: true };
+  if (row.allowed) return { ok: true };
+  return { ok: false, retry_after: Number(row.retry_after_seconds ?? 60) };
 }
 
 function normalizeSlug(input: string): string {
@@ -106,7 +118,7 @@ serve(async (req) => {
     if (!/^[0-9a-f-]{36}$/i.test(clientToken)) {
       return json({ success: false, error: "Token client invalide." }, 400);
     }
-    const rl = checkRateLimit(ip, RATE_MAX_TOKEN);
+    const rl = await checkRateLimit(sb, ip, "token", RATE_MAX_TOKEN);
     if (!rl.ok) {
       return json({ success: false, error: "rate_limited", retry_after_seconds: rl.retry_after }, 429);
     }
@@ -170,7 +182,7 @@ serve(async (req) => {
   if (city.length < 2) {
     return json({ success: false, error: "Indique au moins ta ville." }, 400);
   }
-  const rl = checkRateLimit(ip, RATE_MAX_SLUG);
+  const rl = await checkRateLimit(sb, ip, "slug", RATE_MAX_SLUG);
   if (!rl.ok) {
     return json({ success: false, error: "rate_limited", retry_after_seconds: rl.retry_after }, 429);
   }
@@ -209,7 +221,7 @@ serve(async (req) => {
     .from("client_testimonials")
     .insert({
       client_id: null,
-      client_token: "00000000-0000-0000-0000-000000000000", // sentinel pour col NOT NULL legacy
+      client_token: null, // depuis quality fix A (2026-05-18) la col est nullable
       coach_user_id: coachUserId,
       coach_slug: coachSlug,
       content: contentWithMeta,

--- a/supabase/migrations/20261118000000_distributor_qualifications.sql
+++ b/supabase/migrations/20261118000000_distributor_qualifications.sql
@@ -1,0 +1,155 @@
+-- =============================================================================
+-- Distributor qualifications : fenêtres glissantes 2 / 3 / 6 / 12 mois
+-- 2026-05-18 (chantier feat/jauge-fenetre-glissante)
+-- =============================================================================
+--
+-- Contexte : la jauge Progression utilisait jusqu'ici `pv_monthly_breakdown`
+-- du MOIS COURANT uniquement. Or les règles Herbalife exigent une qualification
+-- sur FENÊTRE GLISSANTE :
+--   - Senior Consultant 35%   : 500  PV sur 2  mois glissants
+--   - Success Builder 42%     : 1000 PV sur 3  mois glissants
+--   - Qualified Producer (QP) : 2500 PV sur 6  mois glissants  (waypoint)
+--   - Supervisor 50%          : 4000 PV sur 1-12 mois glissants
+--
+-- Cette migration apporte 2 RPC + 1 helper SQL :
+--   1) _pv_window_personal_total(user, window_months, as_of_month)
+--      → somme PV perso (pv_15+pv_25+pv_35+pv_42+pv_royalty) sur N mois
+--        glissants finissant à `as_of_month` (inclus).
+--   2) get_distributor_qualifications(user, as_of_month)
+--      → retourne 1 row : pv_2m / pv_3m / pv_6m / pv_12m + booleans qualif
+--        + rank_calculated (rang max atteint d'après ces fenêtres, scope PV
+--        perso seulement — l'extension downline non-Sup reste calculée côté
+--        front via computeQualifyingPersonalPv pour la prochaine étape).
+--   3) _rank_from_pv_windows(pv_2m, pv_3m, pv_12m)
+--      → utilitaire pur de calcul du rang max, partagé par RPC + futur trigger.
+--
+-- Sécurité : SECURITY DEFINER + GRANT EXECUTE TO authenticated. Aucun side
+-- effect : lecture seule sur pv_monthly_breakdown.
+--
+-- Périmètre Étape 1 : RPC + helpers seulement. L'auto-update de
+-- users.current_rank arrive en Étape 3 (trigger upgrade-only).
+-- =============================================================================
+
+-- ─── Helper : somme PV perso sur N mois glissants ────────────────────────────
+CREATE OR REPLACE FUNCTION public._pv_window_personal_total(
+  p_user_id uuid,
+  p_window_months int,
+  p_as_of_month text
+)
+RETURNS numeric
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_as_of date;
+  v_start date;
+  v_total numeric;
+BEGIN
+  IF p_as_of_month !~ '^[0-9]{4}-[0-9]{2}$' THEN
+    RAISE EXCEPTION 'p_as_of_month must be YYYY-MM';
+  END IF;
+  IF p_window_months < 1 OR p_window_months > 24 THEN
+    RAISE EXCEPTION 'p_window_months must be between 1 and 24';
+  END IF;
+
+  v_as_of := to_date(p_as_of_month || '-01', 'YYYY-MM-DD');
+  v_start := v_as_of - ((p_window_months - 1) || ' month')::interval;
+
+  SELECT COALESCE(SUM(pv_15 + pv_25 + pv_35 + pv_42 + pv_royalty), 0)
+    INTO v_total
+    FROM public.pv_monthly_breakdown
+   WHERE user_id = p_user_id
+     AND to_date(month || '-01', 'YYYY-MM-DD') >= v_start
+     AND to_date(month || '-01', 'YYYY-MM-DD') <= v_as_of;
+
+  RETURN v_total;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public._pv_window_personal_total(uuid, int, text)
+  TO authenticated;
+
+-- ─── Helper pur : rang max atteint d'après les fenêtres PV ───────────────────
+-- IMMUTABLE car sans I/O, partagé entre RPC et trigger Étape 3.
+-- N.B. : ne considère que les paliers basés PV (distributor_25 →
+-- supervisor_50). Les paliers structurels (world_team_50+) restent gérés
+-- manuellement par admin via RangHerbalifeBlock.
+CREATE OR REPLACE FUNCTION public._rank_from_pv_windows(
+  p_pv_2m  numeric,
+  p_pv_3m  numeric,
+  p_pv_12m numeric
+)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+BEGIN
+  -- Ordre du plus haut au plus bas (premier match gagne).
+  IF p_pv_12m >= 4000 THEN RETURN 'supervisor_50';        END IF;
+  IF p_pv_3m  >= 1000 THEN RETURN 'success_builder_42';   END IF;
+  IF p_pv_2m  >= 500  THEN RETURN 'senior_consultant_35'; END IF;
+  RETURN 'distributor_25';
+END;
+$$;
+
+-- ─── RPC principale : qualifications d'un distri à un mois donné ─────────────
+DROP FUNCTION IF EXISTS public.get_distributor_qualifications(uuid, text);
+CREATE OR REPLACE FUNCTION public.get_distributor_qualifications(
+  p_user_id uuid,
+  p_as_of_month text DEFAULT to_char(now() AT TIME ZONE 'Europe/Paris', 'YYYY-MM')
+)
+RETURNS TABLE (
+  pv_2m  numeric,
+  pv_3m  numeric,
+  pv_6m  numeric,
+  pv_12m numeric,
+  qualified_senior_consultant boolean,  -- 500  / 2m
+  qualified_success_builder   boolean,  -- 1000 / 3m
+  qualified_qp                boolean,  -- 2500 / 6m  (waypoint)
+  qualified_supervisor        boolean,  -- 4000 / 12m
+  rank_calculated text                  -- rang max parmi {distri, SC, SB, Sup}
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_2m  numeric;
+  v_3m  numeric;
+  v_6m  numeric;
+  v_12m numeric;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF p_as_of_month !~ '^[0-9]{4}-[0-9]{2}$' THEN
+    RAISE EXCEPTION 'p_as_of_month must be YYYY-MM';
+  END IF;
+
+  v_2m  := public._pv_window_personal_total(p_user_id, 2,  p_as_of_month);
+  v_3m  := public._pv_window_personal_total(p_user_id, 3,  p_as_of_month);
+  v_6m  := public._pv_window_personal_total(p_user_id, 6,  p_as_of_month);
+  v_12m := public._pv_window_personal_total(p_user_id, 12, p_as_of_month);
+
+  pv_2m  := v_2m;
+  pv_3m  := v_3m;
+  pv_6m  := v_6m;
+  pv_12m := v_12m;
+  qualified_senior_consultant := (v_2m  >= 500);
+  qualified_success_builder   := (v_3m  >= 1000);
+  qualified_qp                := (v_6m  >= 2500);
+  qualified_supervisor        := (v_12m >= 4000);
+  rank_calculated := public._rank_from_pv_windows(v_2m, v_3m, v_12m);
+
+  RETURN NEXT;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_distributor_qualifications(uuid, text)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.get_distributor_qualifications(uuid, text) IS
+  'Qualifications Herbalife d''un distri sur fenêtres glissantes 2/3/6/12 mois. Source PV perso uniquement (downline non-Sup ajouté côté front via computeQualifyingPersonalPv). Règles 2026-05-18.';

--- a/supabase/migrations/20261118100000_auto_promote_current_rank.sql
+++ b/supabase/migrations/20261118100000_auto_promote_current_rank.sql
@@ -1,0 +1,107 @@
+-- =============================================================================
+-- Auto-promotion users.current_rank — UPGRADE ONLY (jamais downgrade)
+-- 2026-05-18 (chantier feat/jauge-fenetre-glissante, suite migration RPC)
+-- =============================================================================
+--
+-- Quand un distri saisit (ou un admin lui saisit) des PV qui le qualifient
+-- à un palier supérieur d'après la fenêtre glissante, son rang Herbalife
+-- doit changer automatiquement.
+--
+-- Décision produit Thomas (2026-05-18) : on NE descend JAMAIS automatiquement.
+-- Si la fenêtre glissante repasse sous le seuil, le pin reste — re-qualif
+-- manuelle par admin via RangHerbalifeBlock pour redescendre.
+--
+-- Périmètre du trigger :
+--   - Calcule le rang max d'après les fenêtres 2m / 3m / 12m via
+--     `_rank_from_pv_windows` (migration 20261118000000).
+--   - Compare avec users.current_rank actuel via `_rank_order`.
+--   - Si nouveau rang > actuel ET nouveau rang ≤ supervisor_50, UPDATE.
+--   - Les paliers structurels (world_team_50+) ne sont JAMAIS touchés ici
+--     (ils dépendent de la structure downline, pas des PV perso).
+--
+-- Le trigger est AFTER INSERT OR UPDATE sur pv_monthly_breakdown — fire
+-- après que la nouvelle row est dispo pour le calcul `_pv_window_personal_total`.
+-- =============================================================================
+
+-- ─── Helper : ordre numérique des rangs (1=distri → 8=presidents) ────────────
+CREATE OR REPLACE FUNCTION public._rank_order(p_rank text)
+RETURNS int
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+BEGIN
+  RETURN CASE p_rank
+    WHEN 'distributor_25'       THEN 1
+    WHEN 'senior_consultant_35' THEN 2
+    WHEN 'success_builder_42'   THEN 3
+    WHEN 'supervisor_50'        THEN 4
+    WHEN 'world_team_50'        THEN 5
+    WHEN 'get_team_50'          THEN 6
+    WHEN 'millionaire_50'       THEN 7
+    WHEN 'presidents_50'        THEN 8
+    ELSE 1
+  END;
+END;
+$$;
+
+-- ─── Trigger function : promote si fenêtre glissante qualifie un palier sup ─
+CREATE OR REPLACE FUNCTION public._tg_auto_promote_current_rank()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_month text;
+  v_current_rank text;
+  v_calculated_rank text;
+  v_pv_2m numeric;
+  v_pv_3m numeric;
+  v_pv_12m numeric;
+BEGIN
+  v_user_id := NEW.user_id;
+  v_month   := NEW.month;
+
+  -- 1) Rang actuel du distri
+  SELECT current_rank INTO v_current_rank
+    FROM public.users
+   WHERE id = v_user_id;
+  IF v_current_rank IS NULL THEN
+    v_current_rank := 'distributor_25';
+  END IF;
+
+  -- 2) Si déjà Supervisor ou plus haut, on ne touche jamais (les paliers
+  --    structurels world_team+ ne se calculent pas depuis les PV).
+  IF public._rank_order(v_current_rank) >= 4 THEN
+    RETURN NEW;
+  END IF;
+
+  -- 3) Calcule les 3 fenêtres pertinentes au mois de la row modifiée.
+  v_pv_2m  := public._pv_window_personal_total(v_user_id, 2,  v_month);
+  v_pv_3m  := public._pv_window_personal_total(v_user_id, 3,  v_month);
+  v_pv_12m := public._pv_window_personal_total(v_user_id, 12, v_month);
+
+  v_calculated_rank := public._rank_from_pv_windows(v_pv_2m, v_pv_3m, v_pv_12m);
+
+  -- 4) Promotion uniquement (upgrade only — règle Thomas 2026-05-18).
+  IF public._rank_order(v_calculated_rank) > public._rank_order(v_current_rank) THEN
+    UPDATE public.users
+       SET current_rank = v_calculated_rank,
+           rank_set_at  = now()
+     WHERE id = v_user_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ─── Wire le trigger ─────────────────────────────────────────────────────────
+DROP TRIGGER IF EXISTS tg_auto_promote_current_rank ON public.pv_monthly_breakdown;
+CREATE TRIGGER tg_auto_promote_current_rank
+  AFTER INSERT OR UPDATE ON public.pv_monthly_breakdown
+  FOR EACH ROW
+  EXECUTE FUNCTION public._tg_auto_promote_current_rank();
+
+COMMENT ON FUNCTION public._tg_auto_promote_current_rank() IS
+  'Trigger upgrade-only : promote users.current_rank si la fenêtre glissante PV qualifie un palier supérieur (jamais au-dessus de supervisor_50). Jamais de downgrade auto (règle Thomas 2026-05-18).';

--- a/supabase/migrations/20261118200000_distributor_qualifications_v2_extended.sql
+++ b/supabase/migrations/20261118200000_distributor_qualifications_v2_extended.sql
@@ -1,0 +1,234 @@
+-- =============================================================================
+-- Distributor qualifications V2 : PV étendu glissant 12 mois (self + downline)
+-- 2026-05-18 (suite chantier feat/jauge-fenetre-glissante)
+-- =============================================================================
+--
+-- V1 (migration 20261118000000) ne calculait que les PV PERSO du distri sur
+-- les fenêtres glissantes. Pour la qualification Supervisor, la règle
+-- Herbalife exige le PV PERSONNEL ÉTENDU = perso + downline NON-Supervisor
+-- (chaque branche s'arrête au premier Supervisor rencontré, ses PV basculent
+-- en Royalty Override pour les paliers supérieurs).
+--
+-- Le compromis V1 côté front (MAX(pv_12m_perso, extended_mois_courant)) rate
+-- les cas où la downline accumule sur plusieurs mois sans rien faire le mois
+-- courant — ex. 8 distri à 500 PV/mois pendant 12 mois = 4000 PV cumul mais
+-- 0 ce mois → V1 affichait 0/4000.
+--
+-- Cette V2 ajoute :
+--   1) `_pv_window_extended_total(user_id, window_months, as_of_month)`
+--      → somme PV (5 colonnes pv_*) sur fenêtre glissante, sur self + tous
+--        descendants NON-Supervisor (BFS récursif via sponsor_id).
+--   2) Étend `get_distributor_qualifications` avec `pv_12m_extended`.
+--
+-- Simplification métier : la condition "non-Sup" est évaluée sur le rang
+-- ACTUEL (users.current_rank), pas mois par mois. L'historique de rang
+-- mensuel n'existe pas dans le schéma — précision suffisante en pratique.
+--
+-- Self est inclus inconditionnellement (même si le distri est Supervisor,
+-- on calcule quand même son extended — la jauge UI ne s'affiche plus à ce
+-- niveau de toute façon).
+-- =============================================================================
+
+-- ─── Helper : PV étendu glissant (self + descendants non-Sup) ────────────────
+CREATE OR REPLACE FUNCTION public._pv_window_extended_total(
+  p_user_id uuid,
+  p_window_months int,
+  p_as_of_month text
+)
+RETURNS numeric
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_as_of date;
+  v_start date;
+  v_total numeric;
+BEGIN
+  IF p_as_of_month !~ '^[0-9]{4}-[0-9]{2}$' THEN
+    RAISE EXCEPTION 'p_as_of_month must be YYYY-MM';
+  END IF;
+  IF p_window_months < 1 OR p_window_months > 24 THEN
+    RAISE EXCEPTION 'p_window_months must be between 1 and 24';
+  END IF;
+
+  v_as_of := to_date(p_as_of_month || '-01', 'YYYY-MM-DD');
+  v_start := v_as_of - ((p_window_months - 1) || ' month')::interval;
+
+  -- CTE récursive : self inclus + tous descendants non-Supervisor.
+  -- On s'arrête à chaque Supervisor rencontré (sa branche "casse" pour ce
+  -- calcul — règle breakaway Herbalife).
+  WITH RECURSIVE scope AS (
+    -- Self (inclus inconditionnellement)
+    SELECT u.id, u.current_rank, u.frozen_at
+      FROM public.users u
+     WHERE u.id = p_user_id
+    UNION ALL
+    -- Descendants non-Sup (rank_order < 4 = en-dessous de supervisor_50)
+    SELECT u.id, u.current_rank, u.frozen_at
+      FROM public.users u
+      JOIN scope s ON u.sponsor_id = s.id
+     WHERE public._rank_order(COALESCE(u.current_rank, 'distributor_25')) < 4
+       AND u.frozen_at IS NULL
+  )
+  SELECT COALESCE(SUM(b.pv_15 + b.pv_25 + b.pv_35 + b.pv_42 + b.pv_royalty), 0)
+    INTO v_total
+    FROM public.pv_monthly_breakdown b
+    JOIN scope s ON b.user_id = s.id
+   WHERE to_date(b.month || '-01', 'YYYY-MM-DD') >= v_start
+     AND to_date(b.month || '-01', 'YYYY-MM-DD') <= v_as_of;
+
+  RETURN v_total;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public._pv_window_extended_total(uuid, int, text)
+  TO authenticated;
+
+COMMENT ON FUNCTION public._pv_window_extended_total(uuid, int, text) IS
+  'Somme PV (5 colonnes) sur fenêtre glissante, sur self + descendants NON-Supervisor (règle breakaway Herbalife). Utilisé pour qualif Supervisor 4000 PV / 12 mois.';
+
+-- ─── Drop et recrée get_distributor_qualifications avec pv_12m_extended ──────
+DROP FUNCTION IF EXISTS public.get_distributor_qualifications(uuid, text);
+CREATE OR REPLACE FUNCTION public.get_distributor_qualifications(
+  p_user_id uuid,
+  p_as_of_month text DEFAULT to_char(now() AT TIME ZONE 'Europe/Paris', 'YYYY-MM')
+)
+RETURNS TABLE (
+  pv_2m  numeric,
+  pv_3m  numeric,
+  pv_6m  numeric,
+  pv_12m numeric,
+  pv_12m_extended numeric,             -- NEW V2 : self + downline non-Sup, 12m glissants
+  qualified_senior_consultant boolean, -- 500  / 2m
+  qualified_success_builder   boolean, -- 1000 / 3m
+  qualified_qp                boolean, -- 2500 / 6m   (waypoint)
+  qualified_supervisor        boolean, -- 4000 / 12m EXTENDED (V2)
+  rank_calculated text
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_2m  numeric;
+  v_3m  numeric;
+  v_6m  numeric;
+  v_12m numeric;
+  v_12m_extended numeric;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF p_as_of_month !~ '^[0-9]{4}-[0-9]{2}$' THEN
+    RAISE EXCEPTION 'p_as_of_month must be YYYY-MM';
+  END IF;
+
+  v_2m  := public._pv_window_personal_total(p_user_id, 2,  p_as_of_month);
+  v_3m  := public._pv_window_personal_total(p_user_id, 3,  p_as_of_month);
+  v_6m  := public._pv_window_personal_total(p_user_id, 6,  p_as_of_month);
+  v_12m := public._pv_window_personal_total(p_user_id, 12, p_as_of_month);
+  v_12m_extended := public._pv_window_extended_total(p_user_id, 12, p_as_of_month);
+
+  pv_2m  := v_2m;
+  pv_3m  := v_3m;
+  pv_6m  := v_6m;
+  pv_12m := v_12m;
+  pv_12m_extended := v_12m_extended;
+  qualified_senior_consultant := (v_2m  >= 500);
+  qualified_success_builder   := (v_3m  >= 1000);
+  qualified_qp                := (v_6m  >= 2500);
+  -- V2 : on utilise le PV ÉTENDU pour la qualif Supervisor (règle officielle)
+  qualified_supervisor        := (v_12m_extended >= 4000);
+  -- rank_calculated : utilise extended pour le seuil Supervisor (cohérent UI)
+  IF v_12m_extended >= 4000 THEN
+    rank_calculated := 'supervisor_50';
+  ELSIF v_3m >= 1000 THEN
+    rank_calculated := 'success_builder_42';
+  ELSIF v_2m >= 500 THEN
+    rank_calculated := 'senior_consultant_35';
+  ELSE
+    rank_calculated := 'distributor_25';
+  END IF;
+
+  RETURN NEXT;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_distributor_qualifications(uuid, text)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.get_distributor_qualifications(uuid, text) IS
+  'Qualifications Herbalife V2 : ajoute pv_12m_extended (self + downline non-Sup) pour la qualif Supervisor sur fenêtre 12 mois glissants. Règles 2026-05-18.';
+
+-- ─── Et le trigger d'auto-promotion : il doit aussi utiliser extended ────────
+-- Le trigger 20261118100000 lit `_rank_from_pv_windows(pv_2m, pv_3m, pv_12m)`
+-- qui ne connaît pas pv_12m_extended. Pour rester cohérent avec la jauge UI,
+-- on patch le trigger pour qu'il calcule pv_12m_extended et l'utilise pour
+-- la borne Supervisor. On garde `_rank_from_pv_windows` legacy pour
+-- compatibilité (utile si un autre caller).
+CREATE OR REPLACE FUNCTION public._tg_auto_promote_current_rank()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_month text;
+  v_current_rank text;
+  v_calculated_rank text;
+  v_pv_2m numeric;
+  v_pv_3m numeric;
+  v_pv_12m_extended numeric;
+BEGIN
+  v_user_id := NEW.user_id;
+  v_month   := NEW.month;
+
+  SELECT current_rank INTO v_current_rank
+    FROM public.users
+   WHERE id = v_user_id;
+  IF v_current_rank IS NULL THEN
+    v_current_rank := 'distributor_25';
+  END IF;
+
+  IF public._rank_order(v_current_rank) >= 4 THEN
+    RETURN NEW;
+  END IF;
+
+  v_pv_2m := public._pv_window_personal_total(v_user_id, 2, v_month);
+  v_pv_3m := public._pv_window_personal_total(v_user_id, 3, v_month);
+  v_pv_12m_extended := public._pv_window_extended_total(v_user_id, 12, v_month);
+
+  -- V2 : utilise pv_12m_extended pour la borne Supervisor
+  IF v_pv_12m_extended >= 4000 THEN
+    v_calculated_rank := 'supervisor_50';
+  ELSIF v_pv_3m >= 1000 THEN
+    v_calculated_rank := 'success_builder_42';
+  ELSIF v_pv_2m >= 500 THEN
+    v_calculated_rank := 'senior_consultant_35';
+  ELSE
+    v_calculated_rank := 'distributor_25';
+  END IF;
+
+  IF public._rank_order(v_calculated_rank) > public._rank_order(v_current_rank) THEN
+    UPDATE public.users
+       SET current_rank = v_calculated_rank,
+           rank_set_at  = now()
+     WHERE id = v_user_id;
+  END IF;
+
+  RETURN NEW;
+EXCEPTION
+  -- Sécurité : un trigger qui plante ne doit JAMAIS bloquer la saisie PV.
+  -- Si le calcul extended échoue (cas dégénéré BFS), on laisse passer.
+  WHEN OTHERS THEN
+    RAISE NOTICE 'auto-promote skipped for user % : %', v_user_id, SQLERRM;
+    RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public._tg_auto_promote_current_rank() IS
+  'Trigger upgrade-only V2 : utilise pv_12m_extended pour qualif Supervisor (self + downline non-Sup). UPGRADE ONLY, jamais downgrade. Catch tout exception pour ne jamais bloquer la saisie PV.';

--- a/supabase/migrations/20261118300000_testimonials_quality_fixes.sql
+++ b/supabase/migrations/20261118300000_testimonials_quality_fixes.sql
@@ -1,0 +1,247 @@
+-- =============================================================================
+-- Chantier #11 — Quality fixes (2026-05-18)
+-- =============================================================================
+-- Suite à l'audit qualité demandé par Thomas, 4 fixes :
+--   A. client_token devient nullable (vire le sentinel UUID 00000000-...)
+--   B. anti-collision slug coach (trigger BEFORE INSERT/UPDATE users)
+--   D. rate limit persistant en table (au lieu de Map RAM volatile)
+--   E. restauration cron J+60 (digest admin, pas par client individuel)
+-- =============================================================================
+
+begin;
+
+-- ─── Extension unaccent (requise par ls_normalize_slug) ──────────────────────
+create extension if not exists unaccent;
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- ─── A. client_token nullable + nettoyage sentinel ───────────────────────────
+alter table public.client_testimonials
+  alter column client_token drop not null;
+
+update public.client_testimonials
+   set client_token = null
+ where client_token = '00000000-0000-0000-0000-000000000000';
+
+comment on column public.client_testimonials.client_token is
+  'Optionnel : token client_app_accounts si mode V1 per-client. NULL si mode
+   V1.1 lien generique coach. Plus de sentinel UUID depuis migration quality
+   fixes 2026-05-18.';
+
+-- ─── Helper : normalisation slug (avec gestion accents via unaccent) ────────
+create or replace function public.ls_normalize_slug(p_input text)
+returns text
+language sql
+immutable
+as $$
+  select trim(regexp_replace(
+    lower(unaccent(coalesce(p_input, ''))),
+    '[^a-z0-9]', '', 'g'
+  ));
+$$;
+
+comment on function public.ls_normalize_slug(text) is
+  'Normalise un texte en slug stable (lowercase, sans accents, alphanum only).
+   Utilise pour generer le slug coach a partir de users.name (prenom).';
+
+-- ─── B. Trigger anti-collision slug coach ────────────────────────────────────
+-- Quand un user devient actif distributor/admin/referent, on verifie qu'aucun
+-- autre coach actif n'a deja le meme slug (prenom normalise). Si collision,
+-- l'INSERT/UPDATE est bloque avec un message explicite.
+
+create or replace function public._check_coach_slug_unique()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_slug text;
+  v_count int;
+  v_first_name text;
+begin
+  -- Skip si user pas concerne par les pages publiques
+  if NEW.active is false then return NEW; end if;
+  if NEW.role is null or NEW.role not in ('distributor', 'admin', 'referent') then
+    return NEW;
+  end if;
+
+  v_first_name := split_part(coalesce(NEW.name, ''), ' ', 1);
+  v_slug := public.ls_normalize_slug(v_first_name);
+  if length(v_slug) < 2 then return NEW; end if;
+
+  select count(*) into v_count
+    from public.users
+   where id <> NEW.id
+     and active = true
+     and role in ('distributor', 'admin', 'referent')
+     and public.ls_normalize_slug(split_part(coalesce(name, ''), ' ', 1)) = v_slug;
+
+  if v_count > 0 then
+    raise exception 'Slug coach « % » deja utilise par un autre coach actif. Ajoute une initiale au prenom (ex « Marie L. ») ou choisis un prenom court different.', v_slug
+      using errcode = 'unique_violation';
+  end if;
+  return NEW;
+end;
+$$;
+
+drop trigger if exists tg_coach_slug_unique on public.users;
+create trigger tg_coach_slug_unique
+  before insert or update of name, role, active on public.users
+  for each row
+  execute function public._check_coach_slug_unique();
+
+comment on function public._check_coach_slug_unique() is
+  'Empeche 2 coaches actifs d''avoir le meme prenom normalise (= meme slug
+   public). Evite la collision sur /temoignage/coach/:slug et /bilan-online/:slug.';
+
+-- Log info sur les collisions existantes (NOTICE, ne bloque pas la migration)
+do $$
+declare
+  r record;
+begin
+  for r in
+    select public.ls_normalize_slug(split_part(name, ' ', 1)) as slug,
+           array_agg(name) as names,
+           count(*) as n
+      from public.users
+     where active = true
+       and role in ('distributor', 'admin', 'referent')
+       and length(coalesce(name, '')) >= 2
+     group by 1
+    having count(*) > 1
+  loop
+    raise notice 'Collision slug coach EXISTANTE : « % » utilise par %', r.slug, r.names;
+  end loop;
+end$$;
+
+-- ─── D. Rate limit persistant en table ──────────────────────────────────────
+create table if not exists public.testimonial_rate_log (
+  id bigserial primary key,
+  ip text not null,
+  mode text not null check (mode in ('token', 'slug')),
+  attempted_at timestamptz not null default now()
+);
+create index if not exists testimonial_rate_log_ip_idx
+  on public.testimonial_rate_log (ip, mode, attempted_at desc);
+
+alter table public.testimonial_rate_log enable row level security;
+drop policy if exists testimonial_rate_log_no_direct on public.testimonial_rate_log;
+create policy testimonial_rate_log_no_direct on public.testimonial_rate_log
+  for all to authenticated using (false) with check (false);
+
+create or replace function public.check_testimonial_rate(
+  p_ip text,
+  p_mode text,
+  p_max int default 3,
+  p_window_seconds int default 3600
+)
+returns table (allowed boolean, retry_after_seconds int)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_count int;
+  v_oldest_in_window timestamptz;
+begin
+  if p_ip is null or p_ip = '' then
+    allowed := true; retry_after_seconds := 0; return next; return;
+  end if;
+
+  -- GC opportuniste (> 1 jour)
+  delete from public.testimonial_rate_log
+   where attempted_at < now() - interval '1 day';
+
+  select count(*), min(attempted_at) into v_count, v_oldest_in_window
+    from public.testimonial_rate_log
+   where ip = p_ip
+     and mode = p_mode
+     and attempted_at >= now() - (p_window_seconds || ' seconds')::interval;
+
+  if v_count >= p_max then
+    allowed := false;
+    retry_after_seconds := greatest(
+      1,
+      extract(epoch from (v_oldest_in_window + (p_window_seconds || ' seconds')::interval - now()))::int
+    );
+    return next; return;
+  end if;
+
+  insert into public.testimonial_rate_log (ip, mode) values (p_ip, p_mode);
+  allowed := true;
+  retry_after_seconds := 0;
+  return next;
+end;
+$$;
+
+grant execute on function public.check_testimonial_rate(text, text, int, int)
+  to authenticated, anon, service_role;
+
+-- ─── E. Cron J+60 (digest admin, pas relance client individuel) ─────────────
+-- Restaure la RPC supprimee en V1.1 + reschedule cron daily.
+-- L'edge fn request-testimonial (deja deployee) consomme cette RPC.
+
+create or replace function public.get_testimonial_request_candidates(
+  p_start timestamptz,
+  p_end timestamptz
+)
+returns table (
+  client_id uuid,
+  first_name text,
+  coach_user_id uuid,
+  coach_name text
+)
+language sql
+security definer
+set search_path = public
+as $$
+  -- Clients dont le client_app_accounts a entre 60 et 75 jours (fenetre lue
+  -- par l'edge fn = [now-75d, now-60d[) et qui n'ont pas encore de temoignage
+  -- pending/approved.
+  select
+    c.id as client_id,
+    c.first_name,
+    c.coach_user_id,
+    u.name as coach_name
+  from public.clients c
+  join public.client_app_accounts caa on c.id::text = caa.client_id
+  left join public.users u on u.id = c.coach_user_id
+  where caa.created_at >= p_start
+    and caa.created_at < p_end
+    and not exists (
+      select 1 from public.client_testimonials t
+      where t.client_id = c.id
+        and t.status in ('pending', 'approved')
+    );
+$$;
+
+comment on function public.get_testimonial_request_candidates(timestamptz, timestamptz) is
+  'Chantier #11 quality fix E (2026-05-18) : restaure la RPC supprimee en
+   V1.1. Retourne les clients atteignant J+60 sans temoignage actif. Consommee
+   par le cron daily request-testimonial qui notif les admins.';
+
+-- Reschedule cron : 8h UTC = 9-10h Paris (digest matinal admin)
+do $$
+begin
+  if exists (select 1 from cron.job where jobname = 'request-testimonial-daily') then
+    perform cron.unschedule('request-testimonial-daily');
+  end if;
+end$$;
+
+select cron.schedule(
+  'request-testimonial-daily',
+  '0 8 * * *',
+  $cron$
+  select net.http_post(
+    url := current_setting('app.settings.supabase_url', true) || '/functions/v1/request-testimonial',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || current_setting('app.settings.service_role_key'),
+      'Content-Type', 'application/json'
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 60000
+  );
+  $cron$
+);
+
+commit;

--- a/supabase/migrations/20261118300000_testimonials_quality_fixes.sql
+++ b/supabase/migrations/20261118300000_testimonials_quality_fixes.sql
@@ -244,4 +244,22 @@ select cron.schedule(
   $cron$
 );
 
+-- ─── F. Bonus : INSERT admin (saisie manuelle "seed" des premiers avis) ─────
+-- Sans policy INSERT publique, l'admin ne peut pas ajouter de témoignage à la
+-- main depuis /admin/testimonials. On en ajoute une, scopée admin actif only,
+-- pour seeder le carrousel avec les vrais retours clients que Thomas a déjà.
+drop policy if exists "testimonials_admin_insert" on public.client_testimonials;
+create policy "testimonials_admin_insert"
+  on public.client_testimonials
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from public.users u
+      where u.id = auth.uid()
+        and u.active = true
+        and u.role = 'admin'
+    )
+  );
+
 commit;

--- a/supabase/migrations/20261118400000_founders_avatars.sql
+++ b/supabase/migrations/20261118400000_founders_avatars.sql
@@ -57,4 +57,42 @@ comment on function public.get_founders_avatars() is
    anciens) pour le bloc §05 Témoignages de /business. Pas d''autres
    donnees sensibles. 2026-05-18.';
 
+-- ─── Avatars par slug (partenaires §05) ─────────────────────────────────────
+-- Permet de hydrater les avatars partenaires affichés sur /business §05
+-- (Ambre, Laura, Valentin, etc.) en lookant via le prénom normalisé.
+-- Réutilise ls_normalize_slug (migration 20261118300000).
+
+create or replace function public.get_avatars_by_slugs(p_slugs text[])
+returns table (slug text, avatar_url text)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  return query
+  with input as (
+    select unnest(p_slugs) as s
+  )
+  select i.s, u.avatar_url
+    from input i
+    left join lateral (
+      select avatar_url
+        from public.users u2
+       where u2.active = true
+         and u2.role in ('distributor', 'admin', 'referent')
+         and length(coalesce(u2.avatar_url, '')) > 0
+         and public.ls_normalize_slug(split_part(coalesce(u2.name, ''), ' ', 1)) = i.s
+       limit 1
+    ) u on true;
+end;
+$$;
+
+grant execute on function public.get_avatars_by_slugs(text[]) to anon, authenticated;
+
+comment on function public.get_avatars_by_slugs(text[]) is
+  'Public : lookup d''avatars partenaires par slug prénom normalisé. Utilisé
+   par /business §05 pour les cards partenaires. Retourne avatar_url=NULL si
+   slug non trouvé (fallback gradient initiale côté front). 2026-05-18.';
+
 commit;

--- a/supabase/migrations/20261118400000_founders_avatars.sql
+++ b/supabase/migrations/20261118400000_founders_avatars.sql
@@ -1,0 +1,60 @@
+-- =============================================================================
+-- Founders avatars — RPC publique pour /business §05 (2026-05-18)
+-- =============================================================================
+-- Expose les avatars de Thomas et Mélanie pour le bloc fondateurs sur la
+-- page publique /business. Les noms/IDs sont identifiés par role + position
+-- dans l'équipe : admin actif le plus ancien (Thomas) + 2e admin actif le
+-- plus ancien (Mélanie).
+--
+-- Pas d'expo d'autres champs sensibles. Just l'URL publique de l'avatar
+-- (déjà publique de fait dans le bucket Storage).
+-- =============================================================================
+
+begin;
+
+create or replace function public.get_founders_avatars()
+returns table (
+  thomas_avatar_url text,
+  melanie_avatar_url text
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_thomas_avatar text;
+  v_melanie_avatar text;
+begin
+  -- Thomas : 1er admin actif (par created_at)
+  select avatar_url into v_thomas_avatar
+    from public.users
+   where role = 'admin'
+     and active = true
+     and length(coalesce(avatar_url, '')) > 0
+   order by created_at asc
+   limit 1;
+
+  -- Mélanie : 2e admin actif. Si seul 1 admin existe, retourne NULL.
+  select avatar_url into v_melanie_avatar
+    from public.users
+   where role = 'admin'
+     and active = true
+     and length(coalesce(avatar_url, '')) > 0
+   order by created_at asc
+   offset 1 limit 1;
+
+  thomas_avatar_url := v_thomas_avatar;
+  melanie_avatar_url := v_melanie_avatar;
+  return next;
+end;
+$$;
+
+grant execute on function public.get_founders_avatars() to anon, authenticated;
+
+comment on function public.get_founders_avatars() is
+  'Public : expose les avatars des 2 fondateurs (admins actifs les plus
+   anciens) pour le bloc §05 Témoignages de /business. Pas d''autres
+   donnees sensibles. 2026-05-18.';
+
+commit;


### PR DESCRIPTION
Merge dev/thomas-test → prod. Inclut PR #68 + #69 + #70 mergées ce matin.

## Chantiers livrés

### Jauge fenêtre glissante Herbalife (PR #68)
- RPC `get_distributor_qualifications` (fenêtres 2/3/6/12 mois)
- PV étendu V2 (perso + downline non-Sup) calculé en SQL via CTE récursive
- Trigger upgrade-only auto-promote `users.current_rank`
- Pin Herbalife câblé sur 4 pages (TeamMemberDrilldownModal, EngagementTable, DistributorPortfolioPage, XpPodium)

### Welcome bilan online (PR #69)
- Composant `<LaBase360Logo />` lecteur SVG officiel
- Coach card refondue : logo La Base 360 + nom coach + pin Herbalife auto

### Témoignages quality fixes (PR #70)
- A. `client_token` nullable (vire sentinel UUID)
- B. Anti-collision slug coach (trigger + `ls_normalize_slug` avec unaccent)
- C. Bouton 'Demander un témoignage' dans ClientDetailPage (clipboard + WhatsApp)
- D. Rate limit persistant DB (`testimonial_rate_log` + RPC)
- E. Cron J+60 restauré (digest admin matinal)
- F. Bouton 'Ajouter manuellement' dans /admin/testimonials (seed carrousel)
- §05 BusinessPage : fake stories supprimées, 1 bloc fondateurs Tom+Mélanie en 4 chapitres + 3 cards partenaires (Ambre, Laura, Valentin)
- RPC `get_founders_avatars` + `get_avatars_by_slugs` (lecture publique users.avatar_url)

## Migrations à apply

```
supabase db push --linked --include-all
```

Migrations concernées :
- `20261118000000_distributor_qualifications.sql`
- `20261118100000_auto_promote_current_rank.sql`
- `20261118200000_distributor_qualifications_v2_extended.sql`
- `20261118300000_testimonials_quality_fixes.sql`
- `20261118400000_founders_avatars.sql`

Edge function à redéployer :
```
supabase functions deploy submit-testimonial --no-verify-jwt
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)