### PR TITLE
Prod sync 2026-05-19 — fix drapeaux + pays Liste 100

### DIFF
--- a/src/hooks/useCahierDeBord.ts
+++ b/src/hooks/useCahierDeBord.ts
@@ -34,6 +34,7 @@ interface UseCahierResult {
     contact_email?: string;
     platform?: string | null;
     profile_url?: string | null;
+    country_code?: string | null;
   }) => Promise<void>;
   updateContact: (id: string, patch: Partial<Liste100Contact>) => Promise<void>;
   deleteContact: (id: string) => Promise<void>;
@@ -150,6 +151,7 @@ export function useCahierDeBord(userId: string | null): UseCahierResult {
           contact_email: params.contact_email ?? null,
           platform: params.platform ?? null,
           profile_url: params.profile_url ?? null,
+          country_code: params.country_code ?? null,
         })
         .select()
         .single();

--- a/src/lib/countries.ts
+++ b/src/lib/countries.ts
@@ -1,0 +1,65 @@
+// =============================================================================
+// countries — liste curée de pays pour la Liste 100 (2026-05-19)
+// =============================================================================
+//
+// Liste optimisée pour le contexte Thomas (coach FR avec ambitions
+// internationales — francophonie + Europe + LatAm + marchés Herbalife
+// prioritaires). Pas exhaustif (200 pays = liste imbuvable dans un
+// select). 22 pays + "Autre" pour les cas hors-liste.
+//
+// Code = ISO 3166 alpha-2 (standard). Drapeaux Twemoji emoji rendus
+// via la font-family Twemoji Country Flags (cf. globals.css).
+// =============================================================================
+
+export interface CountryMeta {
+  /** ISO 3166 alpha-2 uppercase (FR, BE, CH, etc.). */
+  code: string;
+  /** Drapeau emoji regional indicators (rendu Twemoji). */
+  flag: string;
+  /** Nom français du pays. */
+  label: string;
+}
+
+const COUNTRIES: CountryMeta[] = [
+  // Francophonie
+  { code: "FR", flag: "🇫🇷", label: "France" },
+  { code: "BE", flag: "🇧🇪", label: "Belgique" },
+  { code: "CH", flag: "🇨🇭", label: "Suisse" },
+  { code: "CA", flag: "🇨🇦", label: "Canada" },
+  { code: "LU", flag: "🇱🇺", label: "Luxembourg" },
+  // Maghreb + Afrique francophone
+  { code: "MA", flag: "🇲🇦", label: "Maroc" },
+  { code: "DZ", flag: "🇩🇿", label: "Algérie" },
+  { code: "TN", flag: "🇹🇳", label: "Tunisie" },
+  { code: "SN", flag: "🇸🇳", label: "Sénégal" },
+  { code: "CI", flag: "🇨🇮", label: "Côte d'Ivoire" },
+  // Europe
+  { code: "GB", flag: "🇬🇧", label: "Royaume-Uni" },
+  { code: "ES", flag: "🇪🇸", label: "Espagne" },
+  { code: "PT", flag: "🇵🇹", label: "Portugal" },
+  { code: "IT", flag: "🇮🇹", label: "Italie" },
+  { code: "DE", flag: "🇩🇪", label: "Allemagne" },
+  { code: "NL", flag: "🇳🇱", label: "Pays-Bas" },
+  // Amériques
+  { code: "US", flag: "🇺🇸", label: "États-Unis" },
+  { code: "BR", flag: "🇧🇷", label: "Brésil" },
+  { code: "MX", flag: "🇲🇽", label: "Mexique" },
+  // Asie + Méditerranée
+  { code: "TR", flag: "🇹🇷", label: "Turquie" },
+  { code: "IN", flag: "🇮🇳", label: "Inde" },
+  // Fallback générique (pas d'emoji drapeau — globe)
+  { code: "XX", flag: "🌍", label: "Autre" },
+];
+
+const COUNTRIES_BY_CODE: Record<string, CountryMeta> = Object.fromEntries(
+  COUNTRIES.map((c) => [c.code, c]),
+);
+
+export function listCountries(): CountryMeta[] {
+  return COUNTRIES;
+}
+
+export function getCountry(code: string | null | undefined): CountryMeta | null {
+  if (!code) return null;
+  return COUNTRIES_BY_CODE[code.toUpperCase()] ?? null;
+}

--- a/src/pages/CahierDeBordPage.tsx
+++ b/src/pages/CahierDeBordPage.tsx
@@ -32,6 +32,7 @@ import {
   PLATFORM_META,
   type ContactPlatform,
 } from "../lib/profileDeepLink";
+import { listCountries, getCountry } from "../lib/countries";
 
 /** Split "Karim Ben" → { firstName: "Karim", lastName: "Ben" }. */
 function splitFullName(full: string): { firstName: string; lastName: string } {
@@ -413,9 +414,11 @@ function ListeSection({ cahier }: { cahier: ReturnType<typeof useCahierDeBord> }
     contact_phone: "",
     platform: "" as ContactPlatform | "",
     profile_url: "",
+    country_code: "",
   });
   const [filterTemp, setFilterTemp] = useState<Liste100Temperature | "all">("all");
   const [filterStatus, setFilterStatus] = useState<Liste100Status | "all">("all");
+  const [filterCountry, setFilterCountry] = useState<string | "all">("all");
   /** Connexion Liste 100 → Agenda (2026-05-04) : quand un contact passe en
       `rdv_cale`, on propose de créer un prospect agenda pré-rempli. */
   const [prospectModalContact, setProspectModalContact] = useState<Liste100Contact | null>(null);
@@ -439,6 +442,7 @@ function ListeSection({ cahier }: { cahier: ReturnType<typeof useCahierDeBord> }
       contact_phone: draft.contact_phone.trim() || undefined,
       platform: draft.platform || null,
       profile_url: draft.profile_url.trim() || null,
+      country_code: draft.country_code || null,
     });
     setDraft({
       full_name: "",
@@ -448,6 +452,7 @@ function ListeSection({ cahier }: { cahier: ReturnType<typeof useCahierDeBord> }
       contact_phone: "",
       platform: "",
       profile_url: "",
+      country_code: "",
     });
     setShowForm(false);
   }
@@ -455,6 +460,7 @@ function ListeSection({ cahier }: { cahier: ReturnType<typeof useCahierDeBord> }
   const filtered = cahier.contacts.filter((c) => {
     if (filterTemp !== "all" && c.temperature !== filterTemp) return false;
     if (filterStatus !== "all" && c.status !== filterStatus) return false;
+    if (filterCountry !== "all" && (c.country_code ?? "") !== filterCountry) return false;
     return true;
   });
 
@@ -495,6 +501,19 @@ function ListeSection({ cahier }: { cahier: ReturnType<typeof useCahierDeBord> }
           {(Object.keys(LISTE_100_STATUS_META) as Liste100Status[]).map((s) => (
             <option key={s} value={s}>
               {LISTE_100_STATUS_META[s].emoji} {LISTE_100_STATUS_META[s].label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={filterCountry}
+          onChange={(e) => setFilterCountry(e.target.value)}
+          style={selectStyle}
+          title="Filtrer par pays de prospection"
+        >
+          <option value="all">🌍 Tous pays</option>
+          {listCountries().map((c) => (
+            <option key={c.code} value={c.code}>
+              {c.flag} {c.label}
             </option>
           ))}
         </select>
@@ -590,14 +609,30 @@ function ListeSection({ cahier }: { cahier: ReturnType<typeof useCahierDeBord> }
               />
             </Field>
           </div>
-          <Field label="Téléphone (optionnel)">
-            <input
-              type="tel"
-              value={draft.contact_phone}
-              onChange={(e) => setDraft({ ...draft, contact_phone: e.target.value })}
-              style={inputStyle}
-            />
-          </Field>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+            <Field label="Téléphone (optionnel)">
+              <input
+                type="tel"
+                value={draft.contact_phone}
+                onChange={(e) => setDraft({ ...draft, contact_phone: e.target.value })}
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="Pays de prospection (optionnel)">
+              <select
+                value={draft.country_code}
+                onChange={(e) => setDraft({ ...draft, country_code: e.target.value })}
+                style={selectStyle}
+              >
+                <option value="">—</option>
+                {listCountries().map((c) => (
+                  <option key={c.code} value={c.code}>
+                    {c.flag} {c.label}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </div>
           <Field label="Note (optionnel)">
             <textarea
               value={draft.note}
@@ -659,7 +694,36 @@ function ListeSection({ cahier }: { cahier: ReturnType<typeof useCahierDeBord> }
               >
                 <span style={{ fontSize: 18 }}>{temp.emoji}</span>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontWeight: 600, color: "var(--ls-text)", fontSize: 14 }}>{c.full_name}</div>
+                  <div
+                    style={{
+                      fontWeight: 600,
+                      color: "var(--ls-text)",
+                      fontSize: 14,
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    {(() => {
+                      const country = getCountry(c.country_code);
+                      return country ? (
+                        <span
+                          style={{
+                            fontSize: 14,
+                            fontFamily:
+                              "'Twemoji Country Flags', 'Apple Color Emoji', 'Segoe UI Emoji', emoji",
+                            lineHeight: 1,
+                          }}
+                          title={country.label}
+                          aria-label={`Pays : ${country.label}`}
+                        >
+                          {country.flag}
+                        </span>
+                      ) : null;
+                    })()}
+                    <span>{c.full_name}</span>
+                  </div>
                   {c.note && (
                     <div style={{ fontSize: 11, color: "var(--ls-text-muted)", marginTop: 2 }}>{c.note}</div>
                   )}

--- a/src/pages/ProspectionPage.tsx
+++ b/src/pages/ProspectionPage.tsx
@@ -643,8 +643,17 @@ const gridStyle = (cols: 2 | 3): CSSProperties => ({
   gap: 10,
 });
 
+// Fix drapeaux 2026-05-19 : `font-family` Twemoji forcée inline car le
+// fallback global (body) peut être écrasé par un parent (PremiumHero
+// / Card avec Syne ou DM Sans). Sans Twemoji prioritaire, Windows
+// Chrome affiche les regional indicators bruts ("FR", "GB", etc.) au
+// lieu des drapeaux SVG. Fallback `emoji` = generic family système.
 const flagStyle: CSSProperties = {
-  fontSize: 36, lineHeight: 1, display: "block", marginBottom: 4,
+  fontSize: 36,
+  lineHeight: 1,
+  display: "block",
+  marginBottom: 4,
+  fontFamily: "'Twemoji Country Flags', 'Apple Color Emoji', 'Segoe UI Emoji', emoji",
 };
 
 const emojiStyle: CSSProperties = {
@@ -867,7 +876,15 @@ function MarketTimingBanner({
         marginBottom: 10,
         fontFamily: "'Syne', serif",
       }}>
-        <span style={{ fontSize: 20 }} aria-hidden="true">{flag}</span>
+        <span
+          style={{
+            fontSize: 20,
+            fontFamily: "'Twemoji Country Flags', 'Apple Color Emoji', 'Segoe UI Emoji', emoji",
+          }}
+          aria-hidden="true"
+        >
+          {flag}
+        </span>
         {marketLabel} · {languageLabel}
       </div>
       <div style={{

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -885,7 +885,11 @@ main, .main-content {
   html { font-family: 'Twemoji Country Flags', 'DM Sans', sans-serif; }
   body { background: var(--ls-bg); color: var(--ls-text); font-family: 'Twemoji Country Flags', 'DM Sans', sans-serif; transition: background 0.2s, color 0.2s; }
 
-  h1, h2, h3, h4, .font-display { font-family: 'Syne', sans-serif; }
+  /* Fix drapeaux 2026-05-19 : ajoute Twemoji EN TÊTE de chaque
+     font-family de h1-h4 + display (sinon Syne écrase et les regional
+     indicators emoji apparaissent en "FR/GB/MX/BR/TR/IN" bruts). Cette
+     règle remonte Twemoji dans tout descendant, peu importe le parent. */
+  h1, h2, h3, h4, .font-display { font-family: 'Twemoji Country Flags', 'Syne', sans-serif; }
 
   ::-webkit-scrollbar { width: 5px; height: 5px; }
   ::-webkit-scrollbar-track { background: #0B0D11; }

--- a/src/types/cahier.ts
+++ b/src/types/cahier.ts
@@ -59,6 +59,8 @@ export interface Liste100Contact {
   platform: string | null;
   /** Phase 0.8 — username ou URL profil pour deep-link clic. */
   profile_url: string | null;
+  /** 2026-05-19 — code pays ISO 3166 alpha-2 (FR, BE, CH, etc.). */
+  country_code: string | null;
   added_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/20261119000000_liste_100_country_code.sql
+++ b/supabase/migrations/20261119000000_liste_100_country_code.sql
@@ -1,0 +1,17 @@
+-- =============================================================================
+-- Liste 100 — ajout colonne country_code (2026-05-19)
+--
+-- Permet à Thomas de tagger chaque contact par pays (ISO 3166 alpha-2)
+-- pour visualiser sa répartition internationale + filtrer la liste.
+-- Affichage : drapeau Twemoji + label côté front (cf. lib/countries.ts).
+-- =============================================================================
+
+begin;
+
+alter table public.liste_100_contacts
+  add column if not exists country_code text;
+
+comment on column public.liste_100_contacts.country_code is
+  'Code pays ISO 3166 alpha-2 (FR, BE, CH, CA, MA, US, ...). Nullable. Rendu en drapeau Twemoji côté front via lib/countries.ts.';
+
+commit;


### PR DESCRIPTION
## Summary

Push prod des 2 derniers commits depuis sync #84 :

1. `a75fbd5` — **fix(prospection)** : drapeaux pays visibles sur Windows
   - Polyfill Twemoji forcé inline sur les sites de rendu drapeau (flagStyle + bandeau ScriptCard)
   - globals.css : Twemoji en tête de stack pour h1-h4/.font-display
   - Plus de "FR/GB/MX/BR/TR/IN" bruts sur Windows Chrome

2. `5678324` — **feat(liste-100)** : pays de prospection
   - Migration `20261119000000` : colonne `country_code` sur `liste_100_contacts` (déjà appliquée prod Supabase)
   - Nouveau `src/lib/countries.ts` (22 pays curés + Autre)
   - Form Liste 100 : select pays optionnel
   - Filtre pays dans barre filtres ("🌍 Tous pays")
   - Rendu : drapeau Twemoji avant le nom de contact

Build prod ✅. Aucun changement d'API publique.

## Test plan
- [x] `npm run build` ✅
- [x] Migration Supabase appliquée
- [ ] Smoke test : ouvrir /prospection → drapeaux des 6 cards Marché visibles
- [ ] Smoke test : ouvrir /cahier-de-bord?tab=liste → ajouter un contact avec pays → drapeau apparaît dans le rendu + filtre fonctionne