### PR TITLE
Fix cloche : annonce business → /developpement

### DIFF
--- a/supabase/migrations/20261118500000_fix_announce_business_link.sql
+++ b/supabase/migrations/20261118500000_fix_announce_business_link.sql
@@ -1,0 +1,12 @@
+-- =============================================================================
+-- Fix annonce business : redirige cloche vers /developpement (2026-05-18)
+-- =============================================================================
+-- L'annonce "Nouvelle page business 💼" pointait directement vers /business,
+-- mais Thomas veut que les distri atterrissent d'abord dans le hub
+-- "Mon développement" pour découvrir le contexte (Simulateur EBE, Outils
+-- prospection, etc.) avant de partager le lien aux prospects.
+-- =============================================================================
+
+update public.app_announcements
+   set link_path = '/developpement'
+ where title = 'Nouvelle page business 💼';


### PR DESCRIPTION
Update link_path de app_announcements pour pointer vers le hub Mon développement au lieu de /business direct.