### PR TITLE
feat(prospection): V4 design polish — hub refondu + sprint captures Thomas

### DIFF
--- a/docs/mockups/prospection-v4-design-chat.md
+++ b/docs/mockups/prospection-v4-design-chat.md
@@ -1,0 +1,392 @@
+# Chat
+
+_Started 2026-05-19 14:52 UTC_
+
+---
+
+## User
+
+<system-info comment="Only acknowledge these if relevant">
+Project title is now "prospection inter"
+Current date is now May 19, 2026
+</system-info>
+
+<default aesthetic>
+If no references, art direction or design systems were provided, use this default professional modern, minimal aesthetic as a base. Declare your choice out loud so you stick to it. Guidance:
+- Choose a type pairing from web-safe set or Google Fonts. Helvetica is a good choice. Avoid hard-to-read or overly stylized fonts. Use 1-3 fonts only.
+- Foreground and background: choose a color tone (warm, cool, neutral, something in-between). Use subtly-toned whites and blacks; avoid saturations above 0.02 for whites.
+- Accents: choose 0-2 additional accent colors using oklch. All accents should share same chroma and lightness; vary hue.
+- NEVER write out an SVG yourself that's more complicated than a square, circle, diamond, etc.
+- For imagery, never hand-draw SVGs; use subtly-striped SVG placeholders instead with monospace explainers for what should be dropped there (e.g. “product shot”)
+
+CRITICAL: ignore default aesthetic entirely if given other aesthetic instructions like reference images, design systems or guidance, or if there are files in the project already.
+</default aesthetic>
+
+<pasted_text name="Pasted text (149 lines)">
+Tu es designer UX/UI senior. Tu refondes l'écran "Prospection internationale"
+d'une web-app SaaS de coaching nutrition Herbalife (La Base 360). Cible
+principale : distributeurs Herbalife 25-50 ans, sur mobile (iPhone, 393px de
+large). Desktop secondaire (centré 640px max).
+
+═══════════════════════════════════════════════════════════════════════════
+CONTEXTE PRODUIT
+═══════════════════════════════════════════════════════════════════════════
+
+L'écran "/prospection" est le HUB méthode de prospection internationale.
+Un distri arrive ici pour :
+- Choisir un MARCHÉ cible (6 options : 🇫🇷 France, 🇬🇧 International,
+  🇲🇽 LatAm+Espagne, 🇧🇷 Brésil+Portugal, 🇹🇷 Turquie+Allemagne, 🇮🇳 Inde)
+- Choisir un PROFIL cible (4 options : ⚖️ Perte de poids Femmes,
+  💪 Perte de poids Hommes, 🏃 Sportif, 💼 Business)
+- Consulter 10 SECTIONS de contenu adaptées à ce couple (marché × profil) :
+  1. 🧠 Mindset & posture (3 vérités + 5 erreurs)
+  2. 🔍 Trouver les prospects (green/red flags scan 30s + hashtags + sources)
+  3. 📨 Messages M1 (premier contact par plateforme Insta/FB/WhatsApp/SMS)
+  4. 🌳 Arbres M2/M3 (que répondre selon la réaction du prospect)
+  5. 🛡️ Objections (8 objections types + réponses)
+  6. 📞 Séquence post-appel (J0/J+2/J+5/J+30)
+  7. 🎯 Closing (signaux + 3 scripts vente)
+  8. 🔁 Cas spéciaux (ghost, réactivation, recommandation)
+  9. 📖 Storytelling (structure + exemples)
+ 10. ⏰ Routine quotidienne (30min/jour + checklist 7 items)
+
+═══════════════════════════════════════════════════════════════════════════
+PROBLÈME ACTUEL
+═══════════════════════════════════════════════════════════════════════════
+
+Ma version actuelle (que je rejette) empile les 10 modules en accordéon
+vertical sous des filtres marché/profil sur 2 lignes séparées + un tip
+culturel en gros bandeau. Résultat : sticky header de 250px+, scroll
+infini pour atteindre "Storytelling" en bas, perte de contexte quand un
+accordéon s'ouvre. C'est lourd et la nav sur mobile est mauvaise.
+
+J'ai un mockup HTML d'une nouvelle direction (tabs horizontaux + 1 module
+visible à la fois + nav bar sticky bas pour précédent/suivant). Je veux
+que tu pousses ce concept plus loin, avec une vraie identité visuelle.
+
+═══════════════════════════════════════════════════════════════════════════
+DESIGN TOKENS À RESPECTER
+═══════════════════════════════════════════════════════════════════════════
+
+Palette (déjà en prod sur l'app, light mode) :
+  --ls-gold:        #C9A84C   (couleur signature, accents principaux)
+  --ls-gold-light:  #E5C97D   (hover, glow)
+  --ls-teal:        #2DD4BF   (accent secondaire)
+  --ls-teal-dark:   #0F766E
+  --ls-coral:       #FB7185   (warning, erreurs douces)
+  --ls-purple:      #7C3AED   (accent tertiaire)
+  --ls-charcoal:    #0B0D11   (texte principal, dark backgrounds)
+  --ls-cream:       #FBF7F0   (background page)
+  --ls-surface:     #FFFFFF
+  --ls-surface2:    #F7F3EC
+
+Typo :
+  Display headlines    → "Syne" (serif moderne)
+  Body / UI            → "DM Sans"
+  Le distri parle italique sur certains éléments (signatures, citations)
+
+Style général : premium éditorial, chaleureux, pas SaaS générique. Le
+gold/cream donne un ton "magazine wellness premium" plus que tech.
+S'inspire du design des apps Lottie, Mubi, ou des newsletters Substack
+premium.
+
+═══════════════════════════════════════════════════════════════════════════
+CONTRAINTES UX
+═══════════════════════════════════════════════════════════════════════════
+
+✅ Mobile-first absolu (393px iPhone). Tester aussi à 360px (petits
+   Android) et 640px (desktop centré).
+
+✅ La sticky du haut DOIT tenir en ≤ 160px sur mobile. Le user doit voir
+   au moins 1 carte de contenu sans scroller.
+
+✅ La navigation entre les 10 modules doit prendre 1 tap, pas 1 scroll.
+   Les 10 modules doivent rester découvrables à tout moment (pas d'overflow
+   caché derrière un menu hamburger).
+
+✅ Filtres marché + profil simultanément visibles, mais compacts. Pas
+   2 lignes séparées de pills. Penser à un picker combiné, des dropdowns,
+   ou une 1 seule ligne scrollable avec actifs en sticky à gauche.
+
+✅ Variables dans les scripts ([prénom], [contexte]) doivent ressortir
+   visuellement (gold ou teal) pour que le distri les remplisse avant
+   copier.
+
+✅ Bouton "Copier" omniprésent sur les blocs de texte (scripts, réponses
+   d'objections, follow-ups). Feedback toast "Copié !".
+
+✅ Traduction française disponible derrière toggle pour les scripts en
+   EN/ES/PT/TR/HI (le coach FR doit comprendre ce qu'il copie-colle).
+
+✅ Le bouton "J'ai envoyé" déclenche un tracking analytics (statistique
+   sur 7 derniers jours visible quelque part en haut, discrètement).
+
+✅ Une nav précédent/suivant module quelque part (sticky bas mobile ?
+   raccourcis clavier desktop ?) pour parcourir linéairement les 10 sections
+   si on est lecteur du dimanche.
+
+═══════════════════════════════════════════════════════════════════════════
+CONTRAINTES À NE PAS RESPECTER ABSOLUMENT
+═══════════════════════════════════════════════════════════════════════════
+
+❌ Ne pas mettre de hero géant en haut une fois que l'user est "onboardé".
+   Le hero c'est OK pour la 1ère visite (pas dans le scope ici).
+
+❌ Ne pas reproduire le pattern "accordéon vertical des 10 modules".
+   C'est le pattern actuel qu'on rejette.
+
+❌ Pas de menu hamburger. Les 10 modules doivent rester découvrables.
+
+❌ Pas d'animations gadget genre confettis, scroll-jacking, parallax.
+   Du smooth fade/slide max. Reduced-motion respecté.
+
+═══════════════════════════════════════════════════════════════════════════
+LIVRABLE ATTENDU
+═══════════════════════════════════════════════════════════════════════════
+
+1. Un artifact HTML self-contained (1 fichier) qui contient 4 captures
+   d'écran mobile (frame iPhone 393×~750) :
+   - HOME : module Mindset actif (le user vient d'arriver)
+   - MODULE Messages M1 (cards scripts par plateforme avec bouton Copier
+     et toggle traduction FR)
+   - MODULE Objections (8 objections en format quote + bad/good response)
+   - MODULE Trouver (green/red flags + hashtags par catégorie
+     mainstream/niche/cross + sources alt FB/IRL/reco)
+
+2. Bonus : 1 frame desktop 640px avec le même module actif.
+
+3. CSS inline. Pas de framework. Variables CSS pour les tokens.
+
+4. Annoter chaque frame avec 2-3 lignes en bas expliquant tes choix
+   ("J'ai mis les filtres dans un picker combiné parce que…").
+
+═══════════════════════════════════════════════════════════════════════════
+RÉFÉRENCE
+═══════════════════════════════════════════════════════════════════════════
+
+Mon mockup actuel (point de départ, à dépasser) :
+docs/mockups/prospection-v4-hub-redesign.html
+
+Tu peux le respecter ou le casser : si tu trouves une meilleure direction
+(side rail desktop, bottom tabs persistants, picker combiné, etc.), montre.
+
+Je veux un livrable qui me fasse dire "ah ouais, OK, je n'avais pas vu ça
+comme ça" — pas une variation cosmétique de mon mockup.
+</pasted_text>
+
+<!-- The user explicitly selected the following skills for this project, as attachments to their message. These are not optional context — they define how you work. Use them. -->
+<attached-skill name="Hi-fi design">
+Create a high-fidelity, polished design. Follow the instructions about design in your system prompt, particularly the 'How to do design work' section. Use the design_canvas starter component, or make a full-bleed prototype and offer options via Tweaks.
+</attached-skill>
+
+<attached-skill name="Interactive prototype">
+Create a fully interactive prototype with realistic state management and transitions. Use React useState/useEffect for dynamic behavior. Include hover states, click interactions, form validation, animated transitions, and multi-step navigation flows. It should feel like a real working app, not a static mockup.
+</attached-skill>
+
+
+<system-reminder>Auto-injected reminder (ignore if not relevant): do not recreate copyrighted or branded UI unless the user's email domain matches that company. Create original designs instead.</system-reminder>
+
+## Assistant
+
+_[tool: list_files]_
+
+## Assistant
+
+_[tool: list_files]_
+
+A few notes before building: I'll design this as an original product called **"La Base 360"** using your design tokens — I won't reproduce any Herbalife logos, trademarks, or branded UI (your email domain doesn't match). The screens reference "distributeurs de coaching nutrition" generically. The IP belongs to your product.
+
+Let me check the reference mockup, plan the layout, and start building.
+
+## Assistant
+
+## User
+
+<pasted_text name="Pasted text (149 lines)">
+Tu es designer UX/UI senior. Tu refondes l'écran "Prospection internationale"
+d'une web-app SaaS de coaching nutrition Herbalife (La Base 360). Cible
+principale : distributeurs Herbalife 25-50 ans, sur mobile (iPhone, 393px de
+large). Desktop secondaire (centré 640px max).
+
+═══════════════════════════════════════════════════════════════════════════
+CONTEXTE PRODUIT
+═══════════════════════════════════════════════════════════════════════════
+
+L'écran "/prospection" est le HUB méthode de prospection internationale.
+Un distri arrive ici pour :
+- Choisir un MARCHÉ cible (6 options : 🇫🇷 France, 🇬🇧 International,
+  🇲🇽 LatAm+Espagne, 🇧🇷 Brésil+Portugal, 🇹🇷 Turquie+Allemagne, 🇮🇳 Inde)
+- Choisir un PROFIL cible (4 options : ⚖️ Perte de poids Femmes,
+  💪 Perte de poids Hommes, 🏃 Sportif, 💼 Business)
+- Consulter 10 SECTIONS de contenu adaptées à ce couple (marché × profil) :
+  1. 🧠 Mindset & posture (3 vérités + 5 erreurs)
+  2. 🔍 Trouver les prospects (green/red flags scan 30s + hashtags + sources)
+  3. 📨 Messages M1 (premier contact par plateforme Insta/FB/WhatsApp/SMS)
+  4. 🌳 Arbres M2/M3 (que répondre selon la réaction du prospect)
+  5. 🛡️ Objections (8 objections types + réponses)
+  6. 📞 Séquence post-appel (J0/J+2/J+5/J+30)
+  7. 🎯 Closing (signaux + 3 scripts vente)
+  8. 🔁 Cas spéciaux (ghost, réactivation, recommandation)
+  9. 📖 Storytelling (structure + exemples)
+ 10. ⏰ Routine quotidienne (30min/jour + checklist 7 items)
+
+═══════════════════════════════════════════════════════════════════════════
+PROBLÈME ACTUEL
+═══════════════════════════════════════════════════════════════════════════
+
+Ma version actuelle (que je rejette) empile les 10 modules en accordéon
+vertical sous des filtres marché/profil sur 2 lignes séparées + un tip
+culturel en gros bandeau. Résultat : sticky header de 250px+, scroll
+infini pour atteindre "Storytelling" en bas, perte de contexte quand un
+accordéon s'ouvre. C'est lourd et la nav sur mobile est mauvaise.
+
+J'ai un mockup HTML d'une nouvelle direction (tabs horizontaux + 1 module
+visible à la fois + nav bar sticky bas pour précédent/suivant). Je veux
+que tu pousses ce concept plus loin, avec une vraie identité visuelle.
+
+═══════════════════════════════════════════════════════════════════════════
+DESIGN TOKENS À RESPECTER
+═══════════════════════════════════════════════════════════════════════════
+
+Palette (déjà en prod sur l'app, light mode) :
+  --ls-gold:        #C9A84C   (couleur signature, accents principaux)
+  --ls-gold-light:  #E5C97D   (hover, glow)
+  --ls-teal:        #2DD4BF   (accent secondaire)
+  --ls-teal-dark:   #0F766E
+  --ls-coral:       #FB7185   (warning, erreurs douces)
+  --ls-purple:      #7C3AED   (accent tertiaire)
+  --ls-charcoal:    #0B0D11   (texte principal, dark backgrounds)
+  --ls-cream:       #FBF7F0   (background page)
+  --ls-surface:     #FFFFFF
+  --ls-surface2:    #F7F3EC
+
+Typo :
+  Display headlines    → "Syne" (serif moderne)
+  Body / UI            → "DM Sans"
+  Le distri parle italique sur certains éléments (signatures, citations)
+
+Style général : premium éditorial, chaleureux, pas SaaS générique. Le
+gold/cream donne un ton "magazine wellness premium" plus que tech.
+S'inspire du design des apps Lottie, Mubi, ou des newsletters Substack
+premium.
+
+═══════════════════════════════════════════════════════════════════════════
+CONTRAINTES UX
+═══════════════════════════════════════════════════════════════════════════
+
+✅ Mobile-first absolu (393px iPhone). Tester aussi à 360px (petits
+   Android) et 640px (desktop centré).
+
+✅ La sticky du haut DOIT tenir en ≤ 160px sur mobile. Le user doit voir
+   au moins 1 carte de contenu sans scroller.
+
+✅ La navigation entre les 10 modules doit prendre 1 tap, pas 1 scroll.
+   Les 10 modules doivent rester découvrables à tout moment (pas d'overflow
+   caché derrière un menu hamburger).
+
+✅ Filtres marché + profil simultanément visibles, mais compacts. Pas
+   2 lignes séparées de pills. Penser à un picker combiné, des dropdowns,
+   ou une 1 seule ligne scrollable avec actifs en sticky à gauche.
+
+✅ Variables dans les scripts ([prénom], [contexte]) doivent ressortir
+   visuellement (gold ou teal) pour que le distri les remplisse avant
+   copier.
+
+✅ Bouton "Copier" omniprésent sur les blocs de texte (scripts, réponses
+   d'objections, follow-ups). Feedback toast "Copié !".
+
+✅ Traduction française disponible derrière toggle pour les scripts en
+   EN/ES/PT/TR/HI (le coach FR doit comprendre ce qu'il copie-colle).
+
+✅ Le bouton "J'ai envoyé" déclenche un tracking analytics (statistique
+   sur 7 derniers jours visible quelque part en haut, discrètement).
+
+✅ Une nav précédent/suivant module quelque part (sticky bas mobile ?
+   raccourcis clavier desktop ?) pour parcourir linéairement les 10 sections
+   si on est lecteur du dimanche.
+
+═══════════════════════════════════════════════════════════════════════════
+CONTRAINTES À NE PAS RESPECTER ABSOLUMENT
+═══════════════════════════════════════════════════════════════════════════
+
+❌ Ne pas mettre de hero géant en haut une fois que l'user est "onboardé".
+   Le hero c'est OK pour la 1ère visite (pas dans le scope ici).
+
+❌ Ne pas reproduire le pattern "accordéon vertical des 10 modules".
+   C'est le pattern actuel qu'on rejette.
+
+❌ Pas de menu hamburger. Les 10 modules doivent rester découvrables.
+
+❌ Pas d'animations gadget genre confettis, scroll-jacking, parallax.
+   Du smooth fade/slide max. Reduced-motion respecté.
+
+═══════════════════════════════════════════════════════════════════════════
+LIVRABLE ATTENDU
+═══════════════════════════════════════════════════════════════════════════
+
+1. Un artifact HTML self-contained (1 fichier) qui contient 4 captures
+   d'écran mobile (frame iPhone 393×~750) :
+   - HOME : module Mindset actif (le user vient d'arriver)
+   - MODULE Messages M1 (cards scripts par plateforme avec bouton Copier
+     et toggle traduction FR)
+   - MODULE Objections (8 objections en format quote + bad/good response)
+   - MODULE Trouver (green/red flags + hashtags par catégorie
+     mainstream/niche/cross + sources alt FB/IRL/reco)
+
+2. Bonus : 1 frame desktop 640px avec le même module actif.
+
+3. CSS inline. Pas de framework. Variables CSS pour les tokens.
+
+4. Annoter chaque frame avec 2-3 lignes en bas expliquant tes choix
+   ("J'ai mis les filtres dans un picker combiné parce que…").
+
+═══════════════════════════════════════════════════════════════════════════
+RÉFÉRENCE
+═══════════════════════════════════════════════════════════════════════════
+
+Mon mockup actuel (point de départ, à dépasser) :
+docs/mockups/prospection-v4-hub-redesign.html
+
+Tu peux le respecter ou le casser : si tu trouves une meilleure direction
+(side rail desktop, bottom tabs persistants, picker combiné, etc.), montre.
+
+Je veux un livrable qui me fasse dire "ah ouais, OK, je n'avais pas vu ça
+comme ça" — pas une variation cosmétique de mon mockup.
+</pasted_text>
+
+## Assistant
+
+_[tool: update_todos]_
+
+The reference mockup isn't in the project, so I'll design fresh from your spec. Locking in the direction now:
+
+**Concept: "L'index éditorial"** — the 10 modules become a numbered horizontal index (like a magazine table of contents), the two filters become twin compact pills on a single line, and the 7-day analytics stat lives discreetly in the header chip. Bottom sticky nav for linear browsing. Editorial, not SaaS-generic.
+
+Let me build the single self-contained HTML.
+
+_[tool: write_file]_
+
+_[tool: done]_
+
+_[tool: fork_verifier_agent]_
+
+Livré : **Prospection — Refonte.html** (un seul fichier, CSS inline, vos tokens respectés, aucun framework).
+
+**Direction prise : « L'index éditorial »**
+- Header sticky **136 px** = brand+stat 7j (28) + jumeau marché×profil (44) + index numéroté 01–10 (52)
+- Filtres en **deux pickers compacts sur 1 ligne** (pas 2 lignes de pills)
+- Les 10 modules en **index numéroté** type sommaire magazine, actif s'étend en gold, autres restent visibles (pas de hamburger, pas de scroll caché)
+- **Nav bas** précédent / 10 dots / suivant pour la lecture linéaire
+- Variables `[prénom]` en **gold** vs `[contexte]` en **teal** — deux familles distinctes
+- Toggle EN↔FR par script + **traduction FR inline en italique** sous le script original
+- Bouton **Copier** (charcoal+gold) et **J'ai envoyé** (gold outline) côte à côte
+
+**5 frames livrés :**
+1. Mindset (home) — pull-quote charcoal × gold, ton magazine
+2. Messages M1 — sous-tabs Insta/FB/WA/SMS, scripts EN+trad FR, taux réponse par script
+3. Objections — citation Syne italique, mauvaise réponse barrée rouge, bonne réponse teal
+4. Trouver — drapeaux verts/rouges en colonnes, hashtags par 3 catégories colorées, sources hors-feed en carte charcoal
+5. Bonus desktop 640 px — tous les 10 modules dans l'index sans scroll, raccourcis ←/→/1-4/C en hint
+
+Chaque frame est annoté en monospace gold avec les 2-3 décisions clés.
+

--- a/docs/mockups/prospection-v4-hub-redesign.html
+++ b/docs/mockups/prospection-v4-hub-redesign.html
@@ -1,0 +1,1056 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Prospection V4 — Hub redesign (Option A : tabs horizontaux)</title>
+<style>
+  :root {
+    --ls-gold: #C9A84C;
+    --ls-gold-light: #E5C97D;
+    --ls-teal: #2DD4BF;
+    --ls-teal-dark: #0F766E;
+    --ls-coral: #FB7185;
+    --ls-purple: #7C3AED;
+    --ls-charcoal: #0B0D11;
+    --ls-cream: #FBF7F0;
+    --ls-surface: #FFFFFF;
+    --ls-surface2: #F7F3EC;
+    --ls-border: rgba(11,13,17,0.10);
+    --ls-text: #1F2937;
+    --ls-text-muted: #4B5563;
+    --ls-text-hint: #9CA3AF;
+    --green-50: #ECFDF5;
+    --green-300: #6EE7B7;
+    --green-700: #047857;
+    --red-50: #FEF2F2;
+    --red-300: #FCA5A5;
+    --red-700: #B91C1C;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body {
+    font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: var(--ls-cream);
+    color: var(--ls-text);
+    line-height: 1.5;
+    font-size: 15px;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  .mockup-banner {
+    background: var(--ls-charcoal);
+    color: var(--ls-gold);
+    padding: 8px 12px;
+    text-align: center;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+  }
+  .mockup-banner .small { color: rgba(255,255,255,.55); font-weight: 400; }
+
+  .app-shell {
+    max-width: 640px;
+    margin: 0 auto;
+    background: var(--ls-cream);
+    min-height: calc(100vh - 36px);
+    padding-bottom: 80px;
+  }
+
+  /* ===== Sticky compact header ===== */
+  .sticky-top {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: var(--ls-cream);
+    border-bottom: 1px solid var(--ls-border);
+  }
+  .crumb-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 16px 6px;
+  }
+  .crumb-eyebrow {
+    font-family: 'Syne', serif;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    color: var(--ls-gold);
+    text-transform: uppercase;
+  }
+  .crumb-eyebrow .dot { display:inline-block;width:4px;height:4px;border-radius:50%;background:var(--ls-teal);margin:0 5px;transform:translateY(-2px); }
+  .help-link {
+    font-size: 11px;
+    color: var(--ls-text-muted);
+    text-decoration: none;
+    padding: 4px 8px;
+    border: 1px solid var(--ls-border);
+    border-radius: 999px;
+    background: white;
+  }
+
+  /* Combined filter row : marché + profil sur 1 ligne scrollable */
+  .filter-row {
+    display: flex;
+    gap: 6px;
+    padding: 6px 16px 8px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .filter-row::-webkit-scrollbar { display: none; }
+  .chip {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    background: white;
+    border: 1px solid var(--ls-border);
+    border-radius: 999px;
+    font-size: 13px;
+    color: var(--ls-text);
+    cursor: pointer;
+    white-space: nowrap;
+    font-family: inherit;
+  }
+  .chip:hover { background: var(--ls-surface2); }
+  .chip.active {
+    background: linear-gradient(135deg, var(--ls-gold-light), var(--ls-gold));
+    color: var(--ls-charcoal);
+    border-color: var(--ls-gold);
+    font-weight: 600;
+  }
+  .chip .sep {
+    margin: 0 4px;
+    color: var(--ls-text-hint);
+    font-size: 10px;
+  }
+  .filter-label {
+    flex-shrink: 0;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--ls-text-hint);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 6px 6px 6px 0;
+    align-self: center;
+  }
+
+  /* Tip cultural en 1 ligne ultra-compact */
+  .culture-line {
+    padding: 6px 16px;
+    font-size: 11px;
+    color: var(--ls-text-muted);
+    background: color-mix(in srgb, var(--ls-teal) 8%, var(--ls-cream));
+    border-top: 1px solid var(--ls-border);
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+  .culture-line strong { color: var(--ls-text); font-weight: 600; }
+
+  /* Tabs modules : scrollable horizontal */
+  .module-tabs {
+    display: flex;
+    gap: 0;
+    padding: 0 8px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    border-top: 1px solid var(--ls-border);
+    background: white;
+  }
+  .module-tabs::-webkit-scrollbar { display: none; }
+  .mtab {
+    flex-shrink: 0;
+    padding: 12px 10px;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--ls-text-muted);
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3px;
+    min-width: 64px;
+    font-family: inherit;
+    transition: color 120ms;
+  }
+  .mtab .emoji { font-size: 18px; line-height: 1; }
+  .mtab .label { font-size: 10px; letter-spacing: 0.02em; }
+  .mtab:hover { color: var(--ls-text); }
+  .mtab.active {
+    color: var(--ls-gold);
+    border-bottom-color: var(--ls-gold);
+    font-weight: 700;
+  }
+
+  /* ===== Stats stripe ===== */
+  .stats-stripe {
+    display: flex;
+    gap: 0;
+    padding: 8px 16px;
+    background: color-mix(in srgb, var(--ls-gold) 6%, var(--ls-cream));
+    border-bottom: 1px solid var(--ls-border);
+    font-size: 11px;
+    color: var(--ls-text-muted);
+  }
+  .stats-stripe .stat { flex: 1; text-align: center; }
+  .stats-stripe .stat b { display: block; color: var(--ls-text); font-family: 'Syne', serif; font-size: 18px; font-weight: 700; margin-bottom: 2px; }
+
+  /* ===== Module content ===== */
+  .module-content {
+    padding: 16px;
+    animation: fade 220ms ease;
+  }
+  @keyframes fade {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 0 0 14px;
+  }
+  .section-emoji {
+    width: 40px; height: 40px;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--ls-gold) 14%, var(--ls-surface2));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 22px;
+  }
+  .section-title {
+    font-family: 'Syne', serif;
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--ls-text);
+  }
+  .section-subtitle {
+    font-size: 12px;
+    color: var(--ls-text-muted);
+    margin-top: 2px;
+  }
+  .section-meta { display: flex; flex-direction: column; }
+
+  h3.sub {
+    font-family: 'Syne', serif;
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--ls-text-muted);
+    margin: 18px 0 8px;
+  }
+  h3.sub:first-of-type { margin-top: 8px; }
+
+  .card {
+    background: white;
+    border: 1px solid var(--ls-border);
+    border-radius: 14px;
+    padding: 14px 16px;
+    margin-bottom: 10px;
+  }
+  .card-title {
+    font-family: 'Syne', serif;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--ls-text);
+    margin-bottom: 6px;
+  }
+  .card-body {
+    font-size: 13.5px;
+    color: var(--ls-text);
+    line-height: 1.55;
+  }
+
+  .error-card {
+    border-color: color-mix(in srgb, var(--ls-coral) 35%, var(--ls-border));
+    background: linear-gradient(135deg, color-mix(in srgb, var(--ls-coral) 6%, white), white);
+  }
+  .error-num {
+    display: inline-flex;
+    width: 22px; height: 22px;
+    border-radius: 50%;
+    background: var(--ls-coral);
+    color: white;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 700;
+    margin-right: 8px;
+  }
+
+  /* Flags green/red side by side */
+  .flag-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin-bottom: 12px;
+  }
+  @media (max-width: 480px) {
+    .flag-grid { grid-template-columns: 1fr; }
+  }
+  .flag-card {
+    border-radius: 14px;
+    padding: 12px 14px;
+  }
+  .flag-card.green {
+    background: var(--green-50);
+    border: 1px solid var(--green-300);
+  }
+  .flag-card.red {
+    background: var(--red-50);
+    border: 1px solid var(--red-300);
+  }
+  .flag-card h4 {
+    font-size: 12px;
+    font-weight: 700;
+    margin-bottom: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .flag-card.green h4 { color: var(--green-700); }
+  .flag-card.red h4 { color: var(--red-700); }
+  .flag-card ul { list-style: none; }
+  .flag-card li {
+    font-size: 12.5px;
+    padding: 3px 0;
+    color: var(--ls-text);
+  }
+
+  /* Script cards (Messages M1) */
+  .script-card {
+    background: white;
+    border: 1px solid var(--ls-border);
+    border-radius: 16px;
+    padding: 14px 16px;
+    margin-bottom: 12px;
+    position: relative;
+  }
+  .script-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+  }
+  .platform-pill {
+    width: 32px; height: 32px;
+    border-radius: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    color: white;
+  }
+  .platform-pill.wa { background: #25D366; }
+  .platform-pill.ig { background: linear-gradient(135deg, #F58529, #DD2A7B, #8134AF); }
+  .platform-pill.fb { background: #1877F2; }
+  .platform-pill.sms { background: #6B7280; }
+  .script-meta { flex: 1; }
+  .script-meta .name {
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--ls-text);
+  }
+  .script-meta .lang {
+    font-size: 11px;
+    color: var(--ls-text-hint);
+  }
+  .script-body {
+    background: color-mix(in srgb, var(--ls-gold) 5%, var(--ls-surface2));
+    border-radius: 10px;
+    padding: 12px 14px;
+    font-size: 13.5px;
+    line-height: 1.55;
+    white-space: pre-wrap;
+    color: var(--ls-text);
+    font-family: inherit;
+  }
+  .script-body .var { color: var(--ls-teal-dark); font-weight: 600; }
+  .script-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 10px;
+  }
+  .btn {
+    padding: 8px 14px;
+    border-radius: 999px;
+    border: 1px solid var(--ls-border);
+    background: white;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--ls-text);
+    font-family: inherit;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .btn:hover { background: var(--ls-surface2); }
+  .btn.primary {
+    background: linear-gradient(135deg, var(--ls-gold-light), var(--ls-gold));
+    color: var(--ls-charcoal);
+    border-color: var(--ls-gold);
+  }
+  .script-tip {
+    margin-top: 10px;
+    padding: 8px 12px;
+    background: color-mix(in srgb, var(--ls-teal) 10%, white);
+    border-left: 3px solid var(--ls-teal);
+    border-radius: 4px;
+    font-size: 12px;
+    color: var(--ls-text-muted);
+  }
+  .toggle-fr {
+    font-size: 11.5px;
+    color: var(--ls-text-muted);
+    cursor: pointer;
+    margin-top: 8px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  /* Objection block */
+  .obj {
+    background: white;
+    border: 1px solid var(--ls-border);
+    border-radius: 16px;
+    padding: 14px 16px;
+    margin-bottom: 12px;
+  }
+  .obj-quote {
+    font-family: 'Syne', serif;
+    font-size: 17px;
+    font-weight: 700;
+    color: var(--ls-text);
+    margin-bottom: 10px;
+    line-height: 1.3;
+  }
+  .obj-quote::before { content: "« "; color: var(--ls-gold); }
+  .obj-quote::after { content: " »"; color: var(--ls-gold); }
+  .obj-row {
+    margin-bottom: 8px;
+    font-size: 12.5px;
+    line-height: 1.5;
+  }
+  .obj-row .tag {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 700;
+    margin-right: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .obj-row .tag.bad { background: var(--red-50); color: var(--red-700); }
+  .obj-row .tag.good { background: var(--green-50); color: var(--green-700); }
+  .obj-row .tag.meaning { background: var(--ls-surface2); color: var(--ls-text-muted); }
+  .obj-row .tag.warn { background: color-mix(in srgb, var(--ls-gold) 18%, white); color: #92400e; }
+  .obj-good-body {
+    margin-top: 6px;
+    background: color-mix(in srgb, var(--ls-gold) 4%, var(--ls-surface2));
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 13px;
+    line-height: 1.55;
+    white-space: pre-wrap;
+  }
+
+  /* Bottom CTA bar : navigation rapide prev/next module */
+  .module-nav-bar {
+    position: sticky;
+    bottom: 0;
+    background: linear-gradient(to top, var(--ls-cream) 60%, color-mix(in srgb, var(--ls-cream) 80%, transparent));
+    padding: 12px 16px;
+    display: flex;
+    gap: 8px;
+    justify-content: space-between;
+    align-items: center;
+    backdrop-filter: blur(8px);
+    border-top: 1px solid var(--ls-border);
+  }
+  .module-nav-bar .nav-btn {
+    padding: 8px 14px;
+    background: white;
+    border: 1px solid var(--ls-border);
+    border-radius: 10px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--ls-text);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    flex: 1;
+    justify-content: center;
+    max-width: 45%;
+    font-family: inherit;
+  }
+  .module-nav-bar .nav-btn:hover { background: var(--ls-surface2); }
+  .module-nav-bar .module-position {
+    font-size: 11px;
+    color: var(--ls-text-muted);
+    font-family: 'Syne', serif;
+    font-weight: 600;
+  }
+
+  /* Comparison reference (old design teaser) */
+  .compare-note {
+    margin-top: 40px;
+    padding: 16px 20px;
+    background: white;
+    border: 1px dashed var(--ls-border);
+    border-radius: 12px;
+    font-size: 12px;
+    color: var(--ls-text-muted);
+    text-align: center;
+  }
+  .compare-note b { color: var(--ls-text); }
+
+  /* Side-by-side comparison */
+  .side-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 24px;
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 16px;
+  }
+  @media (min-width: 1024px) {
+    .side-grid { grid-template-columns: 1fr 1fr; }
+  }
+  .panel {
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 4px 24px rgba(0,0,0,.06);
+  }
+  .panel-label {
+    background: var(--ls-charcoal);
+    color: var(--ls-gold);
+    padding: 10px 16px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .panel-label .device { color: rgba(255,255,255,.55); font-weight: 400; text-transform: none; letter-spacing: 0; }
+
+  /* Mobile frame */
+  .mobile-frame {
+    max-width: 393px;
+    margin: 0 auto;
+    border: 8px solid var(--ls-charcoal);
+    border-radius: 32px;
+    overflow: hidden;
+    background: var(--ls-cream);
+  }
+  .mobile-frame .app-shell { max-width: 100%; min-height: 700px; padding-bottom: 60px; }
+
+</style>
+</head>
+<body>
+
+<div class="mockup-banner">
+  MOCKUP V4 HUB — refonte navigation (option A : tabs horizontaux + 1 module à la fois)
+  · <span class="small">Validation Thomas avant port en TSX</span>
+</div>
+
+<div class="side-grid">
+
+  <!-- ============================================================ -->
+  <!-- VARIANT 1 : Mobile (mode hub, distri déjà onboardé)            -->
+  <!-- ============================================================ -->
+  <div class="panel">
+    <div class="panel-label">
+      📱 Mobile · Hub direct
+      <span class="device">distri déjà onboardé · 393 × ~700</span>
+    </div>
+    <div class="mobile-frame">
+      <div class="app-shell">
+
+        <!-- Sticky header -->
+        <div class="sticky-top">
+          <div class="crumb-bar">
+            <div class="crumb-eyebrow">LA BASE 360 <span class="dot"></span> PROSPECTION</div>
+            <a class="help-link" href="#">? Comment ça marche</a>
+          </div>
+
+          <!-- Filter ligne 1 : marché + profil combinés -->
+          <div class="filter-row">
+            <span class="filter-label">CIBLE</span>
+            <button class="chip active">🇫🇷 France</button>
+            <span class="sep">·</span>
+            <button class="chip active">⚖️ Femmes</button>
+            <button class="chip">🇬🇧 Intl</button>
+            <button class="chip">🇲🇽 LatAm</button>
+            <button class="chip">🇧🇷 Brésil</button>
+            <button class="chip">💪 Hommes</button>
+            <button class="chip">🏃 Sport</button>
+            <button class="chip">💼 Business</button>
+          </div>
+
+          <!-- Tip culturel 1 ligne -->
+          <div class="culture-line">
+            ⏰ <strong>12-14h ou 19-21h</strong> · <span>Tutoiement OK Insta/FB · vouvoiement LinkedIn</span>
+          </div>
+
+          <!-- Tabs modules : scrollable -->
+          <div class="module-tabs">
+            <button class="mtab"><span class="emoji">🧠</span><span class="label">Mindset</span></button>
+            <button class="mtab"><span class="emoji">🔍</span><span class="label">Trouver</span></button>
+            <button class="mtab active"><span class="emoji">📨</span><span class="label">M1</span></button>
+            <button class="mtab"><span class="emoji">🌳</span><span class="label">M2/M3</span></button>
+            <button class="mtab"><span class="emoji">🛡️</span><span class="label">Objections</span></button>
+            <button class="mtab"><span class="emoji">📞</span><span class="label">Suivi</span></button>
+            <button class="mtab"><span class="emoji">🎯</span><span class="label">Closing</span></button>
+            <button class="mtab"><span class="emoji">🔁</span><span class="label">Spéciaux</span></button>
+            <button class="mtab"><span class="emoji">📖</span><span class="label">Story</span></button>
+            <button class="mtab"><span class="emoji">⏰</span><span class="label">Routine</span></button>
+          </div>
+        </div>
+
+        <!-- Stats stripe minimaliste -->
+        <div class="stats-stripe">
+          <div class="stat"><b>2</b>envois 7j</div>
+          <div class="stat"><b>0</b>réponses</div>
+          <div class="stat"><b>0</b>leads</div>
+        </div>
+
+        <!-- Module content : Messages M1 -->
+        <div class="module-content">
+          <div class="section-header">
+            <div class="section-emoji">📨</div>
+            <div class="section-meta">
+              <div class="section-title">Messages M1</div>
+              <div class="section-subtitle">Premier contact par plateforme · 4 scripts</div>
+            </div>
+          </div>
+
+          <div class="script-card">
+            <div class="script-header">
+              <span class="platform-pill ig">📷</span>
+              <div class="script-meta">
+                <div class="name">Instagram DM · Premier contact</div>
+                <div class="lang">🇫🇷 Français</div>
+              </div>
+            </div>
+            <div class="script-body">Salut <span class="var">[prénom]</span> ! 👋
+Je suis tombée sur ton profil et tes posts m'ont vraiment parlé. Je vois qu'on partage le côté <span class="var">[healthy / sport / mom-life]</span>.
+
+Petite question pour mieux comprendre — tu cherches plutôt à perdre du poids, à gagner en énergie, ou les deux ? 🌿</div>
+            <div class="script-actions">
+              <button class="btn primary">📋 Copier</button>
+              <button class="btn">✓ J'ai envoyé</button>
+            </div>
+            <div class="script-tip">💡 Personnalise <strong>[détail vu sur son profil]</strong>. Pas de lien dans le 1er message (filtre spam).</div>
+          </div>
+
+          <div class="script-card">
+            <div class="script-header">
+              <span class="platform-pill wa">💬</span>
+              <div class="script-meta">
+                <div class="name">WhatsApp · Contact direct</div>
+                <div class="lang">🇫🇷 Français</div>
+              </div>
+            </div>
+            <div class="script-body">Coucou <span class="var">[prénom]</span> ! 😊
+C'est <span class="var">[ton prénom]</span>, on s'est croisées via <span class="var">[contexte]</span>. Tu m'avais parlé de ton envie de <span class="var">[perdre du poids / te sentir mieux]</span>.
+
+J'ai une approche qui marche bien — tu veux qu'on en discute 15 min ?</div>
+            <div class="script-actions">
+              <button class="btn primary">📋 Copier</button>
+              <button class="btn">✓ J'ai envoyé</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Nav modules en bas -->
+        <div class="module-nav-bar">
+          <button class="nav-btn">← 🔍 Trouver</button>
+          <span class="module-position">3 / 10</span>
+          <button class="nav-btn">🌳 M2/M3 →</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!-- VARIANT 2 : Mobile (module Mindset)                            -->
+  <!-- ============================================================ -->
+  <div class="panel">
+    <div class="panel-label">
+      📱 Mobile · Module Mindset
+      <span class="device">section §1 — tab active</span>
+    </div>
+    <div class="mobile-frame">
+      <div class="app-shell">
+
+        <div class="sticky-top">
+          <div class="crumb-bar">
+            <div class="crumb-eyebrow">LA BASE 360 <span class="dot"></span> PROSPECTION</div>
+            <a class="help-link" href="#">? Aide</a>
+          </div>
+
+          <div class="filter-row">
+            <span class="filter-label">CIBLE</span>
+            <button class="chip active">🇫🇷 France</button>
+            <span class="sep">·</span>
+            <button class="chip active">⚖️ Femmes</button>
+            <button class="chip">🇬🇧 Intl</button>
+            <button class="chip">🇲🇽 LatAm</button>
+            <button class="chip">💪 Hommes</button>
+            <button class="chip">🏃 Sport</button>
+          </div>
+
+          <div class="culture-line">
+            ⏰ <strong>12-14h ou 19-21h</strong> · <span>Tutoiement OK · pas trop d'emojis pro</span>
+          </div>
+
+          <div class="module-tabs">
+            <button class="mtab active"><span class="emoji">🧠</span><span class="label">Mindset</span></button>
+            <button class="mtab"><span class="emoji">🔍</span><span class="label">Trouver</span></button>
+            <button class="mtab"><span class="emoji">📨</span><span class="label">M1</span></button>
+            <button class="mtab"><span class="emoji">🌳</span><span class="label">M2/M3</span></button>
+            <button class="mtab"><span class="emoji">🛡️</span><span class="label">Objections</span></button>
+            <button class="mtab"><span class="emoji">📞</span><span class="label">Suivi</span></button>
+            <button class="mtab"><span class="emoji">🎯</span><span class="label">Closing</span></button>
+            <button class="mtab"><span class="emoji">🔁</span><span class="label">Spéciaux</span></button>
+            <button class="mtab"><span class="emoji">📖</span><span class="label">Story</span></button>
+            <button class="mtab"><span class="emoji">⏰</span><span class="label">Routine</span></button>
+          </div>
+        </div>
+
+        <div class="module-content">
+          <div class="section-header">
+            <div class="section-emoji">🧠</div>
+            <div class="section-meta">
+              <div class="section-title">Mindset & posture</div>
+              <div class="section-subtitle">3 vérités · 5 erreurs · métriques réalistes</div>
+            </div>
+          </div>
+
+          <h3 class="sub">Les 3 vérités à accepter</h3>
+
+          <div class="card">
+            <div class="card-title">Ce n'est pas un jeu de volume aveugle</div>
+            <div class="card-body">Ton travail n'est pas de convaincre. Ton travail est de trouver les bonnes personnes au bon moment. Si tu envoies 100 messages pour convaincre 100 personnes, tu épuises ta motivation en une semaine.</div>
+          </div>
+
+          <div class="card">
+            <div class="card-title">Plus tu es détendu, plus tu attires</div>
+            <div class="card-body">Un prospect sent immédiatement si tu transpires le « il faut absolument que je te recrute ». Le détachement attire, la pression repousse.</div>
+          </div>
+
+          <h3 class="sub">Erreurs du débutant</h3>
+
+          <div class="card error-card">
+            <div class="card-title"><span class="error-num">1</span>Pitcher dès le M1</div>
+            <div class="card-body">Tu perds 90 % des prospects en une phrase. Le M1 n'a qu'un objectif : obtenir une réponse. Pas vendre.</div>
+          </div>
+
+          <div class="card error-card">
+            <div class="card-title"><span class="error-num">2</span>Envoyer le même message à 50 personnes</div>
+            <div class="card-body">Le copier-coller se sent à 100 m. Personnalise au moins le [détail vu sur son profil].</div>
+          </div>
+
+          <div class="card error-card">
+            <div class="card-title"><span class="error-num">3</span>Relancer J+1, J+2, J+3</div>
+            <div class="card-body">Tu passes du coach au harceleur en 48 h. Une seule relance, à J+3, jamais plus.</div>
+          </div>
+
+          <h3 class="sub">Métriques réalistes (débutant)</h3>
+
+          <div class="card" style="padding:0;overflow:hidden">
+            <table style="width:100%;border-collapse:collapse;font-size:13px;">
+              <tr style="border-bottom:1px solid var(--ls-border);">
+                <td style="padding:10px 14px;">Messages M1 envoyés</td>
+                <td style="padding:10px 14px;text-align:right;font-family:'Syne',serif;font-weight:700;">100</td>
+              </tr>
+              <tr style="border-bottom:1px solid var(--ls-border);">
+                <td style="padding:10px 14px;">Réponses reçues</td>
+                <td style="padding:10px 14px;text-align:right;font-family:'Syne',serif;font-weight:700;">15-25</td>
+              </tr>
+              <tr style="border-bottom:1px solid var(--ls-border);">
+                <td style="padding:10px 14px;">Conv. qualifiées (M2-M3)</td>
+                <td style="padding:10px 14px;text-align:right;font-family:'Syne',serif;font-weight:700;">5-10</td>
+              </tr>
+              <tr style="border-bottom:1px solid var(--ls-border);">
+                <td style="padding:10px 14px;">RDV pris</td>
+                <td style="padding:10px 14px;text-align:right;font-family:'Syne',serif;font-weight:700;">1-3</td>
+              </tr>
+              <tr>
+                <td style="padding:10px 14px;">Nouveaux clients</td>
+                <td style="padding:10px 14px;text-align:right;font-family:'Syne',serif;font-weight:700;color:var(--ls-gold);">0-1</td>
+              </tr>
+            </table>
+          </div>
+        </div>
+
+        <div class="module-nav-bar">
+          <button class="nav-btn" style="opacity:.4;">←</button>
+          <span class="module-position">1 / 10</span>
+          <button class="nav-btn">🔍 Trouver →</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!-- VARIANT 3 : Mobile (module Objections)                          -->
+  <!-- ============================================================ -->
+  <div class="panel">
+    <div class="panel-label">
+      📱 Mobile · Module Objections
+      <span class="device">section §5 — 8 objections types</span>
+    </div>
+    <div class="mobile-frame">
+      <div class="app-shell">
+
+        <div class="sticky-top">
+          <div class="crumb-bar">
+            <div class="crumb-eyebrow">LA BASE 360 <span class="dot"></span> PROSPECTION</div>
+            <a class="help-link" href="#">? Aide</a>
+          </div>
+
+          <div class="filter-row">
+            <span class="filter-label">CIBLE</span>
+            <button class="chip active">🇫🇷 France</button>
+            <span class="sep">·</span>
+            <button class="chip active">⚖️ Femmes</button>
+            <button class="chip">🇬🇧 Intl</button>
+            <button class="chip">🇲🇽 LatAm</button>
+          </div>
+
+          <div class="culture-line">
+            ⏰ <strong>12-14h ou 19-21h</strong> · <span>Pas trop d'emojis pro</span>
+          </div>
+
+          <div class="module-tabs">
+            <button class="mtab"><span class="emoji">🧠</span><span class="label">Mindset</span></button>
+            <button class="mtab"><span class="emoji">🔍</span><span class="label">Trouver</span></button>
+            <button class="mtab"><span class="emoji">📨</span><span class="label">M1</span></button>
+            <button class="mtab"><span class="emoji">🌳</span><span class="label">M2/M3</span></button>
+            <button class="mtab active"><span class="emoji">🛡️</span><span class="label">Objections</span></button>
+            <button class="mtab"><span class="emoji">📞</span><span class="label">Suivi</span></button>
+            <button class="mtab"><span class="emoji">🎯</span><span class="label">Closing</span></button>
+            <button class="mtab"><span class="emoji">🔁</span><span class="label">Spéciaux</span></button>
+            <button class="mtab"><span class="emoji">📖</span><span class="label">Story</span></button>
+            <button class="mtab"><span class="emoji">⏰</span><span class="label">Routine</span></button>
+          </div>
+        </div>
+
+        <div class="module-content">
+          <div class="section-header">
+            <div class="section-emoji">🛡️</div>
+            <div class="section-meta">
+              <div class="section-title">Objections</div>
+              <div class="section-subtitle">8 objections types + réponses</div>
+            </div>
+          </div>
+
+          <div class="obj">
+            <div class="obj-quote">C'est cher</div>
+            <div class="obj-row">
+              <span class="tag meaning">CE QU'ELLE VEUT DIRE</span>
+              Elle ne voit pas la valeur, OU elle ne peut pas / ne veut pas mettre cette somme.
+            </div>
+            <div class="obj-row">
+              <span class="tag bad">À ÉVITER</span>
+              Minimiser (« c'est le prix d'un café »), ou rajouter une remise dès la première objection.
+            </div>
+            <div class="obj-row">
+              <span class="tag good">BONNE RÉPONSE</span>
+            </div>
+            <div class="obj-good-body">Je comprends [prénom]. Cher par rapport à quoi ? Et qu'est-ce qui ferait que ça vaut le coup à tes yeux ?
+
+Je te demande pas pour te convaincre — c'est juste que selon ta réponse, soit c'est pas le bon moment, soit on peut voir si y'a une formule plus adaptée.</div>
+          </div>
+
+          <div class="obj">
+            <div class="obj-quote">C'est de l'Herbalife / MLM ?</div>
+            <div class="obj-row">
+              <span class="tag meaning">CE QU'ELLE VEUT DIRE</span>
+              Peur de se faire avoir, ou mauvais souvenir (proche déçu).
+            </div>
+            <div class="obj-row">
+              <span class="tag bad">À ÉVITER</span>
+              Nier, dire « non c'est différent », esquiver.
+            </div>
+            <div class="obj-row">
+              <span class="tag good">BONNE RÉPONSE</span>
+            </div>
+            <div class="obj-good-body">Oui c'est [marque], et oui c'est une distribution multi-niveaux. Pas un système pyramidal au sens illégal — la différence c'est qu'il y a un vrai produit consommé par des clients finaux.
+
+Il y a des choses vraies et fausses qui circulent sur ce modèle. Si tu me dis ce qui te bloque précisément, je te réponds franchement.</div>
+            <div class="obj-row" style="margin-top:8px;">
+              <span class="tag warn">⚠️ ATTENTION</span>
+              Mentir détruit ta crédibilité pour toujours.
+            </div>
+          </div>
+        </div>
+
+        <div class="module-nav-bar">
+          <button class="nav-btn">← 🌳 M2/M3</button>
+          <span class="module-position">5 / 10</span>
+          <button class="nav-btn">📞 Suivi →</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!-- VARIANT 4 : Mobile (module Trouver - flags + hashtags)         -->
+  <!-- ============================================================ -->
+  <div class="panel">
+    <div class="panel-label">
+      📱 Mobile · Module Trouver
+      <span class="device">section §2 — flags + hashtags catégorisés</span>
+    </div>
+    <div class="mobile-frame">
+      <div class="app-shell">
+
+        <div class="sticky-top">
+          <div class="crumb-bar">
+            <div class="crumb-eyebrow">LA BASE 360 <span class="dot"></span> PROSPECTION</div>
+            <a class="help-link" href="#">? Aide</a>
+          </div>
+
+          <div class="filter-row">
+            <span class="filter-label">CIBLE</span>
+            <button class="chip active">🇫🇷 France</button>
+            <span class="sep">·</span>
+            <button class="chip active">⚖️ Femmes</button>
+            <button class="chip">🇬🇧 Intl</button>
+            <button class="chip">💪 Hommes</button>
+            <button class="chip">🏃 Sport</button>
+          </div>
+
+          <div class="culture-line">
+            ⏰ <strong>12-14h ou 19-21h</strong> · <span>Tutoiement Insta/FB</span>
+          </div>
+
+          <div class="module-tabs">
+            <button class="mtab"><span class="emoji">🧠</span><span class="label">Mindset</span></button>
+            <button class="mtab active"><span class="emoji">🔍</span><span class="label">Trouver</span></button>
+            <button class="mtab"><span class="emoji">📨</span><span class="label">M1</span></button>
+            <button class="mtab"><span class="emoji">🌳</span><span class="label">M2/M3</span></button>
+            <button class="mtab"><span class="emoji">🛡️</span><span class="label">Objections</span></button>
+            <button class="mtab"><span class="emoji">📞</span><span class="label">Suivi</span></button>
+            <button class="mtab"><span class="emoji">🎯</span><span class="label">Closing</span></button>
+            <button class="mtab"><span class="emoji">🔁</span><span class="label">Spéciaux</span></button>
+            <button class="mtab"><span class="emoji">📖</span><span class="label">Story</span></button>
+            <button class="mtab"><span class="emoji">⏰</span><span class="label">Routine</span></button>
+          </div>
+        </div>
+
+        <div class="module-content">
+          <div class="section-header">
+            <div class="section-emoji">🔍</div>
+            <div class="section-meta">
+              <div class="section-title">Trouver les prospects</div>
+              <div class="section-subtitle">Scan 30s · hashtags · sources alt</div>
+            </div>
+          </div>
+
+          <h3 class="sub">Scan profil 30 secondes</h3>
+
+          <div class="flag-grid">
+            <div class="flag-card green">
+              <h4>✅ Green flags</h4>
+              <ul>
+                <li>Activité &lt; 2 sem</li>
+                <li>Posts personnels engagés</li>
+                <li>Bio avec intention claire</li>
+                <li>Pas déjà coach concurrent</li>
+              </ul>
+            </div>
+            <div class="flag-card red">
+              <h4>❌ Red flags</h4>
+              <ul>
+                <li>Profil privé sans contexte</li>
+                <li>100 % business / shop</li>
+                <li>Aucun post depuis 6+ mois</li>
+                <li>Beaucoup d'abonnés / peu d'eng.</li>
+              </ul>
+            </div>
+          </div>
+
+          <h3 class="sub">Hashtags catégorisés</h3>
+
+          <div class="card">
+            <div style="font-size:11px;color:var(--ls-text-hint);letter-spacing:0.06em;text-transform:uppercase;margin-bottom:6px;">Mainstream (large)</div>
+            <div style="display:flex;flex-wrap:wrap;gap:6px;">
+              <span style="padding:3px 10px;border:1px solid var(--ls-border);border-radius:999px;font-size:12px;background:white;">#pertedepoidsfr</span>
+              <span style="padding:3px 10px;border:1px solid var(--ls-border);border-radius:999px;font-size:12px;background:white;">#regimefr</span>
+              <span style="padding:3px 10px;border:1px solid var(--ls-border);border-radius:999px;font-size:12px;background:white;">#bienetrefr</span>
+              <span style="padding:3px 10px;border:1px solid var(--ls-border);border-radius:999px;font-size:12px;background:white;">#alimentationsaine</span>
+            </div>
+          </div>
+
+          <div class="card">
+            <div style="font-size:11px;color:var(--ls-teal-dark);letter-spacing:0.06em;text-transform:uppercase;margin-bottom:6px;">Niche (segment précis)</div>
+            <div style="display:flex;flex-wrap:wrap;gap:6px;">
+              <span style="padding:3px 10px;border:1px solid var(--ls-teal);border-radius:999px;font-size:12px;color:var(--ls-teal-dark);background:color-mix(in srgb,var(--ls-teal) 6%,white);">#mamanquisebouge</span>
+              <span style="padding:3px 10px;border:1px solid var(--ls-teal);border-radius:999px;font-size:12px;color:var(--ls-teal-dark);background:color-mix(in srgb,var(--ls-teal) 6%,white);">#mompreneur</span>
+              <span style="padding:3px 10px;border:1px solid var(--ls-teal);border-radius:999px;font-size:12px;color:var(--ls-teal-dark);background:color-mix(in srgb,var(--ls-teal) 6%,white);">#nutritionConsciente</span>
+              <span style="padding:3px 10px;border:1px solid var(--ls-teal);border-radius:999px;font-size:12px;color:var(--ls-teal-dark);background:color-mix(in srgb,var(--ls-teal) 6%,white);">#perteDePoidsSaine</span>
+            </div>
+          </div>
+
+          <div class="card" style="background:color-mix(in srgb,var(--ls-gold) 6%,white);border-color:color-mix(in srgb,var(--ls-gold) 40%,var(--ls-border));">
+            <div style="font-size:11px;color:#92400e;letter-spacing:0.06em;text-transform:uppercase;margin-bottom:6px;">⭐ Cross (à croiser)</div>
+            <div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:8px;">
+              <span style="padding:3px 10px;border:1px solid var(--ls-gold);border-radius:999px;font-size:12px;color:#92400e;background:white;">#pertedepoidsfr</span>
+              <span style="font-size:11px;color:var(--ls-text-muted);align-self:center;">+</span>
+              <span style="padding:3px 10px;border:1px solid var(--ls-gold);border-radius:999px;font-size:12px;color:#92400e;background:white;">#mamanquisebouge</span>
+            </div>
+            <div style="font-size:12px;color:var(--ls-text-muted);line-height:1.5;">À croiser avec <strong>#mamanquisebouge</strong> ou <strong>#sansgluten</strong> pour cibler maman healthy.</div>
+          </div>
+        </div>
+
+        <div class="module-nav-bar">
+          <button class="nav-btn">← 🧠 Mindset</button>
+          <span class="module-position">2 / 10</span>
+          <button class="nav-btn">📨 M1 →</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div style="max-width:760px;margin:30px auto 60px;padding:24px;background:white;border-radius:16px;border:1px solid var(--ls-border);font-size:14px;color:var(--ls-text);line-height:1.65;">
+  <h2 style="font-family:'Syne',serif;font-size:20px;margin-bottom:12px;">🧠 Principes du redesign — pourquoi ça change tout</h2>
+
+  <p style="margin-bottom:10px;"><strong>1. Le header s'efface après onboarding.</strong> Plus de hero gigantesque qui mange 40 % de l'écran. L'eyebrow LA BASE 360 · PROSPECTION suffit à se situer. Hauteur sticky &lt;= 150px sur mobile.</p>
+
+  <p style="margin-bottom:10px;"><strong>2. Marché + profil sur 1 seule ligne scrollable.</strong> Plus 2 lignes séparées qui doublent la hauteur. Les actifs (gold) restent visibles à gauche, le reste défile à droite.</p>
+
+  <p style="margin-bottom:10px;"><strong>3. Tabs horizontaux avec emoji + micro-label.</strong> Le distri voit en permanence les 10 modules. Il scroll horizontalement (1 doigt) pour passer entre eux. <em>Plus de scroll vertical infini pour trouver « Storytelling » à la fin.</em></p>
+
+  <p style="margin-bottom:10px;"><strong>4. Un module visible à la fois.</strong> La page se charge, t'arrives directement sur le module choisi. Pas d'accordion à ouvrir/fermer.</p>
+
+  <p style="margin-bottom:10px;"><strong>5. Nav bar sticky en bas.</strong> Boutons précédent/suivant module. Le distri parcourt linéairement s'il veut tout lire.</p>
+
+  <p style="margin-bottom:10px;"><strong>6. Mobile-first absolu.</strong> Tout est conçu pour 393px de large (iPhone). Sur desktop, le shell est centré à 640px max (comme le tunnel V3).</p>
+
+  <p style="margin-top:16px;padding-top:14px;border-top:1px dashed var(--ls-border);"><strong style="color:var(--ls-gold);">Si validé :</strong> je porte ce design dans <code>src/components/prospection/ProspectionHub.tsx</code> (~2-3h de boulot), je remplace le composant accordion actuel, je push sur dev/thomas-test puis merge prod après ta validation visuelle Vercel.</p>
+</div>
+
+</body>
+</html>

--- a/docs/mockups/prospection-v4-prototype-chat.md
+++ b/docs/mockups/prospection-v4-prototype-chat.md
@@ -1,0 +1,458 @@
+# Compliment feedback
+
+_Started 2026-05-19 14:52 UTC_
+
+---
+
+## User
+
+<system-info comment="Only acknowledge these if relevant">
+Project title is now "prospection inter"
+Current date is now May 19, 2026
+</system-info>
+
+<default aesthetic>
+If no references, art direction or design systems were provided, use this default professional modern, minimal aesthetic as a base. Declare your choice out loud so you stick to it. Guidance:
+- Choose a type pairing from web-safe set or Google Fonts. Helvetica is a good choice. Avoid hard-to-read or overly stylized fonts. Use 1-3 fonts only.
+- Foreground and background: choose a color tone (warm, cool, neutral, something in-between). Use subtly-toned whites and blacks; avoid saturations above 0.02 for whites.
+- Accents: choose 0-2 additional accent colors using oklch. All accents should share same chroma and lightness; vary hue.
+- NEVER write out an SVG yourself that's more complicated than a square, circle, diamond, etc.
+- For imagery, never hand-draw SVGs; use subtly-striped SVG placeholders instead with monospace explainers for what should be dropped there (e.g. “product shot”)
+
+CRITICAL: ignore default aesthetic entirely if given other aesthetic instructions like reference images, design systems or guidance, or if there are files in the project already.
+</default aesthetic>
+
+<pasted_text name="Pasted text (149 lines)">
+Tu es designer UX/UI senior. Tu refondes l'écran "Prospection internationale"
+d'une web-app SaaS de coaching nutrition Herbalife (La Base 360). Cible
+principale : distributeurs Herbalife 25-50 ans, sur mobile (iPhone, 393px de
+large). Desktop secondaire (centré 640px max).
+
+═══════════════════════════════════════════════════════════════════════════
+CONTEXTE PRODUIT
+═══════════════════════════════════════════════════════════════════════════
+
+L'écran "/prospection" est le HUB méthode de prospection internationale.
+Un distri arrive ici pour :
+- Choisir un MARCHÉ cible (6 options : 🇫🇷 France, 🇬🇧 International,
+  🇲🇽 LatAm+Espagne, 🇧🇷 Brésil+Portugal, 🇹🇷 Turquie+Allemagne, 🇮🇳 Inde)
+- Choisir un PROFIL cible (4 options : ⚖️ Perte de poids Femmes,
+  💪 Perte de poids Hommes, 🏃 Sportif, 💼 Business)
+- Consulter 10 SECTIONS de contenu adaptées à ce couple (marché × profil) :
+  1. 🧠 Mindset & posture (3 vérités + 5 erreurs)
+  2. 🔍 Trouver les prospects (green/red flags scan 30s + hashtags + sources)
+  3. 📨 Messages M1 (premier contact par plateforme Insta/FB/WhatsApp/SMS)
+  4. 🌳 Arbres M2/M3 (que répondre selon la réaction du prospect)
+  5. 🛡️ Objections (8 objections types + réponses)
+  6. 📞 Séquence post-appel (J0/J+2/J+5/J+30)
+  7. 🎯 Closing (signaux + 3 scripts vente)
+  8. 🔁 Cas spéciaux (ghost, réactivation, recommandation)
+  9. 📖 Storytelling (structure + exemples)
+ 10. ⏰ Routine quotidienne (30min/jour + checklist 7 items)
+
+═══════════════════════════════════════════════════════════════════════════
+PROBLÈME ACTUEL
+═══════════════════════════════════════════════════════════════════════════
+
+Ma version actuelle (que je rejette) empile les 10 modules en accordéon
+vertical sous des filtres marché/profil sur 2 lignes séparées + un tip
+culturel en gros bandeau. Résultat : sticky header de 250px+, scroll
+infini pour atteindre "Storytelling" en bas, perte de contexte quand un
+accordéon s'ouvre. C'est lourd et la nav sur mobile est mauvaise.
+
+J'ai un mockup HTML d'une nouvelle direction (tabs horizontaux + 1 module
+visible à la fois + nav bar sticky bas pour précédent/suivant). Je veux
+que tu pousses ce concept plus loin, avec une vraie identité visuelle.
+
+═══════════════════════════════════════════════════════════════════════════
+DESIGN TOKENS À RESPECTER
+═══════════════════════════════════════════════════════════════════════════
+
+Palette (déjà en prod sur l'app, light mode) :
+  --ls-gold:        #C9A84C   (couleur signature, accents principaux)
+  --ls-gold-light:  #E5C97D   (hover, glow)
+  --ls-teal:        #2DD4BF   (accent secondaire)
+  --ls-teal-dark:   #0F766E
+  --ls-coral:       #FB7185   (warning, erreurs douces)
+  --ls-purple:      #7C3AED   (accent tertiaire)
+  --ls-charcoal:    #0B0D11   (texte principal, dark backgrounds)
+  --ls-cream:       #FBF7F0   (background page)
+  --ls-surface:     #FFFFFF
+  --ls-surface2:    #F7F3EC
+
+Typo :
+  Display headlines    → "Syne" (serif moderne)
+  Body / UI            → "DM Sans"
+  Le distri parle italique sur certains éléments (signatures, citations)
+
+Style général : premium éditorial, chaleureux, pas SaaS générique. Le
+gold/cream donne un ton "magazine wellness premium" plus que tech.
+S'inspire du design des apps Lottie, Mubi, ou des newsletters Substack
+premium.
+
+═══════════════════════════════════════════════════════════════════════════
+CONTRAINTES UX
+═══════════════════════════════════════════════════════════════════════════
+
+✅ Mobile-first absolu (393px iPhone). Tester aussi à 360px (petits
+   Android) et 640px (desktop centré).
+
+✅ La sticky du haut DOIT tenir en ≤ 160px sur mobile. Le user doit voir
+   au moins 1 carte de contenu sans scroller.
+
+✅ La navigation entre les 10 modules doit prendre 1 tap, pas 1 scroll.
+   Les 10 modules doivent rester découvrables à tout moment (pas d'overflow
+   caché derrière un menu hamburger).
+
+✅ Filtres marché + profil simultanément visibles, mais compacts. Pas
+   2 lignes séparées de pills. Penser à un picker combiné, des dropdowns,
+   ou une 1 seule ligne scrollable avec actifs en sticky à gauche.
+
+✅ Variables dans les scripts ([prénom], [contexte]) doivent ressortir
+   visuellement (gold ou teal) pour que le distri les remplisse avant
+   copier.
+
+✅ Bouton "Copier" omniprésent sur les blocs de texte (scripts, réponses
+   d'objections, follow-ups). Feedback toast "Copié !".
+
+✅ Traduction française disponible derrière toggle pour les scripts en
+   EN/ES/PT/TR/HI (le coach FR doit comprendre ce qu'il copie-colle).
+
+✅ Le bouton "J'ai envoyé" déclenche un tracking analytics (statistique
+   sur 7 derniers jours visible quelque part en haut, discrètement).
+
+✅ Une nav précédent/suivant module quelque part (sticky bas mobile ?
+   raccourcis clavier desktop ?) pour parcourir linéairement les 10 sections
+   si on est lecteur du dimanche.
+
+═══════════════════════════════════════════════════════════════════════════
+CONTRAINTES À NE PAS RESPECTER ABSOLUMENT
+═══════════════════════════════════════════════════════════════════════════
+
+❌ Ne pas mettre de hero géant en haut une fois que l'user est "onboardé".
+   Le hero c'est OK pour la 1ère visite (pas dans le scope ici).
+
+❌ Ne pas reproduire le pattern "accordéon vertical des 10 modules".
+   C'est le pattern actuel qu'on rejette.
+
+❌ Pas de menu hamburger. Les 10 modules doivent rester découvrables.
+
+❌ Pas d'animations gadget genre confettis, scroll-jacking, parallax.
+   Du smooth fade/slide max. Reduced-motion respecté.
+
+═══════════════════════════════════════════════════════════════════════════
+LIVRABLE ATTENDU
+═══════════════════════════════════════════════════════════════════════════
+
+1. Un artifact HTML self-contained (1 fichier) qui contient 4 captures
+   d'écran mobile (frame iPhone 393×~750) :
+   - HOME : module Mindset actif (le user vient d'arriver)
+   - MODULE Messages M1 (cards scripts par plateforme avec bouton Copier
+     et toggle traduction FR)
+   - MODULE Objections (8 objections en format quote + bad/good response)
+   - MODULE Trouver (green/red flags + hashtags par catégorie
+     mainstream/niche/cross + sources alt FB/IRL/reco)
+
+2. Bonus : 1 frame desktop 640px avec le même module actif.
+
+3. CSS inline. Pas de framework. Variables CSS pour les tokens.
+
+4. Annoter chaque frame avec 2-3 lignes en bas expliquant tes choix
+   ("J'ai mis les filtres dans un picker combiné parce que…").
+
+═══════════════════════════════════════════════════════════════════════════
+RÉFÉRENCE
+═══════════════════════════════════════════════════════════════════════════
+
+Mon mockup actuel (point de départ, à dépasser) :
+docs/mockups/prospection-v4-hub-redesign.html
+
+Tu peux le respecter ou le casser : si tu trouves une meilleure direction
+(side rail desktop, bottom tabs persistants, picker combiné, etc.), montre.
+
+Je veux un livrable qui me fasse dire "ah ouais, OK, je n'avais pas vu ça
+comme ça" — pas une variation cosmétique de mon mockup.
+</pasted_text>
+
+<!-- The user explicitly selected the following skills for this project, as attachments to their message. These are not optional context — they define how you work. Use them. -->
+<attached-skill name="Hi-fi design">
+Create a high-fidelity, polished design. Follow the instructions about design in your system prompt, particularly the 'How to do design work' section. Use the design_canvas starter component, or make a full-bleed prototype and offer options via Tweaks.
+</attached-skill>
+
+<attached-skill name="Interactive prototype">
+Create a fully interactive prototype with realistic state management and transitions. Use React useState/useEffect for dynamic behavior. Include hover states, click interactions, form validation, animated transitions, and multi-step navigation flows. It should feel like a real working app, not a static mockup.
+</attached-skill>
+
+
+<system-reminder>Auto-injected reminder (ignore if not relevant): do not recreate copyrighted or branded UI unless the user's email domain matches that company. Create original designs instead.</system-reminder>
+
+## Assistant
+
+_[tool: list_files]_
+
+## Assistant
+
+_[tool: list_files]_
+
+A few notes before building: I'll design this as an original product called **"La Base 360"** using your design tokens — I won't reproduce any Herbalife logos, trademarks, or branded UI (your email domain doesn't match). The screens reference "distributeurs de coaching nutrition" generically. The IP belongs to your product.
+
+Let me check the reference mockup, plan the layout, and start building.
+
+## Assistant
+
+## User
+
+<pasted_text name="Pasted text (149 lines)">
+Tu es designer UX/UI senior. Tu refondes l'écran "Prospection internationale"
+d'une web-app SaaS de coaching nutrition Herbalife (La Base 360). Cible
+principale : distributeurs Herbalife 25-50 ans, sur mobile (iPhone, 393px de
+large). Desktop secondaire (centré 640px max).
+
+═══════════════════════════════════════════════════════════════════════════
+CONTEXTE PRODUIT
+═══════════════════════════════════════════════════════════════════════════
+
+L'écran "/prospection" est le HUB méthode de prospection internationale.
+Un distri arrive ici pour :
+- Choisir un MARCHÉ cible (6 options : 🇫🇷 France, 🇬🇧 International,
+  🇲🇽 LatAm+Espagne, 🇧🇷 Brésil+Portugal, 🇹🇷 Turquie+Allemagne, 🇮🇳 Inde)
+- Choisir un PROFIL cible (4 options : ⚖️ Perte de poids Femmes,
+  💪 Perte de poids Hommes, 🏃 Sportif, 💼 Business)
+- Consulter 10 SECTIONS de contenu adaptées à ce couple (marché × profil) :
+  1. 🧠 Mindset & posture (3 vérités + 5 erreurs)
+  2. 🔍 Trouver les prospects (green/red flags scan 30s + hashtags + sources)
+  3. 📨 Messages M1 (premier contact par plateforme Insta/FB/WhatsApp/SMS)
+  4. 🌳 Arbres M2/M3 (que répondre selon la réaction du prospect)
+  5. 🛡️ Objections (8 objections types + réponses)
+  6. 📞 Séquence post-appel (J0/J+2/J+5/J+30)
+  7. 🎯 Closing (signaux + 3 scripts vente)
+  8. 🔁 Cas spéciaux (ghost, réactivation, recommandation)
+  9. 📖 Storytelling (structure + exemples)
+ 10. ⏰ Routine quotidienne (30min/jour + checklist 7 items)
+
+═══════════════════════════════════════════════════════════════════════════
+PROBLÈME ACTUEL
+═══════════════════════════════════════════════════════════════════════════
+
+Ma version actuelle (que je rejette) empile les 10 modules en accordéon
+vertical sous des filtres marché/profil sur 2 lignes séparées + un tip
+culturel en gros bandeau. Résultat : sticky header de 250px+, scroll
+infini pour atteindre "Storytelling" en bas, perte de contexte quand un
+accordéon s'ouvre. C'est lourd et la nav sur mobile est mauvaise.
+
+J'ai un mockup HTML d'une nouvelle direction (tabs horizontaux + 1 module
+visible à la fois + nav bar sticky bas pour précédent/suivant). Je veux
+que tu pousses ce concept plus loin, avec une vraie identité visuelle.
+
+═══════════════════════════════════════════════════════════════════════════
+DESIGN TOKENS À RESPECTER
+═══════════════════════════════════════════════════════════════════════════
+
+Palette (déjà en prod sur l'app, light mode) :
+  --ls-gold:        #C9A84C   (couleur signature, accents principaux)
+  --ls-gold-light:  #E5C97D   (hover, glow)
+  --ls-teal:        #2DD4BF   (accent secondaire)
+  --ls-teal-dark:   #0F766E
+  --ls-coral:       #FB7185   (warning, erreurs douces)
+  --ls-purple:      #7C3AED   (accent tertiaire)
+  --ls-charcoal:    #0B0D11   (texte principal, dark backgrounds)
+  --ls-cream:       #FBF7F0   (background page)
+  --ls-surface:     #FFFFFF
+  --ls-surface2:    #F7F3EC
+
+Typo :
+  Display headlines    → "Syne" (serif moderne)
+  Body / UI            → "DM Sans"
+  Le distri parle italique sur certains éléments (signatures, citations)
+
+Style général : premium éditorial, chaleureux, pas SaaS générique. Le
+gold/cream donne un ton "magazine wellness premium" plus que tech.
+S'inspire du design des apps Lottie, Mubi, ou des newsletters Substack
+premium.
+
+═══════════════════════════════════════════════════════════════════════════
+CONTRAINTES UX
+═══════════════════════════════════════════════════════════════════════════
+
+✅ Mobile-first absolu (393px iPhone). Tester aussi à 360px (petits
+   Android) et 640px (desktop centré).
+
+✅ La sticky du haut DOIT tenir en ≤ 160px sur mobile. Le user doit voir
+   au moins 1 carte de contenu sans scroller.
+
+✅ La navigation entre les 10 modules doit prendre 1 tap, pas 1 scroll.
+   Les 10 modules doivent rester découvrables à tout moment (pas d'overflow
+   caché derrière un menu hamburger).
+
+✅ Filtres marché + profil simultanément visibles, mais compacts. Pas
+   2 lignes séparées de pills. Penser à un picker combiné, des dropdowns,
+   ou une 1 seule ligne scrollable avec actifs en sticky à gauche.
+
+✅ Variables dans les scripts ([prénom], [contexte]) doivent ressortir
+   visuellement (gold ou teal) pour que le distri les remplisse avant
+   copier.
+
+✅ Bouton "Copier" omniprésent sur les blocs de texte (scripts, réponses
+   d'objections, follow-ups). Feedback toast "Copié !".
+
+✅ Traduction française disponible derrière toggle pour les scripts en
+   EN/ES/PT/TR/HI (le coach FR doit comprendre ce qu'il copie-colle).
+
+✅ Le bouton "J'ai envoyé" déclenche un tracking analytics (statistique
+   sur 7 derniers jours visible quelque part en haut, discrètement).
+
+✅ Une nav précédent/suivant module quelque part (sticky bas mobile ?
+   raccourcis clavier desktop ?) pour parcourir linéairement les 10 sections
+   si on est lecteur du dimanche.
+
+═══════════════════════════════════════════════════════════════════════════
+CONTRAINTES À NE PAS RESPECTER ABSOLUMENT
+═══════════════════════════════════════════════════════════════════════════
+
+❌ Ne pas mettre de hero géant en haut une fois que l'user est "onboardé".
+   Le hero c'est OK pour la 1ère visite (pas dans le scope ici).
+
+❌ Ne pas reproduire le pattern "accordéon vertical des 10 modules".
+   C'est le pattern actuel qu'on rejette.
+
+❌ Pas de menu hamburger. Les 10 modules doivent rester découvrables.
+
+❌ Pas d'animations gadget genre confettis, scroll-jacking, parallax.
+   Du smooth fade/slide max. Reduced-motion respecté.
+
+═══════════════════════════════════════════════════════════════════════════
+LIVRABLE ATTENDU
+═══════════════════════════════════════════════════════════════════════════
+
+1. Un artifact HTML self-contained (1 fichier) qui contient 4 captures
+   d'écran mobile (frame iPhone 393×~750) :
+   - HOME : module Mindset actif (le user vient d'arriver)
+   - MODULE Messages M1 (cards scripts par plateforme avec bouton Copier
+     et toggle traduction FR)
+   - MODULE Objections (8 objections en format quote + bad/good response)
+   - MODULE Trouver (green/red flags + hashtags par catégorie
+     mainstream/niche/cross + sources alt FB/IRL/reco)
+
+2. Bonus : 1 frame desktop 640px avec le même module actif.
+
+3. CSS inline. Pas de framework. Variables CSS pour les tokens.
+
+4. Annoter chaque frame avec 2-3 lignes en bas expliquant tes choix
+   ("J'ai mis les filtres dans un picker combiné parce que…").
+
+═══════════════════════════════════════════════════════════════════════════
+RÉFÉRENCE
+═══════════════════════════════════════════════════════════════════════════
+
+Mon mockup actuel (point de départ, à dépasser) :
+docs/mockups/prospection-v4-hub-redesign.html
+
+Tu peux le respecter ou le casser : si tu trouves une meilleure direction
+(side rail desktop, bottom tabs persistants, picker combiné, etc.), montre.
+
+Je veux un livrable qui me fasse dire "ah ouais, OK, je n'avais pas vu ça
+comme ça" — pas une variation cosmétique de mon mockup.
+</pasted_text>
+
+## Assistant
+
+_[tool: update_todos]_
+
+The reference mockup isn't in the project, so I'll design fresh from your spec. Locking in the direction now:
+
+**Concept: "L'index éditorial"** — the 10 modules become a numbered horizontal index (like a magazine table of contents), the two filters become twin compact pills on a single line, and the 7-day analytics stat lives discreetly in the header chip. Bottom sticky nav for linear browsing. Editorial, not SaaS-generic.
+
+Let me build the single self-contained HTML.
+
+_[tool: write_file]_
+
+_[tool: done]_
+
+_[tool: fork_verifier_agent]_
+
+Livré : **Prospection — Refonte.html** (un seul fichier, CSS inline, vos tokens respectés, aucun framework).
+
+**Direction prise : « L'index éditorial »**
+- Header sticky **136 px** = brand+stat 7j (28) + jumeau marché×profil (44) + index numéroté 01–10 (52)
+- Filtres en **deux pickers compacts sur 1 ligne** (pas 2 lignes de pills)
+- Les 10 modules en **index numéroté** type sommaire magazine, actif s'étend en gold, autres restent visibles (pas de hamburger, pas de scroll caché)
+- **Nav bas** précédent / 10 dots / suivant pour la lecture linéaire
+- Variables `[prénom]` en **gold** vs `[contexte]` en **teal** — deux familles distinctes
+- Toggle EN↔FR par script + **traduction FR inline en italique** sous le script original
+- Bouton **Copier** (charcoal+gold) et **J'ai envoyé** (gold outline) côte à côte
+
+**5 frames livrés :**
+1. Mindset (home) — pull-quote charcoal × gold, ton magazine
+2. Messages M1 — sous-tabs Insta/FB/WA/SMS, scripts EN+trad FR, taux réponse par script
+3. Objections — citation Syne italique, mauvaise réponse barrée rouge, bonne réponse teal
+4. Trouver — drapeaux verts/rouges en colonnes, hashtags par 3 catégories colorées, sources hors-feed en carte charcoal
+5. Bonus desktop 640 px — tous les 10 modules dans l'index sans scroll, raccourcis ←/→/1-4/C en hint
+
+Chaque frame est annoté en monospace gold avec les 2-3 décisions clés.
+
+## User
+
+beau travail !
+
+## Assistant
+
+Merci ! 🙌
+
+Si tu veux pousser plus loin, quelques pistes possibles :
+- Passer le hub en **prototype interactif** (changer marché/profil → tout le contenu se relocalise, navigation entre modules au clic + flèches clavier)
+- Ajouter les **6 modules manquants** (Arbres M2/M3, Post-appel, Closing, Cas spéciaux, Storytelling, Routine) au même standard
+- **Variations** via Tweaks : tester index numéroté vs. dots, picker jumeau vs. picker combiné en bottom sheet, dark mode
+- Mockup du **bottom sheet** qui s'ouvre au tap sur un picker (les deux grilles marché × profil)
+
+Dis-moi laquelle te tente.
+
+## User
+
+ok montre moi !
+
+## Assistant
+
+_[tool: update_todos]_
+
+On y va — je transforme la maquette en **prototype interactif complet** : les 10 modules, picker bottom-sheets fonctionnels, navigation au clic + flèches clavier, copy/toast, toggle EN↔FR, et un compteur 7j qui s'incrémente quand tu cliques « J'ai envoyé ».
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: done]_
+
+_[tool: fork_verifier_agent]_
+
+Prototype interactif livré — **Prospection - Prototype.html**.
+
+**Tout est branché :**
+- 6 marchés × 4 profils dans des **bottom sheets** (tap sur les pickers)
+- Les 10 modules accessibles au **tap dans l'index**, aux **flèches ←/→** ou aux **touches 1–9/0**
+- **M, P** pour ouvrir les feuilles marché/profil ; **Esc** pour fermer
+- Scripts M1 **localisés** en FR / EN / ES / PT / TR / HI avec **toggle EN→FR inline**
+- Hashtags / drapeaux / sources se localisent automatiquement par marché
+- **« J'ai envoyé »** incrémente le compteur 7j (WhatsApp = +1 RDV en proxy démo)
+- Tap sur la pastille `12 envoyés · 3 RDV` ouvre un **mini funnel**
+- Tap sur un hashtag = copie individuelle
+- Cases spéciaux a un sous-tab Ghost/Réactivation/Reco; routine quotidienne a des checkboxes vivantes
+- Animations fade/slide légères, **reduced-motion respecté**
+
+Le verifier tourne en arrière-plan — il me reviendra si quelque chose accroche.
+
+## User
+
+Verifier agent check completed
+
+## Assistant
+
+Verifier OK — tout marche comme prévu. 🎯
+
+Si tu veux pousser plus loin : ajouter des **Tweaks** (toggle index numéroté vs. dots, dark mode, picker combiné vs. jumeau), brancher l'**onboarding première visite**, ou exporter le tout en PPTX/PDF pour partage. Dis-moi.
+
+## User
+
+ok montre moi
+

--- a/docs/mockups/prospection-v4-prototype-data.js
+++ b/docs/mockups/prospection-v4-prototype-data.js
@@ -1,0 +1,403 @@
+/* ────────────────────────────────────────────────────────────
+   LA BASE 360 · Prospection — Données prototype
+   ──────────────────────────────────────────────────────────── */
+
+window.MARKETS = [
+  { code:'FR', flag:'🇫🇷', name:'France', sub:'fr-FR', lang:'FR',
+    hashtags:{
+      mainstream:['#pertedepoids','#remiseenforme','#maman2026'],
+      niche:['#routinematin','#superfood','#petitdejsain'],
+      cross:['#mealprep','#yogamatinal','#vidasaine']
+    },
+    sources:{
+      fb:'Groupes <em>« Mamans débordées Paris »</em>, <em>« Reprise sport 40+ »</em>. Commentaires &gt; DM.',
+      irl:'Cours collectifs en salle, marchés bio le samedi, sorties d\'école 16h&nbsp;30.',
+      reco:'Anciennes clientes à 3 mois&nbsp;: «&nbsp;qui d\'autre devrait essayer ça&nbsp;?&nbsp;»'
+    },
+    flagsGreen:['Story sport régulière (3+ / sem.)','Bio « maman 2 enfants »','Avant/après visible','Compte actif (3+ posts/sem.)','Hashtags famille + forme'],
+    flagsRed:['Compte privé, 0 interaction','Bio « ne vend rien »','Posts politiques uniquement','Créé il y a < 1 mois','> 50k followers (saturé)']
+  },
+  { code:'INTL', flag:'🇬🇧', name:'International', sub:'en', lang:'EN',
+    hashtags:{
+      mainstream:['#weightloss','#fitmom','#transformation2026'],
+      niche:['#morningroutine','#proteinbreakfast','#busymom'],
+      cross:['#strengthtraining','#mealprep','#cleaneating']
+    },
+    sources:{
+      fb:'Groups <em>« Fit moms over 40 »</em>, <em>« Marathon training UK »</em>. Comments &gt; DMs.',
+      irl:'Gym group classes, weekend farmer markets, school pickup 3-4pm.',
+      reco:'3-month clients: «&nbsp;who else should try this?&nbsp;»'
+    },
+    flagsGreen:['Posts sport réguliers','Bio « mom of 2 » / « entrepreneur »','Before/after visible','Active account (3+ posts/wk)','Hashtags forme + famille'],
+    flagsRed:['Private account, 0 interaction','Bio « doesn\'t sell »','Politics-only feed','Account < 1 month old','> 50k followers (saturated)']
+  },
+  { code:'LATAM', flag:'🇲🇽', name:'LatAm + Espagne', sub:'es', lang:'ES',
+    hashtags:{
+      mainstream:['#perderpeso','#mamáfit','#bajardepeso2026'],
+      niche:['#rutinamañana','#desayunosaludable','#mamáocupada'],
+      cross:['#yogamatutino','#mealprep','#vidasana']
+    },
+    sources:{
+      fb:'Grupos <em>« Mamás emprendedoras CDMX »</em>, <em>« Reto 21 días »</em>. Comentarios &gt; DM.',
+      irl:'Clases colectivas, mercados bio el sábado, salida del cole 14-16h.',
+      reco:'Clientas a 3 meses: «&nbsp;¿quién más debería probar esto?&nbsp;»'
+    },
+    flagsGreen:['Stories deportivas 3+/sem.','Bio « mamá » / « emprendedora »','Antes/después visible','Cuenta activa (3+ posts/sem.)','Hashtags familia + forma'],
+    flagsRed:['Cuenta privada, 0 interacción','Bio « no vendo nada »','Solo política','Creada hace < 1 mes','> 50k followers (saturado)']
+  },
+  { code:'BR', flag:'🇧🇷', name:'Brésil + Portugal', sub:'pt-BR', lang:'PT',
+    hashtags:{
+      mainstream:['#emagrecer','#mamãefit','#projetoverão'],
+      niche:['#rotinamatinal','#caféproteico','#mãeempresária'],
+      cross:['#yogamatinal','#mealprep','#vidasaudável']
+    },
+    sources:{
+      fb:'Grupos <em>« Mães empresárias SP »</em>, <em>« Reto 21 dias »</em>. Comentários &gt; DM.',
+      irl:'Aulas coletivas, feiras orgânicas sábado, saída de escola 16h30.',
+      reco:'Clientes 3 meses: «&nbsp;quem mais deveria experimentar isso?&nbsp;»'
+    },
+    flagsGreen:['Stories esportivos regulares','Bio « mãe » / « empresária »','Antes/depois visível','Conta ativa (3+ posts/sem.)','Hashtags família + forma'],
+    flagsRed:['Conta privada, 0 interação','Bio « não vendo nada »','Só política','Conta < 1 mês','> 50k followers (saturado)']
+  },
+  { code:'TR', flag:'🇹🇷', name:'Turquie + Allemagne', sub:'tr / de', lang:'TR',
+    hashtags:{
+      mainstream:['#kiloverme','#fitanne','#yazprojesi'],
+      niche:['#sabahrutini','#proteinkahvalti','#meşgulanne'],
+      cross:['#yoga','#mealprep','#sağlıklıyaşam']
+    },
+    sources:{
+      fb:'Gruplar <em>« İstanbul fit anneler »</em>, <em>« 21 gün challenge »</em>. Yorumlar &gt; DM.',
+      irl:'Grup dersleri, organik pazar cumartesi, okul çıkışı 15-17h.',
+      reco:'3 aylık müşteriler: «&nbsp;başka kim denemeli?&nbsp;»'
+    },
+    flagsGreen:['Düzenli spor story','Bio « anne » / « girişimci »','Öncesi/sonrası görünür','Aktif hesap (3+ post/hafta)','Aile + spor etiketleri'],
+    flagsRed:['Gizli hesap, 0 etkileşim','Bio « satış yapmıyorum »','Sadece siyaset','Hesap < 1 ay','> 50k takipçi (doymuş)']
+  },
+  { code:'IN', flag:'🇮🇳', name:'Inde', sub:'hi / en', lang:'HI',
+    hashtags:{
+      mainstream:['#weightlossindia','#fitmomindia','#summerproject'],
+      niche:['#morningroutine','#proteinbreakfast','#workingmom'],
+      cross:['#yoga','#cleaneating','#healthyliving']
+    },
+    sources:{
+      fb:'Groups <em>« Indian working moms »</em>, <em>« 21-day reset »</em>. Comments &gt; DMs.',
+      irl:'Yoga classes, weekend organic markets, school pickup 3-4pm.',
+      reco:'3-month clients: «&nbsp;कौन और कोशिश करना चाहिए?&nbsp;» / «&nbsp;who else should try?&nbsp;»'
+    },
+    flagsGreen:['Regular fitness stories','Bio « mom » / « entrepreneur »','Before/after visible','Active account (3+ posts/wk)','Family + fitness tags'],
+    flagsRed:['Private account, 0 interaction','Bio « doesn\'t sell »','Politics-only','Account < 1 month','> 50k followers']
+  }
+];
+
+window.PROFILES = [
+  { code:'WF', glyph:'⚖️', name:'Perte de poids · F', short:'PdP F', accent:'gold',
+    persona:'Maman 32-45 ans, énergie en baisse, veut reprendre le contrôle.' },
+  { code:'WM', glyph:'💪', name:'Perte de poids · H', short:'PdP H', accent:'gold',
+    persona:'Homme 35-50 ans, ventre tenace, peu de temps pour cuisiner.' },
+  { code:'SP', glyph:'🏃', name:'Sportif', short:'Sport', accent:'teal',
+    persona:'Pratique régulière, cherche performance / récupération / clean nutrition.' },
+  { code:'BZ', glyph:'💼', name:'Business', short:'Biz', accent:'purple',
+    persona:'Entrepreneur·e, veut compléter ses revenus via la distribution.' }
+];
+
+window.MODULES = [
+  { ic:'🧠', name:'Mindset', sub:'& posture',
+    kicker:'Module · Mindset & posture',
+    h2:['D\'abord, ','le ton','.'],
+    lede:'Trois vérités à intégrer avant le premier message. Cinq erreurs qui sabotent 80% des conversations.',
+    meta:'≈&nbsp;4&nbsp;min · lu <b style="color:var(--ls-charcoal)">2×</b> cette&nbsp;sem.' },
+
+  { ic:'🔍', name:'Trouver', sub:'les prospects',
+    kicker:'Module · Trouver des prospects',
+    h2:['Le scan ','30 secondes','.'],
+    lede:'Tu ouvres un profil&nbsp;: en 30&nbsp;s tu sais si tu lui écris. Drapeaux, hashtags, sources hors-feed.',
+    meta:'Scan&nbsp;<b style="color:var(--ls-charcoal)">30&nbsp;s</b>&nbsp;·&nbsp;3 sources alt.' },
+
+  { ic:'📨', name:'Messages M1', sub:'premier contact',
+    kicker:'Module · Premier contact',
+    h2:['Messages ','M1','.'],
+    lede:'Sélectionne ta plateforme. Personnalise les variables en gold avant de copier.',
+    meta:'<b style="color:var(--ls-charcoal)">4</b> plateformes · trad.&nbsp;FR&nbsp;dispo.' },
+
+  { ic:'🌳', name:'Arbres M2/M3', sub:'réponses selon réaction',
+    kicker:'Module · Arbres M2/M3',
+    h2:['Que répondre, ','selon ce qu\'il dit','.'],
+    lede:'3 branches&nbsp;: tiède, froid, indécis. Une réponse par branche, prête à copier.',
+    meta:'<b style="color:var(--ls-charcoal)">3</b> branches · <b style="color:var(--ls-charcoal)">9</b> réponses' },
+
+  { ic:'🛡️', name:'Objections', sub:'les 8 non',
+    kicker:'Module · Réponses aux refus',
+    h2:['Les huit ','non','.'],
+    lede:'Pour chaque objection&nbsp;: ce qu\'il ne faut pas dire, ce qui ouvre la porte.',
+    meta:'<b style="color:var(--ls-charcoal)">8</b> objections types' },
+
+  { ic:'📞', name:'Post-appel', sub:'séquence de relance',
+    kicker:'Module · Séquence post-appel',
+    h2:['Après l\'appel, ','quatre touches','.'],
+    lede:'J0&nbsp;– J+2 – J+5 – J+30. Une touche par jour, jamais une de plus.',
+    meta:'<b style="color:var(--ls-charcoal)">4</b> touches · <b style="color:var(--ls-charcoal)">30</b> jours' },
+
+  { ic:'🎯', name:'Closing', sub:'signaux + scripts',
+    kicker:'Module · Closing',
+    h2:['Quand fermer, ','et comment','.'],
+    lede:'5 signaux qui montrent que c\'est mûr, 3 scripts pour passer à l\'acte.',
+    meta:'<b style="color:var(--ls-charcoal)">5</b> signaux · <b style="color:var(--ls-charcoal)">3</b> scripts' },
+
+  { ic:'🔁', name:'Cas spéciaux', sub:'ghost · réactivation · reco',
+    kicker:'Module · Cas spéciaux',
+    h2:['Quand ça ','sort des rails','.'],
+    lede:'Ghosting, réactivation après mois, demande de recommandation. Trois playbooks distincts.',
+    meta:'<b style="color:var(--ls-charcoal)">3</b> playbooks' },
+
+  { ic:'📖', name:'Storytelling', sub:'structure + exemples',
+    kicker:'Module · Storytelling',
+    h2:['Raconte ton ','avant','.'],
+    lede:'La structure en 3 actes qui marche à tous les coups. Deux exemples vivants.',
+    meta:'<b style="color:var(--ls-charcoal)">3</b> actes · <b style="color:var(--ls-charcoal)">2</b> exemples' },
+
+  { ic:'⏰', name:'Routine', sub:'30 min / jour',
+    kicker:'Module · Routine quotidienne',
+    h2:['Trente minutes, ','tous les jours','.'],
+    lede:'7 actions à cocher chaque matin. Sans elles, le reste s\'effondre.',
+    meta:'<b style="color:var(--ls-charcoal)">30&nbsp;min</b> · <b style="color:var(--ls-charcoal)">7</b> actions' }
+];
+
+/* ────────────────────────────────────────────────────────────
+   SCRIPTS M1 — par marché × plateforme
+   Chaque entrée : { script: '...HTML...', trad: '...HTML FR...', stat:'42%', n:19 }
+   Pour les marchés que je ne localise pas en détail je tombe sur EN.
+   ──────────────────────────────────────────────────────────── */
+
+const VAR = (s) => `<span class="var">${s}</span>`;
+const VARt = (s) => `<span class="var teal">${s}</span>`;
+
+window.M1_SCRIPTS = {
+  FR: {
+    insta: { ctx:'prospect a regardé ta story 2× cette semaine', stat:'48%', n:24,
+      script:`<p>Hey ${VAR('[prénom]')} ! J'ai vu que tu suivais ${VARt('[compte fitness]')} — tu bosses sur quoi côté forme en ce moment ?</p>`,
+      trad:`<i>(message déjà en français — pas de traduction nécessaire)</i>` },
+    fb: { ctx:'au moins 1 ami commun', stat:'31%', n:13,
+      script:`<p>Salut ${VAR('[prénom]')}, on a ${VARt('[ami commun]')} en commun. Je bosse avec des gens qui veulent retrouver de l'énergie le matin — ça te parle de là où tu en es ?</p>`,
+      trad:`` },
+    wa: { ctx:'contact tiède, > 6 mois sans nouvelles', stat:'62%', n:9,
+      script:`<p>Coucou ${VAR('[prénom]')} ! Ça fait un bail. Je voulais te demander un truc rapide — t'es ouvert·e à découvrir ce qui m'a aidé à ${VARt('[résultat concret]')} sans frustration ?</p>`,
+      trad:`` },
+    sms: { ctx:'cold mais chaleureux, rencontré IRL', stat:'24%', n:8,
+      script:`<p>Hey ${VAR('[prénom]')}, c'est ${VARt('[moi]')}. On s'était croisé·e·s à ${VARt('[contexte]')}. J'ai un petit truc à te partager si t'es chaud·e — tu me dis ?</p>`,
+      trad:`` },
+  },
+  INTL: {
+    insta: { ctx:'prospect viewed your story 2× this week', stat:'42%', n:19,
+      script:`<p>Hey ${VAR('[first name]')}! Saw you've been following ${VARt('[fitness account]')} — what are you working on right now on the training side?</p>`,
+      trad:`Hey ${VAR('[prénom]')} ! J'ai vu que tu suivais ${VARt('[compte fitness]')} — tu bosses sur quoi côté entraînement en ce moment ?` },
+    fb: { ctx:'at least 1 mutual friend', stat:'28%', n:11,
+      script:`<p>Hey ${VAR('[first name]')}, I noticed we both know ${VARt('[mutual friend]')}. I work with athletes who want consistent morning energy without crashing at 3pm — does that resonate?</p>`,
+      trad:`Salut ${VAR('[prénom]')} ! J'ai vu qu'on avait ${VARt('[ami commun]')} en commun. Je bosse avec des sportifs qui veulent une énergie stable sans baisse à 15h — ça te parle ?` },
+    wa: { ctx:'warm contact, > 6 months silent', stat:'55%', n:7,
+      script:`<p>Hey ${VAR('[first name]')}! Long time. Quick question — would you be open to hearing what's helped me ${VARt('[concrete result]')} without burning out?</p>`,
+      trad:`Hey ${VAR('[prénom]')} ! Ça fait un bail. Question rapide — t'es ouvert·e à entendre ce qui m'a aidé à ${VARt('[résultat]')} sans m'épuiser ?` },
+    sms: { ctx:'cold but warm, met in person', stat:'19%', n:6,
+      script:`<p>Hey ${VAR('[first name]')}, it's ${VARt('[me]')} — we met at ${VARt('[context]')}. Got something small to share if you're curious. Let me know?</p>`,
+      trad:`Hey ${VAR('[prénom]')}, c'est ${VARt('[moi]')}. On s'est croisé·e·s à ${VARt('[contexte]')}. J'ai un truc à te partager si curieux·se. Tu me dis ?` },
+  },
+  LATAM: {
+    insta: { ctx:'vio tu story 2× esta semana', stat:'46%', n:21,
+      script:`<p>Hola ${VAR('[nombre]')}! Vi que sigues ${VARt('[cuenta fitness]')} — ¿en qué estás trabajando ahora del lado de tu forma física?</p>`,
+      trad:`Salut ${VAR('[prénom]')} ! J'ai vu que tu suis ${VARt('[compte fitness]')} — sur quoi tu bosses côté forme en ce moment ?` },
+    fb: { ctx:'al menos 1 amigo en común', stat:'33%', n:14,
+      script:`<p>Hola ${VAR('[nombre]')}, vi que tenemos a ${VARt('[amigo común]')} en común. Trabajo con mamás que quieren energía constante en la mañana — ¿te resuena?</p>`,
+      trad:`Salut ${VAR('[prénom]')}, on a ${VARt('[ami commun]')} en commun. Je bosse avec des mamans qui veulent une énergie stable le matin — ça te parle ?` },
+    wa: { ctx:'contacto tibio, > 6 meses sin hablar', stat:'58%', n:8,
+      script:`<p>¡Hola ${VAR('[nombre]')}! Mucho tiempo. Pregunta rápida — ¿estarías abierta a oír lo que me ayudó a ${VARt('[resultado concreto]')} sin sufrir?</p>`,
+      trad:`Salut ${VAR('[prénom]')} ! Ça fait un bail. Question rapide — t'es ouverte à entendre ce qui m'a aidée à ${VARt('[résultat]')} sans souffrir ?` },
+    sms: { ctx:'frío pero cálido, conocido IRL', stat:'21%', n:7,
+      script:`<p>Hola ${VAR('[nombre]')}, soy ${VARt('[yo]')}. Nos vimos en ${VARt('[contexto]')}. Tengo algo chiquito que compartirte si te animas. ¿Me dices?</p>`,
+      trad:`Hola ${VAR('[prénom]')}, c'est ${VARt('[moi]')}. On s'est vus à ${VARt('[contexte]')}. J'ai un petit truc à te partager si ça te tente. Tu me dis ?` },
+  },
+  BR: {
+    insta: { ctx:'viu seu story 2× esta semana', stat:'44%', n:19,
+      script:`<p>Oi ${VAR('[nome]')}! Vi que segue ${VARt('[conta fitness]')} — em que está focando agora no lado da forma física?</p>`,
+      trad:`Salut ${VAR('[prénom]')} ! J'ai vu que tu suivais ${VARt('[compte fitness]')} — sur quoi tu te concentres côté forme ?` },
+    fb: { ctx:'pelo menos 1 amigo em comum', stat:'30%', n:12,
+      script:`<p>Oi ${VAR('[nome]')}, vi que temos ${VARt('[amigo comum]')} em comum. Trabalho com mães que querem energia estável de manhã — faz sentido pra você?</p>`,
+      trad:`Salut ${VAR('[prénom]')}, on a ${VARt('[ami commun]')} en commun. Je bosse avec des mamans qui veulent une énergie stable le matin — ça te parle ?` },
+    wa: { ctx:'contato morno, > 6 meses sem falar', stat:'56%', n:8,
+      script:`<p>Oi ${VAR('[nome]')}! Faz tempo. Pergunta rápida — você toparia ouvir o que me ajudou a ${VARt('[resultado concreto]')} sem sofrer?</p>`,
+      trad:`Salut ${VAR('[prénom]')} ! Ça fait un bail. Question rapide — t'es ouvert·e à entendre ce qui m'a aidé à ${VARt('[résultat]')} sans souffrir ?` },
+    sms: { ctx:'frio mas caloroso, conhecido IRL', stat:'20%', n:6,
+      script:`<p>Oi ${VAR('[nome]')}, é ${VARt('[eu]')}. A gente se viu em ${VARt('[contexto]')}. Tenho uma coisinha pra compartilhar se topar. Me diz?</p>`,
+      trad:`Hey ${VAR('[prénom]')}, c'est ${VARt('[moi]')}. On s'est vu à ${VARt('[contexte]')}. J'ai un petit truc à partager si tu veux. Tu me dis ?` },
+  },
+  TR: {
+    insta: { ctx:'story\'ni 2× izledi bu hafta', stat:'40%', n:16,
+      script:`<p>Selam ${VAR('[isim]')}! ${VARt('[fitness hesabını]')} takip ettiğini gördüm — şu an formuna dair neye odaklanıyorsun?</p>`,
+      trad:`Salut ${VAR('[prénom]')} ! J'ai vu que tu suivais ${VARt('[compte fitness]')} — sur quoi tu te concentres côté forme ?` },
+    fb: { ctx:'en az 1 ortak arkadaş', stat:'27%', n:10,
+      script:`<p>Merhaba ${VAR('[isim]')}, ${VARt('[ortak arkadaş]')}'la ortak olduğumuzu fark ettim. Sabah enerji isteyen annelerle çalışıyorum — sana hitap ediyor mu?</p>`,
+      trad:`Salut ${VAR('[prénom]')}, on a ${VARt('[ami commun]')} en commun. Je bosse avec des mamans qui veulent de l'énergie le matin — ça te parle ?` },
+    wa: { ctx:'ılık temas, 6 aydır sessiz', stat:'52%', n:7,
+      script:`<p>Selam ${VAR('[isim]')}! Uzun zaman oldu. Hızlı bir soru — ${VARt('[somut sonuç]')} elde etmeme yardım eden şeyi duymaya açık mısın?</p>`,
+      trad:`Salut ${VAR('[prénom]')} ! Ça fait un bail. Question rapide — t'es ouvert·e à entendre ce qui m'a aidé à ${VARt('[résultat]')} ?` },
+    sms: { ctx:'soğuk ama samimi, IRL tanıştık', stat:'18%', n:5,
+      script:`<p>Selam ${VAR('[isim]')}, ben ${VARt('[ben]')}. ${VARt('[bağlam]')}'da karşılaştık. Paylaşmak istediğim küçük bir şey var. Söyle?</p>`,
+      trad:`Hey ${VAR('[prénom]')}, c'est ${VARt('[moi]')}. On s'est rencontrés à ${VARt('[contexte]')}. J'ai un petit truc à partager. Tu me dis ?` },
+  },
+  IN: {
+    insta: { ctx:'viewed your story 2× this week', stat:'38%', n:14,
+      script:`<p>Hi ${VAR('[first name]')}! Noticed you follow ${VARt('[fitness account]')} — what are you focusing on right now health-wise?</p>`,
+      trad:`Salut ${VAR('[prénom]')} ! J'ai vu que tu suis ${VARt('[compte fitness]')} — sur quoi tu te concentres côté santé ?` },
+    fb: { ctx:'at least 1 mutual friend', stat:'25%', n:9,
+      script:`<p>Hi ${VAR('[first name]')}, I see we both know ${VARt('[mutual friend]')}. I work with working moms who want stable morning energy — does that resonate?</p>`,
+      trad:`Salut ${VAR('[prénom]')}, on a ${VARt('[ami commun]')} en commun. Je bosse avec des mamans qui veulent une énergie stable le matin — ça te parle ?` },
+    wa: { ctx:'warm contact, > 6 months silent', stat:'50%', n:6,
+      script:`<p>Hi ${VAR('[first name]')}! Long time. Quick one — would you be open to hearing what helped me ${VARt('[concrete result]')} without burning out?</p>`,
+      trad:`Salut ${VAR('[prénom]')} ! Ça fait un bail. Question rapide — t'es ouvert·e à entendre ce qui m'a aidé à ${VARt('[résultat]')} ?` },
+    sms: { ctx:'cold but warm, met IRL', stat:'17%', n:4,
+      script:`<p>Hi ${VAR('[first name]')}, ${VARt('[me]')} here — we met at ${VARt('[context]')}. Small thing to share if you're curious. Let me know?</p>`,
+      trad:`Hey ${VAR('[prénom]')}, c'est ${VARt('[moi]')}. On s'est rencontrés à ${VARt('[contexte]')}. J'ai un petit truc à partager. Tu me dis ?` },
+  }
+};
+
+window.PLATFORMS = [
+  { code:'insta', ic:'📷', name:'Instagram', sub:'DM après story',
+    glyphStyle:'' },
+  { code:'fb',    ic:'f',  name:'Facebook',  sub:'Messenger · via ami',
+    glyphStyle:'background:#1877F210;border-color:#1877F230;color:#1877F2;font-weight:700' },
+  { code:'wa',    ic:'💬', name:'WhatsApp',  sub:'contact tiède',
+    glyphStyle:'background:#25D36610;border-color:#25D36630' },
+  { code:'sms',   ic:'✉',  name:'SMS',       sub:'cold après IRL',
+    glyphStyle:'' }
+];
+
+/* ────────────────────────────────────────────────────────────
+   OBJECTIONS (8) — texte FR de base
+   ──────────────────────────────────────────────────────────── */
+window.OBJECTIONS = [
+  { tag:'budget',  quote:"Je n'ai pas le budget pour ça.",
+    bad:'« Mais c\'est pas cher du tout en fait ! »',
+    good:`« Je comprends. C'est quoi le budget que tu te fixes pour ${VAR('[forme / objectif]')} chaque mois en ce moment ? »`,
+    variants:3 },
+  { tag:'échec passé', quote:"J'connais quelqu'un, ça n'a pas marché pour lui.",
+    bad:'« Bah il s\'est mal pris alors. »',
+    good:'« Intéressant. Tu sais ce qu\'il a fait exactement ? Souvent c\'est un petit détail qui change tout — je te raconte ? »',
+    variants:2 },
+  { tag:'secte', quote:"C'est une secte ton truc, non ?",
+    bad:'« Mais pas du tout, comment tu peux dire ça ?! »',
+    good:'« T\'inquiète, j\'étais sceptique aussi. C\'est juste un programme nutrition. Je t\'explique en 2 minutes ? »',
+    variants:3 },
+  { tag:'pas le temps', quote:"J'ai pas le temps pour ça.",
+    bad:'« Si si t\'as le temps, tu vas voir. »',
+    good:'« C\'est exactement pour ça que c\'est fait — 3 minutes le matin. T\'as 3 minutes maintenant pour que je te montre ? »',
+    variants:2 },
+  { tag:'mari · femme', quote:"Je veux en parler à mon mari d'abord.",
+    bad:'« Tu vois ton mari quand ? »',
+    good:`« Bien sûr. Tu veux que je te prépare les infos précises pour qu'il puisse juger en connaissance de cause ? ${VAR('[2-3 questions]')} et je te fais un récap'. »`,
+    variants:2 },
+  { tag:'envoie infos', quote:"Tu peux m'envoyer les infos par écrit ?",
+    bad:'(envoyer un gros PDF directement)',
+    good:'« Carrément. Avant que je t\'envoie ça — dis-moi en une phrase ton objectif principal, comme ça je t\'envoie pile ce qui t\'intéresse, pas un pavé. »',
+    variants:2 },
+  { tag:'préfère sport', quote:"Moi je préfère faire du sport.",
+    bad:'« Le sport seul c\'est pas suffisant. »',
+    good:'« Top, j\'adore. Le sport représente 30% du résultat, l\'assiette 70%. Tu veux que je te montre ce qu\'on fait sur les 70% ? »',
+    variants:3 },
+  { tag:'je réfléchis', quote:"Je vais y réfléchir.",
+    bad:'« OK, tu me dis quand. »',
+    good:'« Bien sûr. Tu réfléchis sur quoi exactement — le programme, le prix, le timing ? Je t\'aide à clarifier en 2 min. »',
+    variants:2 }
+];
+
+/* ARBRES M2/M3 */
+window.TREES = [
+  { reaction:'warm', label:'Tiède', emoji:'🔥',
+    they:'Ouais carrément, raconte-moi !',
+    you:`Cool. Quick context — je fais du coaching nutrition depuis ${VAR('[X mois/ans]')}. La meilleure manière de voir si ça matche c'est qu'on prenne 20 min pour creuser ton objectif. T'es dispo ${VAR('[jour]')} ou ${VAR('[jour]')} en visio ?`,
+    variants:3 },
+  { reaction:'cold', label:'Froid', emoji:'❄️',
+    they:'Non merci, je gère, je vais pas être client·e.',
+    you:`Pas de souci ${VAR('[prénom]')}, je comprends. Pour info je travaille aussi avec des gens qui veulent compléter leurs revenus en parallèle — c'est pas ton kif, ou je te fais signe si je vois un truc qui pourrait t'aider ?`,
+    variants:2 },
+  { reaction:'maybe', label:'Indécis', emoji:'🤔',
+    they:'Hum, peut-être, je sais pas trop là.',
+    you:`Ouais je sens que c'est pas évident. Dis-moi — c'est plus l'idée du programme qui te bloque, ou le moment où je t'écris est pas bon ? Je veux pas te forcer la main, juste comprendre.`,
+    variants:3 }
+];
+
+/* POST-APPEL */
+window.POSTCALL = [
+  { when:'J0 · juste après appel', title:'Récap chaud',
+    state:'now',
+    msg:`Merci pour notre échange ${VAR('[prénom]')} ! Petit récap : on a vu ${VARt('[problème principal]')} et l'idée d'attaquer par ${VARt('[solution proposée]')}. Je te file les 2 docs promis ce soir. À très vite !` },
+  { when:'J+2', title:'Question ouverte',
+    msg:`Salut ${VAR('[prénom]')}, j'y repensais après notre call — t'as eu le temps de regarder ${VARt('[doc envoyé]')} ? Quelle question t'est venue en premier ?` },
+  { when:'J+5', title:'Témoignage similaire',
+    state:'future',
+    msg:`${VAR('[prénom]')}, je te partage un témoignage rapide d'une cliente qui avait exactement ton profil ${VARt('[contexte]')} — résultat à 3 mois. Si tu veux qu'on se reparle, je t'envoie 2 créneaux ?` },
+  { when:'J+30', title:'Pas de pression',
+    state:'future',
+    msg:`Hey ${VAR('[prénom]')} ! Je ferme la boucle de mon côté — pas de pression. Si jamais ${VARt('[objectif initial]')} revient sur ta liste, ma porte reste ouverte. Belle suite !` }
+];
+
+/* CLOSING */
+window.CLOSING = {
+  signals:[
+    'Pose des questions sur le prix ou les modalités',
+    'Demande « ça commence quand ? »',
+    'Évoque une date / un événement où il/elle veut être prêt·e',
+    'Pose des questions sur les autres clients',
+    'Répète tes mots en disant « ouais, c\'est ça que je veux »'
+  ],
+  scripts:[
+    { name:'Le récap·décision', ctx:'fin d\'appel · prospect mûr',
+      body:`«&nbsp;Alors ${VAR('[prénom]')}, on a vu que tu voulais ${VARt('[résultat]')} et que ce qui te bloque c'est ${VARt('[obstacle]')}. Ce programme adresse pile ça. Tu veux qu'on cale le démarrage la semaine prochaine ou tu préfères dans deux semaines ?&nbsp;»` },
+    { name:'Le choix binaire', ctx:'évite le « oui/non »',
+      body:`«&nbsp;Pour démarrer, tu préfères le pack ${VARt('[A]')} à ${VARt('[X€]')} ou le pack ${VARt('[B]')} à ${VARt('[Y€]')} ? Les deux fonctionnent pour ton objectif, c'est juste une question de rythme.&nbsp;»` },
+    { name:'L\'assumed close', ctx:'prospect très chaud',
+      body:`«&nbsp;Parfait. Je te crée ton compte ce soir, tu reçois tes accès demain matin ${VARt('[heure]')}, et on cale notre premier point ${VARt('[jour]')} ?&nbsp;»` }
+  ]
+};
+
+/* CAS SPÉCIAUX */
+window.SPECIAL = {
+  ghost:{
+    title:'Ghosting · pas de réponse depuis 5+ jours',
+    body:`Salut ${VAR('[prénom]')} ! Je voulais pas te lâcher comme ça — soit le timing est pas bon, soit le sujet t'intéresse pas, soit j'ai mal expliqué. Dis-moi juste lequel des trois et je m'adapte (ou je te laisse tranquille, promis 🙂).`,
+    tips:['1 seule relance, pas 2','Donne 3 options claires (timing, sujet, explication)','Mets une porte de sortie polie']
+  },
+  reactivation:{
+    title:'Réactivation · client·e parti·e il y a 6+ mois',
+    body:`Hey ${VAR('[prénom]')} ! Ça fait un moment. Je ferai pas le coup du « ça serait bien de reprendre » — je voulais juste te demander : qu'est-ce qui t'a fait arrêter à l'époque ? J'ai changé pas mal de choses depuis, et je serais curieux·se d'entendre ton retour.`,
+    tips:['Demande pourquoi avant de proposer','Montre ce qui a changé','Pas de promo immédiate']
+  },
+  reco:{
+    title:'Demande de recommandation',
+    body:`${VAR('[prénom]')}, je voulais te demander un petit truc — depuis qu'on bosse ensemble t'as ${VARt('[résultat concret]')}. Qui dans ton entourage proche pourrait avoir besoin de ce qu'on a fait ensemble ? Je te demande pas de pitcher, juste 1 ou 2 prénoms et je m'en occupe.`,
+    tips:['Attendre un résultat concret','Demande 1-2 prénoms, pas une liste','Tu pitches pas, tu prends le relais']
+  }
+};
+
+/* STORYTELLING */
+window.STORY = {
+  acts:[
+    {step:'Acte I',title:'Avant',body:'Le problème vécu, le quotidien d\'avant.'},
+    {step:'Acte II',title:'Le déclic',body:'L\'événement, la rencontre, le ras-le-bol.', gold:true},
+    {step:'Acte III',title:'Après',body:'La transformation, en chiffres et en ressenti.'}
+  ],
+  examples:[
+    { by:'Marie · maman 38 ans · Lyon',
+      body:`<p><em>Avant&nbsp;:</em> je me levais à 6h en étant déjà fatiguée. Café sur café, et à 16h je m'écroulais. J'étais devenue irritable avec mes enfants — je m'en voulais.</p><p><em>Déclic&nbsp;:</em> ma sœur m'a montré ce qu'elle faisait depuis 3 mois. Pas un mot sur le « produit », elle m'a juste raconté sa routine du matin.</p><p><em>Après&nbsp;:</em> 8 mois plus tard, -9 kg, je dors comme un bébé, et je suis devenue celle qui partage. C'est elle qui m'avait sauvée.</p>` },
+    { by:'Karim · entrepreneur · 42 ans',
+      body:`<p><em>Avant&nbsp;:</em> 14h de boulot par jour, ventre tendu, je mangeais devant l'écran sans goûter.</p><p><em>Déclic&nbsp;:</em> un client a refusé un meeting parce que j'avais l'air « épuisé ». J'ai compris que ça impactait mon business.</p><p><em>Après&nbsp;:</em> 4 mois, -7 kg, et surtout 2h d'énergie en plus chaque jour. Mes deals se signent mieux.</p>` }
+  ]
+};
+
+/* ROUTINE */
+window.ROUTINE = [
+  { mins:'5 min', txt:'Bilan rapide hier&nbsp;: combien de M1 envoyés ? Combien de réponses ?' },
+  { mins:'5 min', txt:'Identifier <b>5 nouveaux prospects</b> (scan 30s par profil)' },
+  { mins:'8 min', txt:'Envoyer les <b>5 messages M1</b> personnalisés avec [prénom]' },
+  { mins:'5 min', txt:'Relancer <b>2-3 conversations</b> en cours · M2 / M3' },
+  { mins:'3 min', txt:'Répondre aux objections du jour si arrivées' },
+  { mins:'2 min', txt:'Logger ce qui a marché aujourd\'hui · 1 phrase' },
+  { mins:'2 min', txt:'Poster <b>1 story</b> en lien avec ton avant→après' }
+];

--- a/docs/mockups/prospection-v4-prototype-v3.html
+++ b/docs/mockups/prospection-v4-prototype-v3.html
@@ -1,0 +1,1528 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Prospection · La Base 360 — Prototype</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Syne:wght@500;600;700;800&family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+<style>
+:root{
+  --ls-gold:#C9A84C;
+  --ls-gold-light:#E5C97D;
+  --ls-gold-dark:#8E7430;
+  --ls-teal:#2DD4BF;
+  --ls-teal-dark:#0F766E;
+  --ls-coral:#FB7185;
+  --ls-coral-dark:#BE3242;
+  --ls-purple:#7C3AED;
+  --ls-charcoal:#0B0D11;
+  --ls-cream:#FBF7F0;
+  --ls-surface:#FFFFFF;
+  --ls-surface2:#F7F3EC;
+  --ls-line:rgba(11,13,17,.08);
+  --ls-line-2:rgba(11,13,17,.14);
+  --ls-muted:rgba(11,13,17,.56);
+  --ls-muted-2:rgba(11,13,17,.40);
+  --f-display:"Syne", "Times New Roman", serif;
+  --f-body:"DM Sans", system-ui, sans-serif;
+  --f-mono:"JetBrains Mono", ui-monospace, Menlo, monospace;
+  --phone-scale:1;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;height:100%}
+body{
+  font-family:var(--f-body);
+  background:#EFE9DC;
+  color:var(--ls-charcoal);
+  -webkit-font-smoothing:antialiased;
+  text-rendering:optimizeLegibility;
+  overflow:hidden;
+}
+
+.stage{
+  position:fixed;inset:0;
+  display:grid;
+  grid-template-columns:1fr auto 1fr;
+  grid-template-areas:"left phone right";
+  align-items:center;
+  padding:18px;
+  gap:24px;
+  background:
+    radial-gradient(circle at 20% 10%, rgba(201,168,76,.10), transparent 50%),
+    radial-gradient(circle at 90% 90%, rgba(45,212,191,.08), transparent 50%),
+    #EFE9DC;
+}
+.stage-aside{
+  grid-area:left;
+  min-width:0;max-width:280px;
+  font-family:var(--f-mono);
+  font-size:11px;line-height:1.7;
+  color:var(--ls-muted);
+  justify-self:end;align-self:start;
+  padding-top:32px;
+}
+.stage-aside.right{grid-area:right;justify-self:start;padding-top:32px}
+.stage-aside h6{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--ls-gold-dark);margin:0 0 8px;
+}
+.stage-aside .brand-mark{
+  font-family:var(--f-display);font-weight:700;font-size:15px;letter-spacing:-.01em;
+  color:var(--ls-charcoal);text-transform:none;margin-bottom:14px;display:flex;align-items:center;gap:8px;
+}
+.stage-aside .brand-mark .gem{
+  width:14px;height:14px;border-radius:4px;
+  background:linear-gradient(135deg,var(--ls-gold),#fff5d0);
+  box-shadow:0 0 0 1px rgba(142,116,48,.4) inset;
+}
+.stage-aside kbd{
+  font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);
+  background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;padding:1px 6px;
+}
+.stage-aside .hint-row{display:flex;gap:6px;align-items:center;margin:3px 0}
+.stage-aside .hint-row span:last-child{flex:1;text-transform:none}
+.stage-aside b{color:var(--ls-charcoal);font-weight:600}
+.stage-aside .live{
+  display:inline-flex;align-items:center;gap:6px;
+  font-family:var(--f-body);font-size:12px;color:var(--ls-charcoal);font-weight:500;
+}
+.stage-aside .live::before{
+  content:"";width:6px;height:6px;border-radius:50%;background:var(--ls-teal);
+  box-shadow:0 0 0 3px rgba(45,212,191,.18);
+}
+
+.phone-wrap{
+  grid-area:phone;
+  transform:scale(var(--phone-scale));
+  transform-origin:center center;
+  transition:transform .25s;
+}
+.phone{
+  position:relative;
+  width:413px;height:850px;
+  background:#0B0D11;
+  border-radius:54px;
+  padding:10px;
+  box-shadow:
+    0 0 0 2px rgba(255,255,255,.06) inset,
+    0 30px 60px -20px rgba(11,13,17,.35),
+    0 60px 120px -40px rgba(11,13,17,.25);
+}
+.phone .screen{
+  position:relative;
+  width:100%;height:100%;
+  border-radius:44px;
+  overflow:hidden;
+  background:var(--ls-cream);
+  display:flex;flex-direction:column;
+}
+.phone .notch{
+  position:absolute;top:14px;left:50%;transform:translateX(-50%);
+  width:104px;height:32px;background:#0B0D11;border-radius:20px;z-index:30;
+}
+.phone .home-indicator{
+  position:absolute;left:50%;bottom:8px;transform:translateX(-50%);
+  width:130px;height:5px;border-radius:3px;background:rgba(11,13,17,.85);z-index:30;
+}
+
+/* status */
+.status{
+  flex:0 0 auto;height:54px;
+  display:flex;align-items:flex-end;justify-content:space-between;
+  padding:0 30px 8px;
+  font-family:var(--f-body);font-weight:600;font-size:15px;
+  background:var(--ls-cream);
+}
+.status .right{display:flex;gap:6px;align-items:center}
+
+/* header */
+.hdr{
+  flex:0 0 auto;
+  background:var(--ls-cream);
+  padding:6px 18px 12px;
+  border-bottom:1px solid var(--ls-line);
+  position:relative;z-index:5;
+}
+.hdr .row1{
+  display:flex;align-items:center;justify-content:space-between;gap:10px;
+  padding:4px 2px 8px;
+}
+.brand{
+  display:flex;align-items:center;gap:8px;
+  font-family:var(--f-display);font-weight:700;font-size:15px;letter-spacing:-.01em;
+}
+.brand .gem{
+  width:18px;height:18px;border-radius:5px;
+  background:linear-gradient(135deg,var(--ls-gold) 0%,var(--ls-gold-light) 60%, #fff7d6 100%);
+  box-shadow:0 0 0 1px rgba(142,116,48,.3) inset;position:relative;
+}
+.brand .gem::after{
+  content:"";position:absolute;inset:3px;border-radius:3px;
+  background:radial-gradient(circle at 30% 30%, rgba(255,255,255,.7), transparent 60%);
+}
+.brand small{
+  font-family:var(--f-mono);font-weight:400;font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--ls-muted);margin-left:4px;align-self:center;
+}
+.stat-chip{
+  display:flex;align-items:center;gap:7px;
+  padding:5px 10px 5px 8px;border-radius:99px;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  font-family:var(--f-mono);font-size:11px;cursor:pointer;
+  transition:background .15s, border-color .15s;
+}
+.stat-chip:hover{border-color:var(--ls-line-2);background:#fff}
+.stat-chip .dot-live{
+  width:6px;height:6px;border-radius:50%;background:var(--ls-teal);
+  box-shadow:0 0 0 3px rgba(45,212,191,.18);
+}
+.stat-chip b{font-weight:600;color:var(--ls-charcoal);transition:color .2s}
+.stat-chip b.bumped{color:var(--ls-gold-dark)}
+
+.pickers{display:flex;gap:8px;align-items:stretch}
+.picker{
+  flex:1;min-width:0;
+  display:flex;align-items:center;gap:8px;
+  padding:9px 10px 9px 12px;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  border-radius:12px;font-size:13px;font-weight:500;
+  cursor:pointer;
+  transition:background .15s, border-color .15s, box-shadow .15s;
+}
+.picker:hover{border-color:var(--ls-line-2)}
+.picker:active{transform:scale(.985)}
+.picker.opening{border-color:var(--ls-gold);box-shadow:0 0 0 3px rgba(201,168,76,.15)}
+.picker .lbl{
+  font-family:var(--f-mono);font-size:9px;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--ls-muted);display:block;
+}
+.picker .val{
+  font-family:var(--f-body);font-weight:600;font-size:13.5px;
+  color:var(--ls-charcoal);display:flex;align-items:center;gap:6px;line-height:1.15;margin-top:1px;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+.picker .flag{
+  display:inline-flex;align-items:center;justify-content:center;
+  width:22px;height:16px;border-radius:3px;overflow:hidden;font-size:14px;line-height:1;
+  background:#eee;flex:0 0 auto;
+}
+.picker .glyph{
+  width:22px;height:22px;border-radius:6px;flex:0 0 auto;
+  display:inline-flex;align-items:center;justify-content:center;
+  background:linear-gradient(135deg,#fff,#F7F0DC);
+  border:1px solid var(--ls-line);font-size:13px;
+}
+.picker .caret{margin-left:auto;width:14px;height:14px;flex:0 0 auto;opacity:.5}
+.picker .info-stack{display:flex;flex-direction:column;justify-content:center;min-width:0;flex:1}
+
+/* index rail */
+.index{
+  margin-top:10px;
+  display:flex;align-items:stretch;gap:0;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  border-radius:12px;padding:5px;position:relative;
+  overflow-x:auto;scroll-behavior:smooth;
+  scrollbar-width:none;
+}
+.index::-webkit-scrollbar{display:none}
+.index .step{
+  flex:0 0 auto;
+  display:flex;align-items:center;gap:6px;
+  padding:7px 8px;border-radius:8px;
+  font-family:var(--f-mono);font-size:11px;font-weight:500;
+  color:var(--ls-muted);
+  white-space:nowrap;cursor:pointer;
+  transition:background .15s, color .15s;
+  border:none;background:transparent;
+}
+.index .step:hover{color:var(--ls-charcoal)}
+.index .step .n{font-family:var(--f-mono);font-weight:500;font-size:10px;letter-spacing:.06em;color:var(--ls-muted-2)}
+.index .step .ic{font-family:var(--f-body);font-size:13px;line-height:1}
+.index .step .name{
+  display:none;font-family:var(--f-body);font-weight:600;font-size:12.5px;color:var(--ls-charcoal);
+  letter-spacing:-.005em;
+}
+.index .step.active{
+  background:var(--ls-charcoal);color:#fff;
+  box-shadow:0 1px 0 rgba(0,0,0,.04);
+}
+.index .step.active .n{color:var(--ls-gold-light)}
+.index .step.active .name{display:inline;color:#fff}
+.index .step.done{color:var(--ls-charcoal)}
+.index .step.done .n{color:var(--ls-gold-dark)}
+
+/* section meta */
+.section-meta{
+  display:flex;align-items:center;justify-content:space-between;gap:10px;
+  padding:14px 22px 6px;
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);
+}
+.section-meta .step-of b{color:var(--ls-charcoal);font-weight:600}
+
+/* section heading */
+.section-head{padding:0 22px 14px}
+.section-head .kicker{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-gold-dark);
+  display:flex;align-items:center;gap:8px;margin-bottom:6px;
+}
+.section-head .kicker::before{content:"";width:18px;height:1px;background:var(--ls-gold)}
+.section-head h2{
+  font-family:var(--f-display);font-weight:700;font-size:30px;line-height:1;letter-spacing:-.025em;margin:0 0 8px;
+}
+.section-head h2 .em{font-style:italic;font-weight:500;color:var(--ls-gold-dark)}
+.section-head p.lede{
+  font-family:var(--f-body);font-size:13.5px;line-height:1.5;color:var(--ls-muted);
+  margin:0;max-width:38ch;
+}
+
+/* body */
+.body{
+  flex:1 1 auto;overflow-y:auto;overflow-x:hidden;
+  padding:0 0 14px;position:relative;
+  scrollbar-width:thin;scrollbar-color:rgba(11,13,17,.2) transparent;
+  -webkit-mask-image:linear-gradient(180deg,#000 0,#000 calc(100% - 18px),transparent);
+          mask-image:linear-gradient(180deg,#000 0,#000 calc(100% - 18px),transparent);
+}
+.body::-webkit-scrollbar{width:0}
+.body-inner{padding:0 22px;transition:opacity .18s ease, transform .22s ease}
+.body-inner.swapping{opacity:0;transform:translateY(4px)}
+
+/* cards */
+.card{
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  border-radius:14px;padding:14px 16px;margin-bottom:10px;
+}
+.card h3{
+  font-family:var(--f-display);font-weight:700;font-size:18px;line-height:1.1;
+  letter-spacing:-.015em;margin:0 0 6px;
+}
+
+/* bottom nav */
+.botnav{
+  flex:0 0 auto;
+  background:rgba(251,247,240,.94);
+  backdrop-filter:saturate(140%) blur(12px);
+  border-top:1px solid var(--ls-line);
+  padding:10px 14px 22px;
+  display:flex;align-items:center;justify-content:space-between;gap:6px;
+}
+.btn-nav{
+  display:flex;align-items:center;gap:8px;flex:1;min-width:0;
+  padding:8px 10px;border-radius:10px;
+  font-family:var(--f-body);font-size:12px;font-weight:500;
+  color:var(--ls-charcoal);background:transparent;border:none;
+  cursor:pointer;text-align:left;
+}
+.btn-nav:disabled{opacity:.4;cursor:not-allowed}
+.btn-nav .arr{
+  width:28px;height:28px;border-radius:50%;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  display:flex;align-items:center;justify-content:center;flex:0 0 auto;
+}
+.btn-nav .lab{display:flex;flex-direction:column;line-height:1.2;min-width:0;flex:1}
+.btn-nav .lab small{font-family:var(--f-mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted)}
+.btn-nav .lab span{font-weight:600;font-size:12.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.btn-nav.next{flex-direction:row-reverse;text-align:right}
+.btn-nav.next .lab{align-items:flex-end}
+.dots{display:flex;align-items:center;gap:5px;padding:0 2px;flex:0 0 auto}
+.dots .d{width:5px;height:5px;border-radius:50%;background:rgba(11,13,17,.15);transition:background .2s, width .25s}
+.dots .d.on{background:var(--ls-gold);width:18px;border-radius:3px}
+.dots .d.done{background:var(--ls-gold-dark)}
+
+/* TRUTH */
+.truth{
+  background:var(--ls-charcoal);color:#fff;border-radius:18px;padding:18px 18px 16px;margin-bottom:12px;
+  position:relative;overflow:hidden;
+}
+.truth::before{
+  content:"";position:absolute;right:-30px;top:-30px;width:120px;height:120px;
+  background:radial-gradient(circle,rgba(201,168,76,.35),transparent 70%);pointer-events:none;
+}
+.truth .num{
+  font-family:var(--f-display);font-weight:700;font-size:54px;line-height:.9;color:var(--ls-gold);letter-spacing:-.04em;
+}
+.truth .kicker{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--ls-gold-light);margin-bottom:6px;
+}
+.truth .quote{
+  font-family:var(--f-display);font-weight:600;font-size:21px;line-height:1.15;letter-spacing:-.015em;margin:6px 0 0;
+}
+.truth .quote em{color:var(--ls-gold-light);font-style:italic;font-weight:500}
+.truth .by{font-family:var(--f-body);font-style:italic;font-size:12px;color:rgba(255,255,255,.55);margin-top:10px}
+.truth-row{display:grid;grid-template-columns:auto 1fr;gap:14px;align-items:flex-start}
+
+.truth-lite{
+  background:linear-gradient(180deg,#fff,var(--ls-surface2));
+  border:1px solid var(--ls-line);
+  border-radius:14px;padding:14px 16px;margin-bottom:10px;
+}
+.truth-lite .ctx{font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:4px}
+.truth-lite p{
+  font-family:var(--f-display);font-weight:600;font-size:19px;line-height:1.2;letter-spacing:-.015em;margin:0;
+}
+.truth-lite em{color:var(--ls-gold-dark);font-style:italic;font-weight:500}
+
+.errors-head{display:flex;align-items:baseline;justify-content:space-between;margin:18px 0 8px}
+.errors-head .label{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-coral-dark);
+  display:flex;align-items:center;gap:6px;
+}
+.errors-head .label::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--ls-coral)}
+.err{display:flex;align-items:flex-start;gap:12px;padding:11px 4px;border-top:1px solid var(--ls-line)}
+.err .n{font-family:var(--f-mono);font-size:11px;color:var(--ls-coral-dark);font-weight:500;width:22px;flex:0 0 auto;letter-spacing:.05em}
+.err .txt{font-size:13.5px;line-height:1.4;color:var(--ls-charcoal)}
+.err .txt .strike{color:var(--ls-muted);text-decoration:line-through;text-decoration-thickness:1px}
+
+/* MESSAGES */
+.platform-tabs{
+  display:flex;gap:6px;margin-bottom:14px;padding:4px;
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:11px;
+}
+.platform-tabs .tab{
+  flex:1;display:flex;flex-direction:column;align-items:center;gap:2px;
+  padding:7px 4px;border-radius:8px;
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.06em;text-transform:uppercase;
+  color:var(--ls-muted);cursor:pointer;background:transparent;border:none;
+  transition:background .15s, color .15s;
+}
+.platform-tabs .tab .ic{font-family:var(--f-body);font-size:15px;line-height:1}
+.platform-tabs .tab.on{background:var(--ls-charcoal);color:#fff}
+.platform-tabs .tab:hover:not(.on){background:var(--ls-surface2)}
+
+.script{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:14px;
+  padding:14px 16px;margin-bottom:10px;position:relative;
+  transition:border-color .2s;
+}
+.script.sent{border-color:rgba(45,212,191,.5);box-shadow:0 0 0 3px rgba(45,212,191,.08)}
+.script .head{display:flex;align-items:center;gap:8px;margin-bottom:10px}
+.script .head .glyph{
+  width:26px;height:26px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:14px;
+  background:var(--ls-surface2);border:1px solid var(--ls-line);
+}
+.script .head h4{font-family:var(--f-display);font-weight:700;font-size:16px;margin:0;letter-spacing:-.01em}
+.script .head .sub{font-family:var(--f-mono);font-size:9.5px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted)}
+.script .ctx{font-family:var(--f-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:6px;display:flex;align-items:center;gap:6px}
+.script .ctx::before{content:"";width:14px;height:1px;background:var(--ls-line-2)}
+
+.lang-switch{
+  display:inline-flex;align-items:center;gap:0;
+  background:var(--ls-surface2);border:1px solid var(--ls-line);border-radius:99px;padding:2px;
+  font-family:var(--f-mono);font-size:10px;font-weight:500;letter-spacing:.02em;margin-left:auto;
+}
+.lang-switch button{
+  border:none;background:transparent;padding:4px 9px;border-radius:99px;color:var(--ls-muted);cursor:pointer;font:inherit;
+  transition:background .15s, color .15s;
+}
+.lang-switch button.on{background:var(--ls-charcoal);color:#fff}
+
+.msg-body{
+  font-family:var(--f-body);font-size:14px;line-height:1.55;color:var(--ls-charcoal);
+  padding:12px 0 4px;border-top:1px dashed var(--ls-line-2);
+}
+.msg-body p{margin:0 0 8px}
+.msg-body p:last-child{margin-bottom:0}
+.var{
+  display:inline-block;font-family:var(--f-body);font-weight:600;font-size:13.5px;
+  color:var(--ls-gold-dark);background:rgba(201,168,76,.12);
+  padding:1px 7px;border-radius:4px;border:1px dashed rgba(201,168,76,.5);
+  margin:0 1px;line-height:1.2;
+}
+.var.teal{color:var(--ls-teal-dark);background:rgba(45,212,191,.13);border-color:rgba(15,118,110,.4)}
+
+.trad-line{
+  font-family:var(--f-body);font-style:italic;font-size:12.5px;line-height:1.5;color:var(--ls-muted);
+  padding:8px 0 0;border-top:1px dashed var(--ls-line);margin-top:8px;
+}
+.trad-line::before{
+  content:"FR";font-family:var(--f-mono);font-style:normal;font-size:9px;letter-spacing:.14em;
+  background:var(--ls-surface2);padding:2px 5px;border-radius:3px;color:var(--ls-muted);
+  margin-right:7px;vertical-align:1px;
+}
+
+.script-actions{
+  display:flex;align-items:center;gap:6px;margin-top:10px;
+  padding-top:8px;border-top:1px solid var(--ls-line);
+}
+.btn{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:7px 11px;border-radius:8px;
+  font-family:var(--f-body);font-weight:600;font-size:12px;
+  border:1px solid var(--ls-line);background:var(--ls-surface);
+  color:var(--ls-charcoal);cursor:pointer;line-height:1;
+  transition:background .15s, border-color .15s, transform .1s;
+}
+.btn:hover{border-color:var(--ls-line-2)}
+.btn:active{transform:scale(.97)}
+.btn.copy{background:var(--ls-charcoal);color:#fff;border-color:transparent}
+.btn.copy .ic{color:var(--ls-gold-light)}
+.btn.send{background:var(--ls-surface);border-color:var(--ls-gold);color:var(--ls-gold-dark)}
+.btn.send.done{background:var(--ls-teal-dark);color:#fff;border-color:transparent}
+.btn .ic{font-family:var(--f-mono);font-size:11px;line-height:1}
+.btn.ghost{background:transparent;border-color:transparent;color:var(--ls-muted);padding:7px 8px}
+.script-actions .spacer{flex:1}
+.script-actions .stat-mini{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted);
+  display:flex;align-items:center;gap:5px;
+}
+.script-actions .stat-mini b{font-family:var(--f-body);font-weight:700;font-size:12px;letter-spacing:0;text-transform:none;color:var(--ls-charcoal)}
+
+/* OBJ */
+.obj{border-bottom:1px solid var(--ls-line);padding:16px 0 18px}
+.obj:first-child{padding-top:6px}
+.obj:last-child{border-bottom:none}
+.obj .quote{display:flex;gap:10px;align-items:flex-start}
+.obj .quote .n{font-family:var(--f-display);font-weight:700;font-size:24px;line-height:1;color:var(--ls-charcoal);letter-spacing:-.03em;flex:0 0 auto;width:34px}
+.obj .quote .n small{font-family:var(--f-mono);font-size:9px;letter-spacing:.14em;color:var(--ls-muted);font-weight:500;display:block;line-height:1.6}
+.obj .quote q{
+  font-family:var(--f-display);font-weight:600;font-style:italic;font-size:18px;line-height:1.2;letter-spacing:-.01em;quotes:none;color:var(--ls-charcoal);
+}
+.obj .quote q::before{content:"«\00a0"}
+.obj .quote q::after{content:"\00a0»"}
+.obj-row{display:grid;grid-template-columns:24px 1fr;gap:10px;align-items:flex-start;margin-top:10px}
+.obj-row .badge{
+  display:inline-flex;align-items:center;justify-content:center;
+  width:22px;height:22px;border-radius:6px;font-family:var(--f-mono);font-size:11px;font-weight:600;margin-top:2px;
+}
+.obj-row.bad .badge{background:rgba(251,113,133,.14);color:var(--ls-coral-dark);border:1px solid rgba(251,113,133,.3)}
+.obj-row.good .badge{background:rgba(45,212,191,.16);color:var(--ls-teal-dark);border:1px solid rgba(15,118,110,.25)}
+.obj-row .lbl{font-family:var(--f-mono);font-size:9px;letter-spacing:.16em;text-transform:uppercase;font-weight:600}
+.obj-row.bad .lbl{color:var(--ls-coral-dark)}
+.obj-row.good .lbl{color:var(--ls-teal-dark)}
+.obj-row p{margin:2px 0 0;font-size:13.5px;line-height:1.45;color:var(--ls-charcoal)}
+.obj-row.bad p{color:var(--ls-muted);text-decoration:line-through;text-decoration-color:rgba(251,113,133,.35);text-decoration-thickness:1px}
+.obj-row.good p .var{font-weight:600}
+.obj-actions{display:flex;gap:6px;margin-top:12px;align-items:center}
+
+/* TROUVER */
+.flags{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:14px}
+.flag-col{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:12px;padding:11px 12px;
+}
+.flag-col.green{background:linear-gradient(180deg,rgba(45,212,191,.07),transparent 60%),#fff}
+.flag-col.red{background:linear-gradient(180deg,rgba(251,113,133,.07),transparent 60%),#fff}
+.flag-col h5{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+  margin:0 0 8px;display:flex;align-items:center;gap:6px;
+}
+.flag-col.green h5{color:var(--ls-teal-dark)}
+.flag-col.red h5{color:var(--ls-coral-dark)}
+.flag-col h5 .dot{width:7px;height:7px;border-radius:50%}
+.flag-col.green h5 .dot{background:var(--ls-teal);box-shadow:0 0 0 3px rgba(45,212,191,.2)}
+.flag-col.red h5 .dot{background:var(--ls-coral);box-shadow:0 0 0 3px rgba(251,113,133,.2)}
+.flag-col ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px}
+.flag-col li{font-size:12.5px;line-height:1.35;color:var(--ls-charcoal);display:flex;gap:6px;align-items:flex-start}
+.flag-col li::before{content:"";flex:0 0 auto;width:4px;height:4px;border-radius:50%;margin-top:7px}
+.flag-col.green li::before{background:var(--ls-teal-dark)}
+.flag-col.red li::before{background:var(--ls-coral-dark)}
+
+.scan-timer{
+  display:inline-flex;align-items:center;gap:6px;
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--ls-gold-dark);background:rgba(201,168,76,.12);padding:4px 9px;border-radius:99px;margin-bottom:10px;
+}
+.scan-timer .pulse{width:6px;height:6px;border-radius:50%;background:var(--ls-gold);box-shadow:0 0 0 3px rgba(201,168,76,.25)}
+
+.hashtag-card{background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:14px;padding:13px 14px;margin-bottom:10px}
+.hashtag-card .htag-head{display:flex;align-items:center;justify-content:space-between;font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:8px}
+.hashtag-card .htag-head b{color:var(--ls-charcoal);font-weight:600}
+.htag-row{display:flex;flex-wrap:wrap;gap:5px;margin-bottom:9px}
+.htag-row:last-child{margin-bottom:0}
+.htag-row .cat{font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted);align-self:center;margin-right:4px}
+.htag{font-family:var(--f-mono);font-size:11.5px;font-weight:500;padding:3px 8px;border-radius:99px;background:var(--ls-surface2);color:var(--ls-charcoal);border:1px solid var(--ls-line);cursor:pointer;transition:transform .1s, background .15s}
+.htag:active{transform:scale(.96)}
+.htag.gold{background:rgba(201,168,76,.13);border-color:rgba(201,168,76,.3);color:var(--ls-gold-dark)}
+.htag.teal{background:rgba(45,212,191,.13);border-color:rgba(15,118,110,.25);color:var(--ls-teal-dark)}
+.htag.purple{background:rgba(124,58,237,.10);border-color:rgba(124,58,237,.25);color:var(--ls-purple)}
+
+.src-card{background:var(--ls-charcoal);color:#fff;border-radius:14px;padding:14px 16px;margin-bottom:10px;position:relative;overflow:hidden}
+.src-card::before{content:"";position:absolute;left:-30px;bottom:-30px;width:100px;height:100px;background:radial-gradient(circle,rgba(201,168,76,.4),transparent 70%)}
+.src-card h4{font-family:var(--f-display);font-weight:700;font-size:16px;margin:0 0 4px;letter-spacing:-.01em;position:relative}
+.src-card .kk{font-family:var(--f-mono);font-size:9.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-gold-light);margin-bottom:8px}
+.src-row{display:grid;grid-template-columns:46px 1fr;gap:10px;align-items:flex-start;padding:8px 0;border-top:1px solid rgba(255,255,255,.10)}
+.src-row:first-of-type{border-top:none}
+.src-row .src-lab{font-family:var(--f-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ls-gold-light);font-weight:500;padding-top:2px}
+.src-row .src-body{font-size:13px;line-height:1.45;color:rgba(255,255,255,.86)}
+.src-row .src-body em{color:#fff;font-style:italic;font-weight:500}
+
+/* TREE */
+.tree-branch{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:14px;
+  padding:14px 16px;margin-bottom:10px;
+}
+.tree-branch .reaction{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--ls-muted);margin-bottom:6px;display:flex;align-items:center;gap:8px;
+}
+.tree-branch .reaction .pill{
+  background:var(--ls-surface2);padding:3px 8px;border-radius:99px;color:var(--ls-charcoal);
+  font-family:var(--f-mono);font-size:10px;font-weight:500;letter-spacing:.06em;text-transform:none;
+}
+.tree-branch .reaction .pill.warm{background:rgba(45,212,191,.13);color:var(--ls-teal-dark)}
+.tree-branch .reaction .pill.cold{background:rgba(251,113,133,.13);color:var(--ls-coral-dark)}
+.tree-branch .reaction .pill.maybe{background:rgba(201,168,76,.13);color:var(--ls-gold-dark)}
+.tree-branch q{
+  font-family:var(--f-display);font-style:italic;font-weight:600;font-size:16px;line-height:1.2;
+  color:var(--ls-charcoal);quotes:none;display:block;margin-bottom:6px;
+}
+.tree-branch q::before{content:"«\00a0"}.tree-branch q::after{content:"\00a0»"}
+.tree-branch .reply{
+  font-size:13.5px;line-height:1.45;color:var(--ls-charcoal);
+  padding:10px 0 0;border-top:1px dashed var(--ls-line-2);margin-top:6px;
+}
+.tree-branch .reply::before{
+  content:"→ tu réponds";display:block;font-family:var(--f-mono);font-size:9.5px;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--ls-teal-dark);margin-bottom:4px;font-weight:600;
+}
+.tree-branch .actions{display:flex;gap:6px;margin-top:10px;padding-top:8px;border-top:1px solid var(--ls-line)}
+
+/* TIMELINE */
+.timeline{position:relative;padding-left:28px;margin-bottom:10px}
+.timeline::before{
+  content:"";position:absolute;left:9px;top:6px;bottom:6px;width:1.5px;
+  background:linear-gradient(180deg,var(--ls-gold),var(--ls-line-2));
+}
+.t-step{margin-bottom:14px;position:relative}
+.t-step::before{
+  content:"";position:absolute;left:-24px;top:7px;width:13px;height:13px;border-radius:50%;
+  background:var(--ls-cream);border:2px solid var(--ls-gold);
+}
+.t-step.now::before{background:var(--ls-gold);box-shadow:0 0 0 4px rgba(201,168,76,.2)}
+.t-step.future::before{background:var(--ls-cream);border-color:var(--ls-line-2)}
+.t-step .when{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-gold-dark);font-weight:600;margin-bottom:4px;
+}
+.t-step.future .when{color:var(--ls-muted)}
+.t-step h4{font-family:var(--f-display);font-weight:700;font-size:16px;margin:0 0 4px;letter-spacing:-.01em}
+.t-step .msg{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:10px;padding:10px 12px;
+  font-size:13px;line-height:1.45;color:var(--ls-charcoal);margin-top:6px;
+}
+.t-step .msg + .actions{margin-top:8px;display:flex;gap:6px}
+
+/* CLOSING */
+.signal-card{
+  background:linear-gradient(180deg,rgba(45,212,191,.07),transparent 50%),#fff;
+  border:1px solid var(--ls-line);border-radius:14px;padding:13px 14px;margin-bottom:10px;
+}
+.signal-card h5{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-teal-dark);
+  margin:0 0 8px;display:flex;align-items:center;gap:6px;
+}
+.signal-card h5::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--ls-teal);box-shadow:0 0 0 3px rgba(45,212,191,.2)}
+.signal-list{display:flex;flex-direction:column;gap:6px}
+.signal-list .row{display:flex;gap:8px;font-size:13px;line-height:1.4;align-items:flex-start}
+.signal-list .row::before{content:"✓";color:var(--ls-teal-dark);font-weight:700;font-size:13px;margin-top:1px}
+
+.close-script{
+  background:#fff;border:1px solid var(--ls-line);border-radius:14px;padding:13px 16px;margin-bottom:10px;
+}
+.close-script h4{font-family:var(--f-display);font-weight:700;font-size:16px;margin:0 0 4px;letter-spacing:-.01em}
+.close-script .ctx{font-family:var(--f-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:8px}
+.close-script p{margin:0;font-size:13.5px;line-height:1.5}
+
+/* SPECIAL CASES */
+.case-tabs{display:flex;gap:6px;margin-bottom:12px;padding:4px;background:#fff;border:1px solid var(--ls-line);border-radius:11px}
+.case-tabs button{
+  flex:1;padding:8px 6px;border:none;background:transparent;border-radius:8px;cursor:pointer;
+  font-family:var(--f-body);font-weight:600;font-size:12px;color:var(--ls-muted);
+  transition:background .15s, color .15s;
+}
+.case-tabs button.on{background:var(--ls-charcoal);color:#fff}
+
+/* STORYTELLING */
+.story-struct{
+  display:grid;grid-template-columns:repeat(3,1fr);gap:6px;margin-bottom:14px;
+}
+.story-struct .seg{
+  background:#fff;border:1px solid var(--ls-line);border-radius:10px;padding:10px;
+  text-align:center;
+}
+.story-struct .seg .step{
+  font-family:var(--f-mono);font-size:9px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);font-weight:600;
+}
+.story-struct .seg h6{font-family:var(--f-display);font-weight:700;font-size:14px;margin:6px 0 4px;letter-spacing:-.01em}
+.story-struct .seg p{margin:0;font-size:11.5px;color:var(--ls-muted);line-height:1.35}
+.story-struct .seg.gold{background:linear-gradient(180deg,rgba(201,168,76,.15),transparent),#fff;border-color:rgba(201,168,76,.3)}
+
+.story-example{
+  background:#fff;border:1px solid var(--ls-line);border-radius:14px;padding:14px 16px;margin-bottom:10px;
+}
+.story-example .by{font-family:var(--f-mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:6px}
+.story-example p{margin:0 0 8px;font-size:13.5px;line-height:1.5}
+.story-example p:last-child{margin-bottom:0}
+.story-example p em{color:var(--ls-gold-dark);font-style:italic;font-weight:500}
+
+/* ROUTINE */
+.routine-summary{
+  background:var(--ls-charcoal);color:#fff;border-radius:14px;padding:14px 16px;margin-bottom:12px;
+  display:grid;grid-template-columns:auto 1fr;gap:14px;align-items:center;
+}
+.routine-summary .big{
+  font-family:var(--f-display);font-weight:700;font-size:42px;line-height:.9;color:var(--ls-gold);letter-spacing:-.04em;
+}
+.routine-summary .big small{font-family:var(--f-body);font-weight:500;font-size:14px;color:rgba(255,255,255,.6);display:block;letter-spacing:0;margin-top:4px}
+.routine-summary p{margin:0;font-size:13.5px;line-height:1.4;color:rgba(255,255,255,.86)}
+
+.checklist{background:#fff;border:1px solid var(--ls-line);border-radius:14px;padding:6px 14px;margin-bottom:10px}
+.check-item{
+  display:flex;align-items:flex-start;gap:10px;padding:11px 0;border-top:1px solid var(--ls-line);
+  cursor:pointer;
+}
+.check-item:first-child{border-top:none}
+.check-item .box{
+  flex:0 0 auto;width:20px;height:20px;border-radius:6px;border:1.5px solid var(--ls-line-2);
+  background:#fff;display:flex;align-items:center;justify-content:center;margin-top:1px;
+  transition:background .15s, border-color .15s;
+}
+.check-item.done .box{background:var(--ls-gold);border-color:var(--ls-gold)}
+.check-item.done .box::after{content:"✓";color:#fff;font-weight:700;font-size:12px}
+.check-item .txt{font-size:13.5px;line-height:1.4;color:var(--ls-charcoal);flex:1}
+.check-item.done .txt{color:var(--ls-muted);text-decoration:line-through;text-decoration-thickness:1px}
+.check-item .mins{font-family:var(--f-mono);font-size:10px;color:var(--ls-muted);letter-spacing:.1em;align-self:center}
+
+/* TOAST */
+.toast{
+  position:absolute;left:50%;bottom:96px;transform:translateX(-50%);
+  background:var(--ls-charcoal);color:#fff;
+  padding:9px 14px;border-radius:99px;
+  font-family:var(--f-body);font-size:12.5px;font-weight:500;
+  display:flex;align-items:center;gap:8px;
+  box-shadow:0 8px 20px rgba(11,13,17,.3);
+  z-index:40;opacity:0;pointer-events:none;
+  transition:opacity .2s ease, transform .2s ease;
+}
+.toast.show{opacity:1;pointer-events:auto;transform:translateX(-50%) translateY(0)}
+.toast.hide{opacity:0;transform:translateX(-50%) translateY(6px)}
+.toast .ic{color:var(--ls-gold-light);font-family:var(--f-mono);font-size:11px}
+
+/* BOTTOM SHEET */
+.sheet-backdrop{
+  position:absolute;inset:0;background:rgba(11,13,17,0);
+  opacity:0;pointer-events:none;transition:opacity .25s ease;
+  z-index:50;
+}
+.sheet-backdrop.open{background:rgba(11,13,17,.45);opacity:1;pointer-events:auto}
+.sheet{
+  position:absolute;left:0;right:0;bottom:0;
+  background:var(--ls-cream);border-radius:24px 24px 0 0;
+  transform:translateY(110%);transition:transform .3s cubic-bezier(.2,.85,.3,1);
+  z-index:55;max-height:80%;overflow:hidden;display:flex;flex-direction:column;
+}
+.sheet.open{transform:translateY(0)}
+.sheet .grab{
+  width:40px;height:5px;background:var(--ls-line-2);border-radius:3px;margin:10px auto 6px;
+}
+.sheet .sheet-head{
+  padding:6px 22px 14px;border-bottom:1px solid var(--ls-line);
+}
+.sheet .sheet-head .kicker{font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-gold-dark);margin-bottom:4px}
+.sheet .sheet-head h3{font-family:var(--f-display);font-weight:700;font-size:22px;margin:0;letter-spacing:-.02em}
+.sheet .sheet-body{padding:14px 18px 24px;overflow-y:auto}
+.sheet .opts{display:grid;gap:8px}
+.opts.cols-2{grid-template-columns:1fr 1fr}
+.opt{
+  display:flex;align-items:center;gap:12px;padding:11px 12px;
+  background:#fff;border:1px solid var(--ls-line);border-radius:12px;
+  cursor:pointer;text-align:left;width:100%;font:inherit;color:inherit;
+  transition:border-color .15s, background .15s;
+}
+.opt:hover{border-color:var(--ls-line-2)}
+.opt.on{
+  border-color:var(--ls-gold);background:linear-gradient(180deg,rgba(201,168,76,.08),transparent 60%),#fff;
+  box-shadow:0 0 0 2px rgba(201,168,76,.18);
+}
+.opt .flag,.opt .glyph{
+  display:inline-flex;align-items:center;justify-content:center;
+  width:34px;height:34px;border-radius:9px;font-size:18px;flex:0 0 auto;
+  background:var(--ls-surface2);border:1px solid var(--ls-line);
+}
+.opt .info{display:flex;flex-direction:column;line-height:1.2;min-width:0;flex:1}
+.opt .info b{font-family:var(--f-display);font-weight:700;font-size:15px;letter-spacing:-.01em}
+.opt .info small{font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted);margin-top:2px}
+.opt .check{width:18px;height:18px;border-radius:50%;border:1.5px solid var(--ls-line-2);flex:0 0 auto}
+.opt.on .check{background:var(--ls-gold);border-color:var(--ls-gold);position:relative}
+.opt.on .check::after{content:"";position:absolute;left:5px;top:2px;width:4px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}
+
+/* STAT SHEET specifics */
+.stat-sheet .big{
+  display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:12px;
+}
+.stat-sheet .big .stat{
+  background:#fff;border:1px solid var(--ls-line);border-radius:12px;padding:12px;
+}
+.stat-sheet .big .stat .v{font-family:var(--f-display);font-weight:700;font-size:32px;line-height:1;letter-spacing:-.03em}
+.stat-sheet .big .stat .v small{font-family:var(--f-mono);font-size:10px;color:var(--ls-muted);font-weight:500;letter-spacing:.12em;margin-left:4px;text-transform:uppercase}
+.stat-sheet .big .stat .k{font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);margin-top:6px}
+.stat-sheet .funnel{
+  background:#fff;border:1px solid var(--ls-line);border-radius:12px;padding:12px 14px;
+}
+.stat-sheet .fn-row{display:grid;grid-template-columns:90px 1fr 40px;align-items:center;gap:10px;font-size:13px;padding:6px 0}
+.stat-sheet .fn-row .lab{font-family:var(--f-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ls-muted)}
+.stat-sheet .fn-bar{height:8px;border-radius:99px;background:var(--ls-surface2)}
+.stat-sheet .fn-fill{height:100%;border-radius:99px;background:linear-gradient(90deg,var(--ls-gold),var(--ls-gold-light));transition:width .6s ease}
+.stat-sheet .fn-row .v{font-family:var(--f-body);font-weight:700;text-align:right}
+
+@media (prefers-reduced-motion: reduce){
+  *{transition:none !important;animation:none !important}
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   TWEAKS — accent variants
+   ───────────────────────────────────────────────────────────────── */
+html.accent-teal{
+  --ls-gold:#2DD4BF;
+  --ls-gold-light:#7EE8DC;
+  --ls-gold-dark:#0F766E;
+}
+html.accent-purple{
+  --ls-gold:#7C3AED;
+  --ls-gold-light:#A77BF7;
+  --ls-gold-dark:#5B21B6;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   TWEAKS — dark mode (inside phone only, not the stage)
+   ───────────────────────────────────────────────────────────────── */
+html.dark .phone .screen{ background:#0F1115; }
+html.dark .app{ background:#0F1115; color:#F4EFE3 }
+html.dark .status{ background:#0F1115; color:#F4EFE3 }
+html.dark .status .right svg rect,
+html.dark .status .right svg path{ fill:#F4EFE3; stroke:#F4EFE3 }
+html.dark .hdr{ background:#0F1115; border-bottom-color:rgba(255,255,255,.08) }
+html.dark .brand{ color:#F4EFE3 }
+html.dark .brand small{ color:rgba(244,239,227,.5) }
+html.dark .stat-chip{ background:#1A1D24; border-color:rgba(255,255,255,.08); color:#F4EFE3 }
+html.dark .stat-chip b{ color:#F4EFE3 }
+html.dark .picker{ background:#1A1D24; border-color:rgba(255,255,255,.08) }
+html.dark .picker .val{ color:#F4EFE3 }
+html.dark .picker .lbl{ color:rgba(244,239,227,.5) }
+html.dark .picker .glyph{ background:#0F1115; border-color:rgba(255,255,255,.08); color:#F4EFE3 }
+html.dark .picker .caret{ color:#F4EFE3 }
+html.dark .index{ background:#1A1D24; border-color:rgba(255,255,255,.08) }
+html.dark .index .step{ color:rgba(244,239,227,.5) }
+html.dark .index .step .name{ color:#F4EFE3 }
+html.dark .index .step.active{ background:#F4EFE3; color:#0F1115 }
+html.dark .index .step.active .name{ color:#0F1115 }
+html.dark .index .step.active .n{ color:var(--ls-gold-dark) }
+html.dark .index .step.done .n{ color:var(--ls-gold-light) }
+html.dark .section-meta{ color:rgba(244,239,227,.5) }
+html.dark .section-meta .step-of b{ color:#F4EFE3 }
+html.dark .section-meta b{ color:#F4EFE3 }
+html.dark .section-head h2{ color:#F4EFE3 }
+html.dark .section-head .kicker{ color:var(--ls-gold-light) }
+html.dark .section-head .kicker::before{ background:var(--ls-gold) }
+html.dark .section-head p.lede{ color:rgba(244,239,227,.6) }
+html.dark .card,
+html.dark .script,
+html.dark .truth-lite,
+html.dark .obj,
+html.dark .hashtag-card,
+html.dark .tree-branch,
+html.dark .close-script,
+html.dark .signal-card,
+html.dark .checklist,
+html.dark .story-example,
+html.dark .flag-col{
+  background:#1A1D24; border-color:rgba(255,255,255,.08); color:#F4EFE3;
+}
+html.dark .truth-lite{ background:linear-gradient(180deg,#1A1D24,#15171D); }
+html.dark .signal-card{ background:linear-gradient(180deg,rgba(45,212,191,.10),transparent 50%),#1A1D24 }
+html.dark .flag-col.green{ background:linear-gradient(180deg,rgba(45,212,191,.10),transparent 60%),#1A1D24 }
+html.dark .flag-col.red{ background:linear-gradient(180deg,rgba(251,113,133,.10),transparent 60%),#1A1D24 }
+html.dark .truth-lite p, html.dark .truth-lite em{ color:#F4EFE3 }
+html.dark .truth-lite em{ color:var(--ls-gold-light) }
+html.dark .err{ border-top-color:rgba(255,255,255,.08) }
+html.dark .err .txt{ color:#F4EFE3 }
+html.dark .err .txt .strike{ color:rgba(244,239,227,.4) }
+html.dark .obj{ border-bottom-color:rgba(255,255,255,.08); border-radius:0; background:transparent; padding:16px 0 18px }
+html.dark .obj .quote q,
+html.dark .obj .quote .n{ color:#F4EFE3 }
+html.dark .obj-row p{ color:#F4EFE3 }
+html.dark .obj-row.bad p{ color:rgba(244,239,227,.4) }
+html.dark .script .head h4,
+html.dark .tree-branch q,
+html.dark .signal-list .row,
+html.dark .close-script p,
+html.dark .close-script h4,
+html.dark .story-example p,
+html.dark .check-item .txt{ color:#F4EFE3 }
+html.dark .msg-body{ color:#F4EFE3; border-top-color:rgba(255,255,255,.10) }
+html.dark .trad-line{ color:rgba(244,239,227,.55); border-top-color:rgba(255,255,255,.08) }
+html.dark .trad-line::before{ background:#0F1115; color:rgba(244,239,227,.5) }
+html.dark .ctx, html.dark .by, html.dark .htag-head, html.dark .when{ color:rgba(244,239,227,.5) }
+html.dark .lang-switch{ background:#0F1115; border-color:rgba(255,255,255,.08) }
+html.dark .lang-switch button{ color:rgba(244,239,227,.5) }
+html.dark .lang-switch button.on{ background:#F4EFE3; color:#0F1115 }
+html.dark .btn{ background:#0F1115; border-color:rgba(255,255,255,.10); color:#F4EFE3 }
+html.dark .btn.copy{ background:#F4EFE3; color:#0F1115 }
+html.dark .btn.copy .ic{ color:var(--ls-gold-dark) }
+html.dark .btn.send{ background:#1A1D24; border-color:var(--ls-gold); color:var(--ls-gold-light) }
+html.dark .btn.ghost{ background:transparent; color:rgba(244,239,227,.5); border-color:transparent }
+html.dark .platform-tabs{ background:#1A1D24; border-color:rgba(255,255,255,.08) }
+html.dark .platform-tabs .tab{ color:rgba(244,239,227,.5) }
+html.dark .platform-tabs .tab.on{ background:#F4EFE3; color:#0F1115 }
+html.dark .htag{ background:#0F1115; color:#F4EFE3; border-color:rgba(255,255,255,.08) }
+html.dark .botnav{ background:rgba(15,17,21,.94); border-top-color:rgba(255,255,255,.08) }
+html.dark .btn-nav{ color:#F4EFE3 }
+html.dark .btn-nav .arr{ background:#1A1D24; border-color:rgba(255,255,255,.08) }
+html.dark .btn-nav .lab small{ color:rgba(244,239,227,.45) }
+html.dark .body{ -webkit-mask-image:linear-gradient(180deg,#000 0,#000 calc(100% - 18px),transparent); }
+html.dark .sheet{ background:#0F1115; color:#F4EFE3 }
+html.dark .sheet-head{ border-bottom-color:rgba(255,255,255,.08) }
+html.dark .sheet h3{ color:#F4EFE3 }
+html.dark .opt{ background:#1A1D24; border-color:rgba(255,255,255,.10); color:#F4EFE3 }
+html.dark .opt .info small{ color:rgba(244,239,227,.5) }
+html.dark .opt .glyph, html.dark .opt .flag{ background:#0F1115; border-color:rgba(255,255,255,.08) }
+html.dark .opt.on{ background:linear-gradient(180deg,rgba(201,168,76,.10),transparent 60%),#1A1D24; border-color:var(--ls-gold) }
+html.dark .timeline::before{ background:linear-gradient(180deg,var(--ls-gold),rgba(255,255,255,.08)) }
+html.dark .t-step::before{ background:#1A1D24 }
+html.dark .t-step.now::before{ background:var(--ls-gold) }
+html.dark .t-step.future::before{ background:#1A1D24; border-color:rgba(255,255,255,.15) }
+html.dark .t-step .msg{ background:#1A1D24; border-color:rgba(255,255,255,.08); color:#F4EFE3 }
+html.dark .story-struct .seg{ background:#1A1D24; border-color:rgba(255,255,255,.08); color:#F4EFE3 }
+html.dark .story-struct .seg h6{ color:#F4EFE3 }
+html.dark .story-struct .seg p{ color:rgba(244,239,227,.55) }
+html.dark .case-tabs{ background:#1A1D24; border-color:rgba(255,255,255,.08) }
+html.dark .case-tabs button{ color:rgba(244,239,227,.5) }
+html.dark .case-tabs button.on{ background:#F4EFE3; color:#0F1115 }
+html.dark .check-item{ border-top-color:rgba(255,255,255,.08) }
+html.dark .check-item .box{ background:#0F1115; border-color:rgba(255,255,255,.15) }
+html.dark .check-item.done .txt{ color:rgba(244,239,227,.4) }
+html.dark .locale-tag{ background:rgba(255,255,255,.05); color:rgba(244,239,227,.6) }
+html.dark .locale-tag b{ color:#F4EFE3 }
+html.dark .scan-timer{ background:rgba(201,168,76,.18); color:var(--ls-gold-light) }
+html.dark .stat-sheet .big .stat,
+html.dark .stat-sheet .funnel{ background:#1A1D24; border-color:rgba(255,255,255,.08); color:#F4EFE3 }
+html.dark .stat-sheet .fn-bar{ background:rgba(255,255,255,.06) }
+
+/* ─────────────────────────────────────────────────────────────────
+   TWEAKS — combined picker (one pill instead of two)
+   ───────────────────────────────────────────────────────────────── */
+html.picker-combined .pickers{ display:none }
+html.picker-combined .picker-combo{ display:flex }
+.picker-combo{ display:none }
+.picker-combo{
+  width:100%;
+  align-items:center;gap:10px;
+  padding:9px 12px;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  border-radius:12px;cursor:pointer;
+  transition:border-color .15s;
+}
+.picker-combo:hover{ border-color:var(--ls-line-2) }
+.picker-combo .left{ display:flex;align-items:center;gap:8px;min-width:0;flex:1 }
+.picker-combo .stack-flag{
+  display:inline-flex;align-items:center;
+  position:relative;width:36px;height:22px;flex:0 0 auto;
+}
+.picker-combo .stack-flag .flag{
+  position:absolute;display:inline-flex;align-items:center;justify-content:center;
+  width:22px;height:16px;border-radius:3px;font-size:14px;background:#eee;
+  border:2px solid var(--ls-surface);
+}
+.picker-combo .stack-flag .flag.f1{ left:0;top:0;z-index:2 }
+.picker-combo .stack-flag .glyph{
+  position:absolute;right:0;bottom:0;z-index:3;
+  width:18px;height:18px;border-radius:5px;font-size:11px;
+  background:linear-gradient(135deg,#fff,#F7F0DC);border:1px solid var(--ls-line);
+  display:inline-flex;align-items:center;justify-content:center;
+}
+.picker-combo .info-stack{display:flex;flex-direction:column;min-width:0;flex:1}
+.picker-combo .lbl{font-family:var(--f-mono);font-size:9px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-muted)}
+.picker-combo .val{font-family:var(--f-body);font-weight:600;font-size:13.5px;color:var(--ls-charcoal);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:1px}
+.picker-combo .val .x{ color:var(--ls-muted-2);margin:0 6px;font-weight:400 }
+.picker-combo .caret{ width:14px;height:14px;opacity:.5;flex:0 0 auto }
+html.dark .picker-combo{ background:#1A1D24; border-color:rgba(255,255,255,.08) }
+html.dark .picker-combo .val{ color:#F4EFE3 }
+html.dark .picker-combo .lbl{ color:rgba(244,239,227,.5) }
+html.dark .picker-combo .stack-flag .flag{ border-color:#1A1D24 }
+html.dark .picker-combo .stack-flag .glyph{ background:#0F1115; border-color:rgba(255,255,255,.10); color:#F4EFE3 }
+
+/* ─────────────────────────────────────────────────────────────────
+   TWEAKS — index = dots
+   ───────────────────────────────────────────────────────────────── */
+html.index-dots .index{
+  justify-content:space-between;padding:8px 10px;gap:6px;
+  overflow:visible;
+}
+html.index-dots .index .step{
+  flex:1 1 0;
+  display:flex;flex-direction:column;align-items:center;gap:4px;
+  padding:2px 0;background:transparent !important;color:var(--ls-muted) !important;
+}
+html.index-dots .index .step .n{ display:none }
+html.index-dots .index .step .ic{ display:none }
+html.index-dots .index .step .name{ display:none !important }
+html.index-dots .index .step::before{
+  content:"";width:7px;height:7px;border-radius:50%;background:rgba(11,13,17,.18);
+  transition:background .2s, width .25s, height .25s;
+}
+html.dark.index-dots .index .step::before{ background:rgba(244,239,227,.22) }
+html.index-dots .index .step.done::before{ background:var(--ls-gold-dark) }
+html.index-dots .index .step.active::before{
+  background:var(--ls-gold);width:24px;border-radius:4px;
+  box-shadow:0 0 0 3px rgba(201,168,76,.18);
+}
+html.index-dots .index .step::after{
+  content:attr(aria-label);
+  font-family:var(--f-mono);font-size:9px;letter-spacing:.06em;
+  color:transparent;height:0;display:block;
+}
+html.index-dots .index .step.active::after{
+  color:var(--ls-charcoal);height:auto;margin-top:2px;font-weight:600;
+}
+html.dark.index-dots .index .step.active::after{ color:#F4EFE3 }
+
+/* ─────────────────────────────────────────────────────────────────
+   TWEAKS — compact density
+   ───────────────────────────────────────────────────────────────── */
+html.density-compact .section-head{ padding:0 22px 8px }
+html.density-compact .section-head h2{ font-size:24px }
+html.density-compact .section-head p.lede{ font-size:12.5px;line-height:1.4 }
+html.density-compact .body-inner{ padding:0 22px }
+html.density-compact .truth{ padding:14px 16px 12px;margin-bottom:8px }
+html.density-compact .truth .num{ font-size:42px }
+html.density-compact .truth .quote{ font-size:18px }
+html.density-compact .truth-lite{ padding:10px 14px;margin-bottom:8px }
+html.density-compact .truth-lite p{ font-size:16px }
+html.density-compact .err{ padding:8px 4px }
+html.density-compact .err .txt{ font-size:12.5px }
+html.density-compact .script,
+html.density-compact .obj,
+html.density-compact .tree-branch,
+html.density-compact .close-script,
+html.density-compact .signal-card,
+html.density-compact .story-example,
+html.density-compact .hashtag-card{ padding:11px 13px;margin-bottom:8px }
+html.density-compact .obj{ padding:12px 0 13px }
+html.density-compact .msg-body{ font-size:13px;padding-top:9px }
+html.density-compact .script .head h4{ font-size:15px }
+html.density-compact .obj .quote q{ font-size:16px }
+html.density-compact .obj-row p{ font-size:12.5px }
+html.density-compact .t-step{ margin-bottom:10px }
+html.density-compact .t-step h4{ font-size:15px }
+html.density-compact .t-step .msg{ padding:8px 11px;font-size:12.5px }
+html.density-compact .checklist{ padding:4px 13px }
+html.density-compact .check-item{ padding:8px 0 }
+html.density-compact .check-item .txt{ font-size:12.5px }
+
+/* ─────────────────────────────────────────────────────────────────
+   TWEAKS — desktop view (same app, browser window chrome, 760px wide)
+   ───────────────────────────────────────────────────────────────── */
+.window-chrome{ display:none }
+html.view-desktop .phone{
+  width:760px;height:880px;
+  background:var(--ls-cream);
+  border-radius:14px;
+  padding:0;
+  box-shadow:
+    0 30px 60px -20px rgba(11,13,17,.35),
+    0 60px 120px -40px rgba(11,13,17,.20),
+    0 0 0 1px rgba(11,13,17,.08);
+}
+html.view-desktop .phone .screen{ border-radius:14px }
+html.view-desktop .notch,
+html.view-desktop .home-indicator,
+html.view-desktop .status{ display:none }
+html.view-desktop .window-chrome{
+  display:flex;align-items:center;gap:8px;
+  flex:0 0 auto;height:42px;
+  background:#EDE5D2;
+  padding:0 16px;
+  border-bottom:1px solid rgba(11,13,17,.06);
+}
+html.view-desktop .window-chrome .dot{width:12px;height:12px;border-radius:50%}
+html.view-desktop .window-chrome .dot.r{background:#EC6A5E}
+html.view-desktop .window-chrome .dot.y{background:#F4BF4F}
+html.view-desktop .window-chrome .dot.g{background:#61C554}
+html.view-desktop .window-chrome .url{
+  margin-left:18px;font-family:var(--f-mono);font-size:11.5px;color:var(--ls-muted);
+  background:#F7F0DC;padding:6px 14px;border-radius:7px;
+  display:flex;align-items:center;gap:6px;
+}
+html.view-desktop .window-chrome .url::before{content:"";width:8px;height:8px;border:1.5px solid var(--ls-muted);border-radius:50%}
+html.view-desktop .window-chrome .kbd{
+  margin-left:auto;font-family:var(--f-mono);font-size:11px;color:var(--ls-muted);
+  display:flex;align-items:center;gap:6px;
+}
+html.view-desktop .window-chrome .kbd kbd{
+  font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);
+  background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;
+  padding:1px 6px;line-height:1;
+}
+/* Bigger heading + breathing in desktop */
+html.view-desktop .section-head h2{ font-size:34px }
+html.view-desktop.density-compact .section-head h2{ font-size:28px }
+html.view-desktop .section-head p.lede{ font-size:14.5px;max-width:54ch }
+html.view-desktop .body-inner{ padding:0 28px }
+html.view-desktop .section-head{ padding:0 28px 14px }
+html.view-desktop .section-meta{ padding:14px 28px 6px }
+html.view-desktop .hdr{ padding:10px 22px 14px }
+html.view-desktop .pickers{ gap:12px }
+html.view-desktop .index{ margin-top:12px }
+html.view-desktop .botnav{ padding:12px 22px 18px }
+/* In desktop, all 10 modules fit without scroll */
+html.view-desktop .index{ overflow:visible }
+html.view-desktop .index .step{ padding:8px 10px;font-size:11.5px }
+/* Keyboard hint in chrome works as the desktop equivalent of the bottom dots */
+/* Dark mode for the desktop chrome */
+html.dark.view-desktop .phone{ background:#0F1115; box-shadow:0 30px 60px -20px rgba(0,0,0,.5), 0 0 0 1px rgba(255,255,255,.06) }
+html.dark.view-desktop .window-chrome{ background:#1A1D24; border-bottom-color:rgba(255,255,255,.08) }
+html.dark.view-desktop .window-chrome .url{ background:#0F1115; color:rgba(244,239,227,.55) }
+html.dark.view-desktop .window-chrome .url::before{ border-color:rgba(244,239,227,.4) }
+html.dark.view-desktop .window-chrome .kbd kbd{ background:#0F1115; color:#F4EFE3; border-color:rgba(255,255,255,.15) }
+
+/* On smaller screens, force back to mobile */
+@media (max-width: 880px){
+  html.view-desktop .phone{ width:413px;height:850px;border-radius:54px;padding:10px;background:#0B0D11 }
+  html.view-desktop .phone .screen{ border-radius:44px }
+  html.view-desktop .notch,html.view-desktop .home-indicator,html.view-desktop .status{ display:flex }
+  html.view-desktop .status{ display:flex }
+  html.view-desktop .window-chrome{ display:none }
+  html.view-desktop .section-head h2{ font-size:30px }
+  html.view-desktop .body-inner{ padding:0 22px }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   TWEAKS PANEL
+   ───────────────────────────────────────────────────────────────── */
+.tweaks{
+  position:fixed;right:24px;bottom:24px;width:300px;z-index:100;
+  background:#fff;border-radius:16px;
+  box-shadow:0 20px 50px -10px rgba(11,13,17,.25), 0 0 0 1px rgba(11,13,17,.06);
+  font-family:var(--f-body);font-size:13px;color:var(--ls-charcoal);
+  transform:translateY(20px);opacity:0;pointer-events:none;
+  transition:transform .25s ease, opacity .25s ease;
+  overflow:hidden;
+}
+.tweaks.open{ transform:translateY(0);opacity:1;pointer-events:auto }
+.tweaks-head{
+  display:flex;align-items:center;justify-content:space-between;
+  padding:12px 14px;border-bottom:1px solid var(--ls-line);
+  background:linear-gradient(180deg,#fff,var(--ls-surface2));
+}
+.tweaks-head .ttl{
+  font-family:var(--f-display);font-weight:700;font-size:15px;letter-spacing:-.01em;
+  display:flex;align-items:center;gap:8px;
+}
+.tweaks-head .ttl::before{
+  content:"";width:8px;height:8px;border-radius:50%;
+  background:linear-gradient(135deg,var(--ls-gold),#fff7d6);
+  box-shadow:0 0 0 1px var(--ls-gold-dark) inset;
+}
+.tweaks-head button{
+  border:none;background:transparent;cursor:pointer;color:var(--ls-muted);
+  width:24px;height:24px;border-radius:6px;font-size:14px;line-height:1;
+}
+.tweaks-head button:hover{ background:var(--ls-surface2);color:var(--ls-charcoal) }
+.tweaks-body{ padding:8px 14px 14px;max-height:60vh;overflow-y:auto }
+.tw-group{ padding:10px 0;border-top:1px dashed var(--ls-line) }
+.tw-group:first-child{ border-top:none;padding-top:6px }
+.tw-group .lbl{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--ls-muted);margin-bottom:6px;display:flex;align-items:center;justify-content:space-between;
+}
+.tw-group .lbl b{color:var(--ls-charcoal);font-weight:600}
+.tw-seg{
+  display:flex;gap:0;background:var(--ls-surface2);border:1px solid var(--ls-line);
+  border-radius:9px;padding:3px;
+}
+.tw-seg button{
+  flex:1;border:none;background:transparent;cursor:pointer;
+  padding:6px 8px;border-radius:6px;font:inherit;font-size:12px;font-weight:500;color:var(--ls-muted);
+  transition:background .15s,color .15s;
+}
+.tw-seg button.on{ background:#fff;color:var(--ls-charcoal);box-shadow:0 1px 2px rgba(11,13,17,.04) }
+.tw-swatches{ display:flex;gap:6px }
+.tw-sw{
+  flex:1;display:flex;flex-direction:column;align-items:center;gap:4px;
+  padding:8px 6px;background:#fff;border:1px solid var(--ls-line);border-radius:9px;
+  cursor:pointer;font-family:var(--f-mono);font-size:9px;letter-spacing:.08em;color:var(--ls-muted);
+  text-transform:uppercase;
+}
+.tw-sw .ch{ width:22px;height:22px;border-radius:6px }
+.tw-sw.gold .ch{ background:linear-gradient(135deg,#C9A84C,#E5C97D) }
+.tw-sw.teal .ch{ background:linear-gradient(135deg,#2DD4BF,#7EE8DC) }
+.tw-sw.purple .ch{ background:linear-gradient(135deg,#7C3AED,#A77BF7) }
+.tw-sw.on{ border-color:var(--ls-charcoal);color:var(--ls-charcoal) }
+
+.tweaks-launch{
+  position:fixed;right:24px;bottom:24px;z-index:99;
+  display:inline-flex;align-items:center;gap:8px;
+  background:var(--ls-charcoal);color:#fff;border:none;
+  padding:10px 14px 10px 12px;border-radius:99px;cursor:pointer;
+  font-family:var(--f-body);font-weight:600;font-size:13px;
+  box-shadow:0 15px 35px -10px rgba(11,13,17,.3);
+  transition:transform .15s;
+}
+.tweaks-launch:hover{ transform:translateY(-1px) }
+.tweaks-launch .dot{
+  width:8px;height:8px;border-radius:50%;
+  background:linear-gradient(135deg,var(--ls-gold),#fff7d6);
+}
+.tweaks-launch.hide{ display:none }
+
+@media (max-width:760px){
+  .tweaks{ right:12px;left:12px;width:auto;bottom:12px }
+  .tweaks-launch{ right:12px;bottom:12px }
+}
+
+/* Small viewports — info panes collapse */
+@media (max-width: 1100px){
+  .stage-aside{display:none}
+  .stage{grid-template-columns:1fr;grid-template-areas:"phone"}
+}
+
+/* badges & helpers */
+.locale-tag{
+  display:inline-flex;align-items:center;gap:5px;
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--ls-muted);padding:3px 8px;border-radius:99px;background:rgba(11,13,17,.04);
+  margin-bottom:10px;
+}
+.locale-tag b{color:var(--ls-charcoal);font-weight:600}
+
+/* arrow nav (corner) — desktop hint */
+.nudge{
+  position:fixed;left:50%;bottom:8px;transform:translateX(-50%);
+  font-family:var(--f-mono);font-size:11px;color:var(--ls-muted);
+  display:flex;gap:14px;align-items:center;
+  pointer-events:none;
+  z-index:5;
+}
+@media (max-width: 700px){.nudge{display:none}}
+</style>
+</head>
+<body>
+
+<div class="stage">
+
+  <!-- LEFT INFO PANE -->
+  <aside class="stage-aside">
+    <div class="brand-mark"><span class="gem"></span>La Base 360</div>
+    <h6>Prototype interactif</h6>
+    <p style="margin:0 0 14px;font-family:var(--f-mono);font-size:11px;color:var(--ls-muted);line-height:1.6">
+      6 marchés × 4 profils × 10 modules.<br>
+      Tout est cliquable.
+    </p>
+    <h6>Raccourcis</h6>
+    <div class="hint-row"><kbd>←</kbd><kbd>→</kbd><span>module préc./suiv.</span></div>
+    <div class="hint-row"><kbd>1</kbd>—<kbd>9</kbd>,<kbd>0</kbd><span>aller au n° de module</span></div>
+    <div class="hint-row"><kbd>M</kbd><span>changer marché</span></div>
+    <div class="hint-row"><kbd>P</kbd><span>changer profil</span></div>
+    <div class="hint-row"><kbd>C</kbd><span>copier le bloc en focus</span></div>
+    <div class="hint-row"><kbd>Esc</kbd><span>fermer une feuille</span></div>
+  </aside>
+
+  <!-- PHONE -->
+  <div class="phone-wrap">
+    <div class="phone">
+      <div class="notch"></div>
+      <div class="screen" id="screen">
+        <div class="window-chrome" aria-hidden="true">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="url">la-base-360.app/prospection</span>
+          <span class="kbd"><kbd>←</kbd><kbd>→</kbd> modules · <kbd>M</kbd> marché · <kbd>P</kbd> profil · <kbd>C</kbd> copier</span>
+        </div>
+        <div class="app">
+
+          <div class="status">
+            <span>9:41</span>
+            <div class="right">
+              <svg width="17" height="11" viewBox="0 0 17 11"><rect x="0" y="7" width="3" height="4" rx="1" fill="#0B0D11"/><rect x="4.5" y="5" width="3" height="6" rx="1" fill="#0B0D11"/><rect x="9" y="2.5" width="3" height="8.5" rx="1" fill="#0B0D11"/><rect x="13.5" y="0" width="3" height="11" rx="1" fill="#0B0D11"/></svg>
+              <svg width="16" height="11" viewBox="0 0 16 11"><path d="M8 10.5 9.5 8.6c-.8-.7-2.2-.7-3 0L8 10.5Z" fill="#0B0D11"/><path d="M3 4.6c2.9-2.7 7.2-2.7 10 0l-1.5 1.6c-1.9-1.7-5-1.7-7 0L3 4.6Z" fill="#0B0D11"/><path d="M5.5 7.2c1.4-1.3 3.6-1.3 5 0L9 8.7c-.6-.5-1.4-.5-2 0L5.5 7.2Z" fill="#0B0D11"/></svg>
+              <svg width="26" height="12" viewBox="0 0 26 12"><rect x="0.5" y="0.5" width="22" height="11" rx="3" stroke="#0B0D11" fill="none"/><rect x="23.5" y="3.5" width="2" height="5" rx="1" fill="#0B0D11"/><rect x="2" y="2" width="19" height="8" rx="1.5" fill="#0B0D11"/></svg>
+            </div>
+          </div>
+
+          <div class="hdr">
+            <div class="row1">
+              <div class="brand"><span class="gem"></span>La Base 360<small>· prospection</small></div>
+              <button class="stat-chip" id="statChip" type="button">
+                <span class="dot-live"></span>
+                <span><b id="stat-sent">12</b> envoyés · <b id="stat-rdv">3</b> RDV</span>
+                <span style="color:var(--ls-muted)">·&nbsp;7j</span>
+              </button>
+            </div>
+            <div class="pickers">
+              <button class="picker" id="market-picker" type="button">
+                <span class="flag" id="market-flag">🇫🇷</span>
+                <div class="info-stack"><span class="lbl">Marché</span><span class="val" id="market-val">France</span></div>
+                <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+              <button class="picker" id="profile-picker" type="button">
+                <span class="glyph" id="profile-glyph">⚖️</span>
+                <div class="info-stack"><span class="lbl">Profil cible</span><span class="val" id="profile-val">Perte de poids&nbsp;·&nbsp;F</span></div>
+                <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+            </div>
+            <button class="picker-combo" id="combo-picker" type="button">
+              <div class="left">
+                <span class="stack-flag">
+                  <span class="flag f1" id="combo-flag">🇫🇷</span>
+                  <span class="glyph" id="combo-glyph">⚖️</span>
+                </span>
+                <div class="info-stack">
+                  <span class="lbl">Marché × profil</span>
+                  <span class="val"><span id="combo-m">France</span><span class="x">·</span><span id="combo-p">PdP · F</span></span>
+                </div>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <nav class="index" id="index" aria-label="Index des 10 modules"></nav>
+          </div>
+
+          <div class="section-meta">
+            <span class="step-of"><b id="step-of">01</b>&nbsp;/&nbsp;10</span>
+            <span id="section-meta-r"></span>
+          </div>
+
+          <div class="section-head">
+            <div class="kicker" id="section-kicker">Module · Mindset</div>
+            <h2 id="section-h2">D'abord, <span class="em">le ton</span>.</h2>
+            <p class="lede" id="section-lede"></p>
+          </div>
+
+          <div class="body" id="body">
+            <div class="body-inner" id="body-inner"></div>
+          </div>
+
+          <nav class="botnav">
+            <button class="btn-nav prev" id="prev" type="button">
+              <span class="arr"><svg width="12" height="12" viewBox="0 0 12 12"><path d="M7.5 3 4 6l3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg></span>
+              <span class="lab"><small id="prev-small">Début</small><span id="prev-name">Index</span></span>
+            </button>
+            <div class="dots" id="dots" aria-hidden="true"></div>
+            <button class="btn-nav next" id="next" type="button">
+              <span class="arr"><svg width="12" height="12" viewBox="0 0 12 12"><path d="M4.5 3 8 6l-3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg></span>
+              <span class="lab"><small id="next-small">Suivant · 02</small><span id="next-name">Trouver</span></span>
+            </button>
+          </nav>
+
+          <!-- Toast -->
+          <div class="toast" id="toast"><span class="ic">✓</span><span id="toast-text">Copié !</span></div>
+
+          <!-- Bottom sheets -->
+          <div class="sheet-backdrop" id="backdrop"></div>
+          <div class="sheet" id="sheet" role="dialog" aria-modal="true">
+            <div class="grab"></div>
+            <div class="sheet-head">
+              <div class="kicker" id="sheet-kicker"></div>
+              <h3 id="sheet-title"></h3>
+            </div>
+            <div class="sheet-body" id="sheet-body"></div>
+          </div>
+        </div>
+        <div class="home-indicator"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- RIGHT INFO PANE -->
+  <aside class="stage-aside right">
+    <h6>État courant</h6>
+    <div class="live" id="live-market">🇫🇷 France</div>
+    <div class="live" id="live-profile">⚖️ Perte de poids · F</div>
+    <div class="live" id="live-module">01 · Mindset</div>
+    <h6 style="margin-top:18px">Activité 7j</h6>
+    <div style="font-family:var(--f-mono);font-size:11px;line-height:1.7">
+      <b id="aside-sent">12</b> messages envoyés<br>
+      <b id="aside-rdv">3</b> rendez-vous pris<br>
+      <span style="color:var(--ls-muted)">tape sur la pastille pour voir le funnel</span>
+    </div>
+    <h6 style="margin-top:18px">Système</h6>
+    <p style="margin:0;font-family:var(--f-mono);font-size:11px;line-height:1.7">
+      Sticky <b>136 px</b>·<br>
+      <b>1 tap</b> entre modules<br>
+      Toast copier · trad EN→FR inline · variables colorées
+    </p>
+  </aside>
+
+</div>
+
+<div class="nudge">
+  <span>↘ tout est cliquable</span>
+  <span><kbd style="font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;padding:1px 6px">←</kbd> <kbd style="font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;padding:1px 6px">→</kbd> modules</span>
+  <span><kbd style="font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;padding:1px 6px">M</kbd> marché · <kbd style="font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;padding:1px 6px">P</kbd> profil</span>
+</div>
+
+<script src="prototype-data.js"></script>
+<script src="prototype.js"></script>
+
+<!-- ─────────────────────────────────────────────────────────────
+     TWEAKS PANEL
+     ───────────────────────────────────────────────────────────── -->
+<button class="tweaks-launch" id="tweaks-launch" type="button">
+  <span class="dot"></span>Tweaks
+</button>
+
+<div class="tweaks" id="tweaks">
+  <div class="tweaks-head">
+    <div class="ttl">Tweaks</div>
+    <button id="tweaks-close" type="button" aria-label="Fermer">✕</button>
+  </div>
+  <div class="tweaks-body">
+
+    <div class="tw-group">
+      <div class="lbl">Picker · <b id="tw-picker-val">Jumeau</b></div>
+      <div class="tw-seg" data-tw="picker">
+        <button data-v="twin">Jumeau</button>
+        <button data-v="combined">Combiné</button>
+      </div>
+    </div>
+
+    <div class="tw-group">
+      <div class="lbl">Index des 10 modules · <b id="tw-index-val">Numéroté</b></div>
+      <div class="tw-seg" data-tw="index">
+        <button data-v="numbered">Numéroté</button>
+        <button data-v="dots">Dots</button>
+      </div>
+    </div>
+
+    <div class="tw-group">
+      <div class="lbl">Device · <b id="tw-device-val">Mobile</b></div>
+      <div class="tw-seg" data-tw="device">
+        <button data-v="mobile">Mobile · 393</button>
+        <button data-v="desktop">Desktop · 760</button>
+      </div>
+    </div>
+
+    <div class="tw-group">
+      <div class="lbl">Mode <span style="font-family:var(--f-mono);font-size:9px;color:var(--ls-muted-2);text-transform:none;letter-spacing:.04em">· accent auto · <span id="tw-auto-accent">purple</span></span></div>
+      <div class="tw-seg" data-tw="mode">
+        <button data-v="light">Light · purple</button>
+        <button data-v="dark">Dark · teal</button>
+      </div>
+    </div>
+
+    <div class="tw-group">
+      <div class="lbl">Densité · <b id="tw-density-val">Confort</b></div>
+      <div class="tw-seg" data-tw="density">
+        <button data-v="comfortable">Confort</button>
+        <button data-v="compact">Compact</button>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+/* ─────────────────────────────────────────────────────────────
+   TWEAKS — state + persist + host protocol
+   ───────────────────────────────────────────────────────────── */
+(function(){
+  const TWEAKS = /*EDITMODE-BEGIN*/{
+    "picker": "twin",
+    "index": "numbered",
+    "mode": "dark",
+    "density": "compact",
+    "device": "desktop"
+  }/*EDITMODE-END*/;
+
+  /* Accent is implicitly bound to mode */
+  const ACCENT_FOR = { light:'purple', dark:'teal' };
+
+  const state = Object.assign({}, TWEAKS, JSON.parse(localStorage.getItem('lb360-tweaks')||'{}'));
+
+  const LABELS = {
+    picker:  {twin:'Jumeau', combined:'Combiné'},
+    index:   {numbered:'Numéroté', dots:'Dots'},
+    mode:    {light:'Light', dark:'Dark'},
+    density: {comfortable:'Confort', compact:'Compact'},
+    device:  {mobile:'Mobile', desktop:'Desktop'}
+  };
+
+  function apply(){
+    const html = document.documentElement;
+    const accent = ACCENT_FOR[state.mode] || 'purple';
+    html.classList.toggle('picker-combined', state.picker === 'combined');
+    html.classList.toggle('index-dots',      state.index  === 'dots');
+    html.classList.toggle('dark',            state.mode   === 'dark');
+    html.classList.toggle('view-desktop',    state.device === 'desktop');
+    html.classList.remove('accent-teal','accent-purple');
+    if (accent === 'teal')   html.classList.add('accent-teal');
+    if (accent === 'purple') html.classList.add('accent-purple');
+    html.classList.toggle('density-compact', state.density === 'compact');
+
+    /* reflect in panel */
+    document.querySelectorAll('[data-tw]').forEach(grp=>{
+      const key = grp.dataset.tw;
+      grp.querySelectorAll('button[data-v]').forEach(b=>{
+        b.classList.toggle('on', b.dataset.v === state[key]);
+      });
+      const valEl = document.getElementById('tw-'+key+'-val');
+      if (valEl) valEl.textContent = LABELS[key][state[key]];
+    });
+    const aa = document.getElementById('tw-auto-accent');
+    if (aa) aa.textContent = accent;
+
+    /* trigger fit() to recompute scale */
+    window.dispatchEvent(new Event('resize'));
+  }
+
+  function set(key, value){
+    state[key] = value;
+    localStorage.setItem('lb360-tweaks', JSON.stringify(state));
+    apply();
+    try { window.parent.postMessage({type:'__edit_mode_set_keys', edits:{[key]:value}}, '*'); } catch(e){}
+  }
+
+  document.querySelectorAll('[data-tw]').forEach(grp=>{
+    const key = grp.dataset.tw;
+    grp.querySelectorAll('button[data-v]').forEach(b=>{
+      b.addEventListener('click', ()=> set(key, b.dataset.v));
+    });
+  });
+
+  /* Open / close + host protocol */
+  const panel    = document.getElementById('tweaks');
+  const launcher = document.getElementById('tweaks-launch');
+  const closer   = document.getElementById('tweaks-close');
+
+  function open(){ panel.classList.add('open'); launcher.classList.add('hide'); }
+  function close(){
+    panel.classList.remove('open'); launcher.classList.remove('hide');
+    try { window.parent.postMessage({type:'__edit_mode_dismissed'}, '*'); } catch(e){}
+  }
+
+  launcher.addEventListener('click', open);
+  closer.addEventListener('click', close);
+
+  /* Host edit-mode protocol */
+  window.addEventListener('message', (e)=>{
+    const data = e.data || {};
+    if (data.type === '__activate_edit_mode')   open();
+    if (data.type === '__deactivate_edit_mode') close();
+  });
+  try { window.parent.postMessage({type:'__edit_mode_available'}, '*'); } catch(e){}
+
+  /* Wire to combined picker (re-uses the bottom sheet logic by triggering both pickers in sequence) */
+  document.getElementById('combo-picker').addEventListener('click', ()=>{
+    document.getElementById('market-picker').click();
+  });
+  /* Mirror values when state changes — observe market/profile DOM */
+  function syncCombo(){
+    const mFlag = document.getElementById('market-flag').textContent;
+    const mVal  = document.getElementById('market-val').textContent;
+    const pGly  = document.getElementById('profile-glyph').textContent;
+    const pVal  = document.getElementById('profile-val').textContent;
+    document.getElementById('combo-flag').textContent  = mFlag;
+    document.getElementById('combo-glyph').textContent = pGly;
+    document.getElementById('combo-m').textContent     = mVal;
+    document.getElementById('combo-p').textContent     = pVal.replace(/&nbsp;/g,' ');
+  }
+  const mo = new MutationObserver(syncCombo);
+  mo.observe(document.getElementById('market-val'), {childList:true, characterData:true, subtree:true});
+  mo.observe(document.getElementById('profile-val'), {childList:true, characterData:true, subtree:true});
+  syncCombo();
+
+  apply();
+})();
+</script>
+
+</body>
+</html>

--- a/docs/mockups/prospection-v4-prototype-v3.js
+++ b/docs/mockups/prospection-v4-prototype-v3.js
@@ -1,0 +1,684 @@
+/* ────────────────────────────────────────────────────────────
+   LA BASE 360 · Prospection — Prototype interactif
+   ──────────────────────────────────────────────────────────── */
+(function(){
+  const $ = (s, el=document) => el.querySelector(s);
+  const $$ = (s, el=document) => Array.from(el.querySelectorAll(s));
+  const REDUCED = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const state = {
+    market: 0,
+    profile: 0,
+    module: 0,
+    platform: 0,
+    lang: {},          // per-script lang: { 'insta':'native'|'fr', ... }
+    sent: 12,
+    rdv: 3,
+    sentMap: {},       // which scripts were marked sent in this session
+    checks: {},        // routine checkbox state
+    caseTab: 'ghost',
+    sheet: null,       // 'market' | 'profile' | 'stat' | null
+  };
+
+  /* ── FIT phone to viewport ─────────────────────────── */
+  function fit(){
+    const isDesktop = document.documentElement.classList.contains('view-desktop');
+    const targetH = isDesktop ? 880 : 870;
+    const targetW = isDesktop ? 780 : 440;
+    const h = window.innerHeight - 36;
+    const w = window.innerWidth - 36;
+    const s = Math.min(1, h/targetH, w/targetW);
+    document.documentElement.style.setProperty('--phone-scale', s);
+  }
+  window.addEventListener('resize', fit);
+  fit();
+
+  /* ── Toast ─────────────────────────────────────────── */
+  let toastT;
+  function toast(text='Copié !'){
+    const t = $('#toast');
+    $('#toast-text').innerHTML = text;
+    t.classList.remove('hide');
+    t.classList.add('show');
+    clearTimeout(toastT);
+    toastT = setTimeout(()=>{
+      t.classList.remove('show');
+      t.classList.add('hide');
+    }, 1500);
+  }
+
+  /* ── Sheet ─────────────────────────────────────────── */
+  function openSheet(kind){
+    state.sheet = kind;
+    const sheet = $('#sheet');
+    const back = $('#backdrop');
+    const body = $('#sheet-body');
+    const title = $('#sheet-title');
+    const kicker = $('#sheet-kicker');
+    sheet.classList.remove('stat-sheet');
+
+    if (kind === 'market'){
+      kicker.textContent = 'Choisir un marché';
+      title.textContent = 'Marché cible.';
+      body.innerHTML = `
+        <div class="opts cols-2">
+          ${MARKETS.map((m,i)=>`
+            <button class="opt ${i===state.market?'on':''}" data-i="${i}">
+              <span class="flag">${m.flag}</span>
+              <span class="info"><b>${m.name}</b><small>${m.sub} · ${m.lang}</small></span>
+              <span class="check"></span>
+            </button>
+          `).join('')}
+        </div>
+        <div style="font-family:var(--f-mono);font-size:10.5px;color:var(--ls-muted);line-height:1.6;margin-top:14px;padding:10px 12px;background:var(--ls-surface2);border-radius:10px">
+          Les scripts <b style="color:var(--ls-charcoal)">M1</b>, les <b style="color:var(--ls-charcoal)">hashtags</b> et les <b style="color:var(--ls-charcoal)">sources</b> se localisent automatiquement.
+        </div>`;
+      body.querySelectorAll('.opt').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          state.market = parseInt(btn.dataset.i,10);
+          closeSheet();
+          renderAll();
+          flash($('#market-picker'));
+        });
+      });
+    }
+
+    if (kind === 'profile'){
+      kicker.textContent = 'Choisir un profil';
+      title.textContent = 'Profil cible.';
+      body.innerHTML = `
+        <div class="opts">
+          ${PROFILES.map((p,i)=>`
+            <button class="opt ${i===state.profile?'on':''}" data-i="${i}">
+              <span class="glyph">${p.glyph}</span>
+              <span class="info"><b>${p.name}</b><small>${p.persona}</small></span>
+              <span class="check"></span>
+            </button>
+          `).join('')}
+        </div>`;
+      body.querySelectorAll('.opt').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          state.profile = parseInt(btn.dataset.i,10);
+          closeSheet();
+          renderAll();
+          flash($('#profile-picker'));
+        });
+      });
+    }
+
+    if (kind === 'stat'){
+      sheet.classList.add('stat-sheet');
+      kicker.textContent = '7 derniers jours';
+      title.textContent = 'Activité.';
+      const sent = state.sent;
+      const rdv  = state.rdv;
+      const reps = Math.round(sent * 0.42);
+      const clos = Math.max(1, Math.round(rdv * 0.4));
+      const pct = (v, max=sent) => Math.min(100, Math.round(v/max*100));
+      body.innerHTML = `
+        <div class="big">
+          <div class="stat"><div class="v">${sent}<small>↑</small></div><div class="k">M1 envoyés</div></div>
+          <div class="stat"><div class="v">${reps}<small>↑</small></div><div class="k">Réponses</div></div>
+          <div class="stat"><div class="v">${rdv}</div><div class="k">RDV pris</div></div>
+          <div class="stat"><div class="v">${clos}</div><div class="k">Closing</div></div>
+        </div>
+        <div class="funnel">
+          <div class="fn-row"><span class="lab">M1</span><div class="fn-bar"><div class="fn-fill" style="width:${pct(sent)}%"></div></div><span class="v">${sent}</span></div>
+          <div class="fn-row"><span class="lab">Réponses</span><div class="fn-bar"><div class="fn-fill" style="width:${pct(reps)}%"></div></div><span class="v">${reps}</span></div>
+          <div class="fn-row"><span class="lab">RDV</span><div class="fn-bar"><div class="fn-fill" style="width:${pct(rdv)}%"></div></div><span class="v">${rdv}</span></div>
+          <div class="fn-row"><span class="lab">Closing</span><div class="fn-bar"><div class="fn-fill" style="width:${pct(clos)}%"></div></div><span class="v">${clos}</span></div>
+        </div>
+        <p style="font-family:var(--f-mono);font-size:10.5px;color:var(--ls-muted);line-height:1.6;margin:14px 0 0">
+          Chaque <b>« J'ai envoyé »</b> incrémente. Les RDV s'incrémentent quand un script <b>WhatsApp</b> est envoyé (proxy démo).
+        </p>`;
+    }
+
+    back.classList.add('open');
+    sheet.classList.add('open');
+  }
+  function closeSheet(){
+    state.sheet = null;
+    $('#sheet').classList.remove('open');
+    $('#backdrop').classList.remove('open');
+  }
+  function flash(el){
+    el.classList.add('opening');
+    setTimeout(()=>el.classList.remove('opening'), 280);
+  }
+
+  /* ── Render header (picker labels, stat chip, index, dots) ── */
+  function renderHeader(){
+    const m = MARKETS[state.market], p = PROFILES[state.profile], md = MODULES[state.module];
+    $('#market-flag').textContent = m.flag;
+    $('#market-val').innerHTML = m.name;
+    $('#profile-glyph').textContent = p.glyph;
+    $('#profile-val').innerHTML = p.name;
+    $('#stat-sent').textContent = state.sent;
+    $('#stat-rdv').textContent = state.rdv;
+    $('#aside-sent') && ($('#aside-sent').textContent = state.sent);
+    $('#aside-rdv')  && ($('#aside-rdv').textContent  = state.rdv);
+    $('#live-market') && ($('#live-market').textContent = `${m.flag} ${m.name}`);
+    $('#live-profile') && ($('#live-profile').textContent = `${p.glyph} ${p.name}`);
+    $('#live-module')  && ($('#live-module').textContent  = `${String(state.module+1).padStart(2,'0')} · ${md.name}`);
+
+    /* index rail */
+    const rail = $('#index');
+    rail.innerHTML = MODULES.map((mod, i)=>{
+      const cls = i===state.module ? 'active' : (i<state.module ? 'done':'');
+      return `<button class="step ${cls}" data-i="${i}" type="button" aria-label="${mod.name}">
+        <span class="n">${String(i+1).padStart(2,'0')}</span>
+        <span class="ic">${mod.ic}</span>
+        <span class="name">${mod.name}</span>
+      </button>`;
+    }).join('');
+    rail.querySelectorAll('.step').forEach(s=>{
+      s.addEventListener('click', ()=> goModule(parseInt(s.dataset.i,10)));
+    });
+    /* center active */
+    requestAnimationFrame(()=>{
+      const active = rail.querySelector('.step.active');
+      if (active){
+        const railRect = rail.getBoundingClientRect();
+        const aRect = active.getBoundingClientRect();
+        const delta = (aRect.left + aRect.width/2) - (railRect.left + railRect.width/2);
+        rail.scrollBy({left:delta, behavior:'smooth'});
+      }
+    });
+
+    /* dots */
+    $('#dots').innerHTML = MODULES.map((_,i)=>{
+      const cls = i===state.module ? 'on' : (i<state.module ? 'done' : '');
+      return `<span class="d ${cls}"></span>`;
+    }).join('');
+
+    /* section meta + heading */
+    $('#step-of').textContent = String(state.module+1).padStart(2,'0');
+    $('#section-meta-r').innerHTML = md.meta;
+    $('#section-kicker').innerHTML = md.kicker;
+    $('#section-h2').innerHTML = `${md.h2[0]}<span class="em">${md.h2[1]}</span>${md.h2[2]||''}`;
+    $('#section-lede').innerHTML = md.lede;
+
+    /* prev/next */
+    const prev = state.module - 1;
+    const next = state.module + 1;
+    const prevBtn = $('#prev'), nextBtn = $('#next');
+    if (prev < 0){
+      prevBtn.disabled = true;
+      $('#prev-small').textContent = 'Début';
+      $('#prev-name').textContent  = 'Index';
+    } else {
+      prevBtn.disabled = false;
+      $('#prev-small').textContent = `Précédent · ${String(prev+1).padStart(2,'0')}`;
+      $('#prev-name').textContent  = MODULES[prev].name;
+    }
+    if (next > 9){
+      nextBtn.disabled = true;
+      $('#next-small').textContent = 'Fin';
+      $('#next-name').textContent  = '—';
+    } else {
+      nextBtn.disabled = false;
+      $('#next-small').textContent = `Suivant · ${String(next+1).padStart(2,'0')}`;
+      $('#next-name').textContent  = MODULES[next].name;
+    }
+  }
+
+  /* ── Render body (per module) ──────────────────────── */
+  function renderBody(){
+    const inner = $('#body-inner');
+    const html = MODULE_RENDERERS[state.module]();
+    inner.innerHTML = html;
+    /* scroll to top of module */
+    $('#body').scrollTop = 0;
+    /* wire up per-module interactions */
+    wireBody(inner);
+  }
+
+  function renderAll(animated=true){
+    renderHeader();
+    if (animated && !REDUCED){
+      const inner = $('#body-inner');
+      inner.classList.add('swapping');
+      setTimeout(()=>{
+        renderBody();
+        requestAnimationFrame(()=> inner.classList.remove('swapping'));
+      }, 120);
+    } else {
+      renderBody();
+    }
+  }
+
+  /* ── Navigation ────────────────────────────────────── */
+  function goModule(i){
+    if (i<0 || i>9 || i===state.module) return;
+    state.module = i;
+    renderAll(true);
+  }
+
+  $('#prev').addEventListener('click', ()=> goModule(state.module-1));
+  $('#next').addEventListener('click', ()=> goModule(state.module+1));
+  $('#market-picker').addEventListener('click', ()=> { flash($('#market-picker')); openSheet('market'); });
+  $('#profile-picker').addEventListener('click', ()=> { flash($('#profile-picker')); openSheet('profile'); });
+  $('#statChip').addEventListener('click', ()=> openSheet('stat'));
+  $('#backdrop').addEventListener('click', closeSheet);
+
+  /* keyboard */
+  window.addEventListener('keydown', (e)=>{
+    if (e.key === 'Escape'){ closeSheet(); return; }
+    if (state.sheet) return;
+    if (e.key === 'ArrowRight'){ goModule(state.module+1); }
+    if (e.key === 'ArrowLeft') { goModule(state.module-1); }
+    if (/^[1-9]$/.test(e.key))  goModule(parseInt(e.key,10)-1);
+    if (e.key === '0')          goModule(9);
+    if (e.key === 'm' || e.key === 'M') openSheet('market');
+    if (e.key === 'p' || e.key === 'P') openSheet('profile');
+    if (e.key === 'c' || e.key === 'C'){
+      const focus = document.activeElement;
+      const btn = focus && focus.classList && focus.classList.contains('btn') && focus.classList.contains('copy') ? focus : null;
+      if (btn){ btn.click(); }
+      else { const first = $('.btn.copy'); if (first) first.click(); }
+    }
+  });
+
+  /* ────────────────────────────────────────────────────
+     MODULE RENDERERS
+     ──────────────────────────────────────────────────── */
+  const MODULE_RENDERERS = [
+    renderMindset,
+    renderTrouver,
+    renderMessages,
+    renderTrees,
+    renderObjections,
+    renderPostcall,
+    renderClosing,
+    renderSpecial,
+    renderStory,
+    renderRoutine,
+  ];
+
+  function localeTag(extra=''){
+    const m = MARKETS[state.market], p = PROFILES[state.profile];
+    return `<span class="locale-tag">Localisé pour <b>${m.flag}&nbsp;${m.name}</b>&nbsp;·&nbsp;<b>${p.glyph}&nbsp;${p.short}</b>${extra?` · ${extra}`:''}</span>`;
+  }
+
+  function renderMindset(){
+    return `
+      <article class="truth">
+        <div class="truth-row">
+          <div class="num">01</div>
+          <div>
+            <div class="kicker">Vérité n°1 · posture</div>
+            <p class="quote">Tu ne <em>vends</em> pas. Tu invites quelqu'un à se transformer.</p>
+            <p class="by">— extrait <em>Méthode 360</em></p>
+          </div>
+        </div>
+      </article>
+
+      <article class="truth-lite">
+        <div class="ctx">Vérité n°2 · refus</div>
+        <p>Le <em>«&nbsp;non&nbsp;»</em> n'existe pas. Seulement <em>pas encore</em>, <em>pas comme ça</em>, <em>pas avec toi</em>.</p>
+      </article>
+
+      <article class="truth-lite">
+        <div class="ctx">Vérité n°3 · énergie</div>
+        <p>Ton <em>énergie</em> compte plus que ton script.</p>
+      </article>
+
+      <div class="errors-head">
+        <span class="label">5 erreurs à éviter</span>
+        <span style="font-family:var(--f-mono);font-size:10px;color:var(--ls-muted);letter-spacing:.1em">↓</span>
+      </div>
+      ${[
+        'Parler produit avant d\'avoir écouté le besoin.',
+        'Suivre tout le monde au lieu de cibler des profils qualifiés.',
+        'Disparaître après le M1 sans relance structurée.',
+        'Sortir le prix trop tôt dans la conversation.',
+        'Copier-coller sans personnaliser le prénom.'
+      ].map((t,i)=>`
+        <div class="err">
+          <span class="n">0${i+1}</span>
+          <div class="txt"><span class="strike">${t.split(' ').slice(0,3).join(' ')}</span> ${t.split(' ').slice(3).join(' ')}</div>
+        </div>`).join('')}
+
+      <div style="height:14px"></div>
+      ${localeTag(`vue 2× cette sem.`)}
+    `;
+  }
+
+  function renderTrouver(){
+    const m = MARKETS[state.market];
+    return `
+      <div class="scan-timer"><span class="pulse"></span>Scan en 30&nbsp;s · les 4 premières secondes</div>
+
+      <div class="flags">
+        <div class="flag-col green">
+          <h5><span class="dot"></span>Drapeaux verts</h5>
+          <ul>${m.flagsGreen.map(f=>`<li>${f}</li>`).join('')}</ul>
+        </div>
+        <div class="flag-col red">
+          <h5><span class="dot"></span>Drapeaux rouges</h5>
+          <ul>${m.flagsRed.map(f=>`<li>${f}</li>`).join('')}</ul>
+        </div>
+      </div>
+
+      <article class="hashtag-card">
+        <div class="htag-head">
+          <span>Hashtags · <b>${m.flag}&nbsp;${m.name}</b></span>
+          <span style="font-family:var(--f-mono);font-size:9.5px">3 catégories</span>
+        </div>
+        <div class="htag-row">
+          <span class="cat">Mainstream</span>
+          ${m.hashtags.mainstream.map(h=>`<button class="htag" type="button" data-copy="${h}">${h}</button>`).join('')}
+        </div>
+        <div class="htag-row">
+          <span class="cat">Niche</span>
+          ${m.hashtags.niche.map(h=>`<button class="htag gold" type="button" data-copy="${h}">${h}</button>`).join('')}
+        </div>
+        <div class="htag-row">
+          <span class="cat">Cross</span>
+          ${m.hashtags.cross.map((h,i)=>`<button class="htag ${i<2?'teal':'purple'}" type="button" data-copy="${h}">${h}</button>`).join('')}
+        </div>
+      </article>
+
+      <article class="src-card">
+        <div class="kk">3 sources hors-feed</div>
+        <h4>Là où les autres ne cherchent pas.</h4>
+        <div class="src-row"><div class="src-lab">FB</div><div class="src-body">${m.sources.fb}</div></div>
+        <div class="src-row"><div class="src-lab">IRL</div><div class="src-body">${m.sources.irl}</div></div>
+        <div class="src-row"><div class="src-lab">Reco</div><div class="src-body">${m.sources.reco}</div></div>
+      </article>
+
+      <div style="height:8px"></div>
+      ${localeTag()}
+    `;
+  }
+
+  function renderMessages(){
+    const market = MARKETS[state.market];
+    const scripts = M1_SCRIPTS[market.code] || M1_SCRIPTS.INTL;
+    const current = PLATFORMS[state.platform];
+    const data = scripts[current.code];
+    const langKey = `${market.code}-${current.code}`;
+    const lang = state.lang[langKey] || (market.code === 'FR' ? 'native' : 'native'); // default to native
+    const sent = !!state.sentMap[`m1-${langKey}`];
+
+    return `
+      <div class="platform-tabs" role="tablist">
+        ${PLATFORMS.map((pl,i)=>`
+          <button class="tab ${i===state.platform?'on':''}" data-i="${i}" type="button">
+            <span class="ic">${pl.ic}</span>${pl.name}
+          </button>`).join('')}
+      </div>
+
+      <article class="script ${sent?'sent':''}" data-key="${langKey}">
+        <div class="head">
+          <span class="glyph" style="${current.glyphStyle}">${current.ic}</span>
+          <div>
+            <h4>${current.name} · ${current.sub.split('·')[0].trim()}</h4>
+            <span class="sub">${current.sub.includes('·')? current.sub.split('·').slice(1).join('·').trim() : ''}</span>
+          </div>
+          ${market.code === 'FR' ? '' : `
+            <div class="lang-switch" data-key="${langKey}">
+              <button data-l="native" class="${lang==='native'?'on':''}">${market.lang}</button>
+              <button data-l="fr" class="${lang==='fr'?'on':''}">FR</button>
+            </div>`}
+        </div>
+        <div class="ctx">Contexte · ${data.ctx}</div>
+        <div class="msg-body">${lang==='fr' && data.trad ? `<p>${data.trad}</p>` : data.script}</div>
+        ${market.code !== 'FR' && lang === 'native' && data.trad ? `<div class="trad-line">${data.trad}</div>` : ''}
+        <div class="script-actions">
+          <button class="btn copy" type="button" data-msg="m1-${langKey}"><span class="ic">⌘C</span>Copier</button>
+          <button class="btn send ${sent?'done':''}" type="button" data-send="m1-${langKey}" data-platform="${current.code}">
+            <span class="ic">${sent?'✓':'↗'}</span>${sent?'Envoyé':'J\'ai envoyé'}
+          </button>
+          <div class="spacer"></div>
+          <span class="stat-mini">Taux réponse&nbsp; <b>${data.stat}</b>&nbsp; · &nbsp;n=<b>${data.n}</b></span>
+        </div>
+      </article>
+
+      <div style="height:6px"></div>
+      ${localeTag(`taux moyens des autres distri·s`)}
+    `;
+  }
+
+  function renderTrees(){
+    return `
+      ${TREES.map(t=>`
+        <article class="tree-branch">
+          <div class="reaction"><b>Réaction&nbsp;:</b><span class="pill ${t.reaction}">${t.emoji}&nbsp;${t.label}</span></div>
+          <q>${t.they}</q>
+          <div class="reply">${t.you}</div>
+          <div class="actions">
+            <button class="btn copy" type="button" data-msg="tree-${t.reaction}"><span class="ic">⌘C</span>Copier la réponse</button>
+            <button class="btn ghost" type="button">Variantes · ${t.variants}</button>
+          </div>
+        </article>`).join('')}
+      <div style="height:6px"></div>
+      ${localeTag()}
+    `;
+  }
+
+  function renderObjections(){
+    return `
+      ${OBJECTIONS.map((o,i)=>`
+        <article class="obj">
+          <div class="quote">
+            <div class="n">${String(i+1).padStart(2,'0')}<small>·&nbsp;${o.tag}</small></div>
+            <q>${o.quote}</q>
+          </div>
+          <div class="obj-row bad">
+            <span class="badge">✕</span>
+            <div><span class="lbl">À ne pas dire</span><p>${o.bad}</p></div>
+          </div>
+          <div class="obj-row good">
+            <span class="badge">✓</span>
+            <div><span class="lbl">Ce qui ouvre</span><p>${o.good}</p></div>
+          </div>
+          <div class="obj-actions">
+            <button class="btn copy" type="button" data-msg="obj-${i}"><span class="ic">⌘C</span>Copier la réponse</button>
+            <button class="btn ghost" type="button">Variantes · ${o.variants}</button>
+          </div>
+        </article>`).join('')}
+      <div style="height:6px"></div>
+      ${localeTag(`8 objections en France · variantes/marché`)}
+    `;
+  }
+
+  function renderPostcall(){
+    return `
+      <div class="timeline">
+        ${POSTCALL.map((s,i)=>`
+          <div class="t-step ${s.state||''}">
+            <div class="when">${s.when}</div>
+            <h4>${s.title}</h4>
+            <div class="msg">${s.msg}</div>
+            <div class="actions">
+              <button class="btn copy" type="button" data-msg="pc-${i}"><span class="ic">⌘C</span>Copier</button>
+              ${s.state!=='future' ? `<button class="btn send" type="button" data-send="pc-${i}"><span class="ic">↗</span>Programmé</button>` : ''}
+            </div>
+          </div>`).join('')}
+      </div>
+      <div class="card" style="background:linear-gradient(180deg,var(--ls-surface2),transparent),#fff">
+        <div style="font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:4px">Règle</div>
+        <p style="margin:0;font-family:var(--f-display);font-weight:600;font-size:17px;line-height:1.2;letter-spacing:-.01em">
+          Quatre touches <em style="color:var(--ls-gold-dark);font-style:italic;font-weight:500">maximum</em>. Pas une de plus.
+        </p>
+      </div>
+      ${localeTag()}
+    `;
+  }
+
+  function renderClosing(){
+    return `
+      <article class="signal-card">
+        <h5>Les 5 signaux qui montrent que c'est mûr</h5>
+        <div class="signal-list">
+          ${CLOSING.signals.map(s=>`<div class="row">${s}</div>`).join('')}
+        </div>
+      </article>
+      ${CLOSING.scripts.map((s,i)=>`
+        <article class="close-script">
+          <h4>${s.name}</h4>
+          <div class="ctx">${s.ctx}</div>
+          <p>${s.body}</p>
+          <div class="script-actions" style="margin-top:10px;padding-top:8px">
+            <button class="btn copy" type="button" data-msg="close-${i}"><span class="ic">⌘C</span>Copier</button>
+            <button class="btn ghost" type="button">Variante</button>
+          </div>
+        </article>`).join('')}
+      ${localeTag()}
+    `;
+  }
+
+  function renderSpecial(){
+    const cases = [
+      {k:'ghost', label:'Ghost'},
+      {k:'reactivation', label:'Réactivation'},
+      {k:'reco', label:'Recommandation'}
+    ];
+    const active = state.caseTab;
+    const data = SPECIAL[active];
+    return `
+      <div class="case-tabs">
+        ${cases.map(c=>`<button class="${c.k===active?'on':''}" data-case="${c.k}" type="button">${c.label}</button>`).join('')}
+      </div>
+      <article class="card">
+        <h3 style="font-family:var(--f-display);font-weight:700;font-size:18px;letter-spacing:-.015em">${data.title}</h3>
+        <div style="font-size:13.5px;line-height:1.5;color:var(--ls-charcoal);margin:8px 0 10px;padding:12px 14px;background:var(--ls-surface2);border-radius:10px">
+          ${data.body}
+        </div>
+        <div style="font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-gold-dark);margin-bottom:6px">Règles</div>
+        <ul style="margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:6px">
+          ${data.tips.map(t=>`<li style="display:flex;gap:8px;font-size:13px;line-height:1.4"><span style="color:var(--ls-gold);font-weight:700">·</span>${t}</li>`).join('')}
+        </ul>
+        <div class="script-actions" style="margin-top:12px">
+          <button class="btn copy" type="button" data-msg="case-${active}"><span class="ic">⌘C</span>Copier</button>
+          <button class="btn ghost" type="button">Variante</button>
+        </div>
+      </article>
+      ${localeTag()}
+    `;
+  }
+
+  function renderStory(){
+    return `
+      <div class="story-struct">
+        ${STORY.acts.map(a=>`
+          <div class="seg ${a.gold?'gold':''}">
+            <div class="step">${a.step}</div>
+            <h6>${a.title}</h6>
+            <p>${a.body}</p>
+          </div>`).join('')}
+      </div>
+      ${STORY.examples.map((ex,i)=>`
+        <article class="story-example">
+          <div class="by">${ex.by}</div>
+          ${ex.body}
+          <div class="script-actions" style="margin-top:10px;padding-top:8px">
+            <button class="btn copy" type="button" data-msg="story-${i}"><span class="ic">⌘C</span>Copier l'exemple</button>
+          </div>
+        </article>`).join('')}
+      ${localeTag()}
+    `;
+  }
+
+  function renderRoutine(){
+    const done = Object.values(state.checks).filter(Boolean).length;
+    const total = ROUTINE.length;
+    return `
+      <article class="routine-summary">
+        <div class="big">${done}<span>/${total}</span><small>aujourd'hui</small></div>
+        <p>30 minutes par jour, <em style="color:var(--ls-gold-light);font-style:italic;font-weight:500">tous les jours</em>. Pas de routine = pas de pipeline.</p>
+      </article>
+      <article class="checklist">
+        ${ROUTINE.map((r,i)=>`
+          <div class="check-item ${state.checks[i]?'done':''}" data-i="${i}">
+            <div class="box"></div>
+            <div class="txt">${r.txt}</div>
+            <div class="mins">${r.mins}</div>
+          </div>`).join('')}
+      </article>
+      ${localeTag()}
+    `;
+  }
+
+  /* ── Wire body interactions ────────────────────────── */
+  function wireBody(root){
+    /* COPY buttons */
+    root.querySelectorAll('.btn.copy').forEach(btn=>{
+      btn.addEventListener('click', ()=>{
+        const text = btn.closest('article, .t-step, .check-item, .obj')?.innerText?.trim() || '';
+        try { navigator.clipboard?.writeText(text); } catch(e){}
+        toast('Copié ! <span style="color:rgba(255,255,255,.55);font-family:var(--f-mono);font-size:11px;margin-left:4px">— pense au prénom</span>');
+      });
+    });
+    /* J'ai envoyé */
+    root.querySelectorAll('.btn.send').forEach(btn=>{
+      btn.addEventListener('click', ()=>{
+        const key = btn.dataset.send;
+        if (!key || state.sentMap[key]) return;
+        state.sentMap[key] = true;
+        state.sent += 1;
+        const platform = btn.dataset.platform;
+        if (platform === 'wa') state.rdv += 1; // proxy for warm contact converting
+        $('#stat-sent').textContent = state.sent;
+        $('#stat-sent').classList.add('bumped');
+        $('#stat-rdv').textContent = state.rdv;
+        if (platform === 'wa') $('#stat-rdv').classList.add('bumped');
+        setTimeout(()=>{
+          $('#stat-sent').classList.remove('bumped');
+          $('#stat-rdv').classList.remove('bumped');
+        }, 1200);
+        $('#aside-sent') && ($('#aside-sent').textContent = state.sent);
+        $('#aside-rdv')  && ($('#aside-rdv').textContent  = state.rdv);
+        btn.classList.add('done');
+        btn.innerHTML = `<span class="ic">✓</span>Envoyé`;
+        const card = btn.closest('.script');
+        if (card) card.classList.add('sent');
+        toast(`Envoyé&nbsp;! <span style="color:rgba(255,255,255,.55);font-family:var(--f-mono);font-size:11px;margin-left:4px">+1 cette sem.</span>`);
+      });
+    });
+    /* Hashtag copy */
+    root.querySelectorAll('.htag[data-copy]').forEach(h=>{
+      h.addEventListener('click', ()=>{
+        try { navigator.clipboard?.writeText(h.dataset.copy); } catch(e){}
+        toast(`Copié&nbsp;: ${h.textContent}`);
+      });
+    });
+    /* Lang switch */
+    root.querySelectorAll('.lang-switch').forEach(ls=>{
+      ls.querySelectorAll('button').forEach(b=>{
+        b.addEventListener('click', ()=>{
+          const key = ls.dataset.key;
+          state.lang[key] = b.dataset.l;
+          renderBody();
+        });
+      });
+    });
+    /* Platform tabs */
+    root.querySelectorAll('.platform-tabs .tab').forEach(t=>{
+      t.addEventListener('click', ()=>{
+        state.platform = parseInt(t.dataset.i,10);
+        renderBody();
+      });
+    });
+    /* Special case tabs */
+    root.querySelectorAll('.case-tabs button').forEach(b=>{
+      b.addEventListener('click', ()=>{
+        state.caseTab = b.dataset.case;
+        renderBody();
+      });
+    });
+    /* Routine checks */
+    root.querySelectorAll('.check-item').forEach(it=>{
+      it.addEventListener('click', ()=>{
+        const i = parseInt(it.dataset.i,10);
+        state.checks[i] = !state.checks[i];
+        renderBody();
+      });
+    });
+  }
+
+  /* INIT */
+  renderAll(false);
+
+})();

--- a/docs/mockups/prospection-v4-prototype.html
+++ b/docs/mockups/prospection-v4-prototype.html
@@ -1,0 +1,938 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Prospection · La Base 360 — Prototype</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Syne:wght@500;600;700;800&family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+<style>
+:root{
+  --ls-gold:#C9A84C;
+  --ls-gold-light:#E5C97D;
+  --ls-gold-dark:#8E7430;
+  --ls-teal:#2DD4BF;
+  --ls-teal-dark:#0F766E;
+  --ls-coral:#FB7185;
+  --ls-coral-dark:#BE3242;
+  --ls-purple:#7C3AED;
+  --ls-charcoal:#0B0D11;
+  --ls-cream:#FBF7F0;
+  --ls-surface:#FFFFFF;
+  --ls-surface2:#F7F3EC;
+  --ls-line:rgba(11,13,17,.08);
+  --ls-line-2:rgba(11,13,17,.14);
+  --ls-muted:rgba(11,13,17,.56);
+  --ls-muted-2:rgba(11,13,17,.40);
+  --f-display:"Syne", "Times New Roman", serif;
+  --f-body:"DM Sans", system-ui, sans-serif;
+  --f-mono:"JetBrains Mono", ui-monospace, Menlo, monospace;
+  --phone-scale:1;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;height:100%}
+body{
+  font-family:var(--f-body);
+  background:#EFE9DC;
+  color:var(--ls-charcoal);
+  -webkit-font-smoothing:antialiased;
+  text-rendering:optimizeLegibility;
+  overflow:hidden;
+}
+
+.stage{
+  position:fixed;inset:0;
+  display:grid;
+  grid-template-columns:1fr auto 1fr;
+  grid-template-areas:"left phone right";
+  align-items:center;
+  padding:18px;
+  gap:24px;
+  background:
+    radial-gradient(circle at 20% 10%, rgba(201,168,76,.10), transparent 50%),
+    radial-gradient(circle at 90% 90%, rgba(45,212,191,.08), transparent 50%),
+    #EFE9DC;
+}
+.stage-aside{
+  grid-area:left;
+  min-width:0;max-width:280px;
+  font-family:var(--f-mono);
+  font-size:11px;line-height:1.7;
+  color:var(--ls-muted);
+  justify-self:end;align-self:start;
+  padding-top:32px;
+}
+.stage-aside.right{grid-area:right;justify-self:start;padding-top:32px}
+.stage-aside h6{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--ls-gold-dark);margin:0 0 8px;
+}
+.stage-aside .brand-mark{
+  font-family:var(--f-display);font-weight:700;font-size:15px;letter-spacing:-.01em;
+  color:var(--ls-charcoal);text-transform:none;margin-bottom:14px;display:flex;align-items:center;gap:8px;
+}
+.stage-aside .brand-mark .gem{
+  width:14px;height:14px;border-radius:4px;
+  background:linear-gradient(135deg,var(--ls-gold),#fff5d0);
+  box-shadow:0 0 0 1px rgba(142,116,48,.4) inset;
+}
+.stage-aside kbd{
+  font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);
+  background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;padding:1px 6px;
+}
+.stage-aside .hint-row{display:flex;gap:6px;align-items:center;margin:3px 0}
+.stage-aside .hint-row span:last-child{flex:1;text-transform:none}
+.stage-aside b{color:var(--ls-charcoal);font-weight:600}
+.stage-aside .live{
+  display:inline-flex;align-items:center;gap:6px;
+  font-family:var(--f-body);font-size:12px;color:var(--ls-charcoal);font-weight:500;
+}
+.stage-aside .live::before{
+  content:"";width:6px;height:6px;border-radius:50%;background:var(--ls-teal);
+  box-shadow:0 0 0 3px rgba(45,212,191,.18);
+}
+
+.phone-wrap{
+  grid-area:phone;
+  transform:scale(var(--phone-scale));
+  transform-origin:center center;
+  transition:transform .25s;
+}
+.phone{
+  position:relative;
+  width:413px;height:850px;
+  background:#0B0D11;
+  border-radius:54px;
+  padding:10px;
+  box-shadow:
+    0 0 0 2px rgba(255,255,255,.06) inset,
+    0 30px 60px -20px rgba(11,13,17,.35),
+    0 60px 120px -40px rgba(11,13,17,.25);
+}
+.phone .screen{
+  position:relative;
+  width:100%;height:100%;
+  border-radius:44px;
+  overflow:hidden;
+  background:var(--ls-cream);
+  display:flex;flex-direction:column;
+}
+.phone .notch{
+  position:absolute;top:14px;left:50%;transform:translateX(-50%);
+  width:104px;height:32px;background:#0B0D11;border-radius:20px;z-index:30;
+}
+.phone .home-indicator{
+  position:absolute;left:50%;bottom:8px;transform:translateX(-50%);
+  width:130px;height:5px;border-radius:3px;background:rgba(11,13,17,.85);z-index:30;
+}
+
+/* status */
+.status{
+  flex:0 0 auto;height:54px;
+  display:flex;align-items:flex-end;justify-content:space-between;
+  padding:0 30px 8px;
+  font-family:var(--f-body);font-weight:600;font-size:15px;
+  background:var(--ls-cream);
+}
+.status .right{display:flex;gap:6px;align-items:center}
+
+/* header */
+.hdr{
+  flex:0 0 auto;
+  background:var(--ls-cream);
+  padding:6px 18px 12px;
+  border-bottom:1px solid var(--ls-line);
+  position:relative;z-index:5;
+}
+.hdr .row1{
+  display:flex;align-items:center;justify-content:space-between;gap:10px;
+  padding:4px 2px 8px;
+}
+.brand{
+  display:flex;align-items:center;gap:8px;
+  font-family:var(--f-display);font-weight:700;font-size:15px;letter-spacing:-.01em;
+}
+.brand .gem{
+  width:18px;height:18px;border-radius:5px;
+  background:linear-gradient(135deg,var(--ls-gold) 0%,var(--ls-gold-light) 60%, #fff7d6 100%);
+  box-shadow:0 0 0 1px rgba(142,116,48,.3) inset;position:relative;
+}
+.brand .gem::after{
+  content:"";position:absolute;inset:3px;border-radius:3px;
+  background:radial-gradient(circle at 30% 30%, rgba(255,255,255,.7), transparent 60%);
+}
+.brand small{
+  font-family:var(--f-mono);font-weight:400;font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--ls-muted);margin-left:4px;align-self:center;
+}
+.stat-chip{
+  display:flex;align-items:center;gap:7px;
+  padding:5px 10px 5px 8px;border-radius:99px;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  font-family:var(--f-mono);font-size:11px;cursor:pointer;
+  transition:background .15s, border-color .15s;
+}
+.stat-chip:hover{border-color:var(--ls-line-2);background:#fff}
+.stat-chip .dot-live{
+  width:6px;height:6px;border-radius:50%;background:var(--ls-teal);
+  box-shadow:0 0 0 3px rgba(45,212,191,.18);
+}
+.stat-chip b{font-weight:600;color:var(--ls-charcoal);transition:color .2s}
+.stat-chip b.bumped{color:var(--ls-gold-dark)}
+
+.pickers{display:flex;gap:8px;align-items:stretch}
+.picker{
+  flex:1;min-width:0;
+  display:flex;align-items:center;gap:8px;
+  padding:9px 10px 9px 12px;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  border-radius:12px;font-size:13px;font-weight:500;
+  cursor:pointer;
+  transition:background .15s, border-color .15s, box-shadow .15s;
+}
+.picker:hover{border-color:var(--ls-line-2)}
+.picker:active{transform:scale(.985)}
+.picker.opening{border-color:var(--ls-gold);box-shadow:0 0 0 3px rgba(201,168,76,.15)}
+.picker .lbl{
+  font-family:var(--f-mono);font-size:9px;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--ls-muted);display:block;
+}
+.picker .val{
+  font-family:var(--f-body);font-weight:600;font-size:13.5px;
+  color:var(--ls-charcoal);display:flex;align-items:center;gap:6px;line-height:1.15;margin-top:1px;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+.picker .flag{
+  display:inline-flex;align-items:center;justify-content:center;
+  width:22px;height:16px;border-radius:3px;overflow:hidden;font-size:14px;line-height:1;
+  background:#eee;flex:0 0 auto;
+}
+.picker .glyph{
+  width:22px;height:22px;border-radius:6px;flex:0 0 auto;
+  display:inline-flex;align-items:center;justify-content:center;
+  background:linear-gradient(135deg,#fff,#F7F0DC);
+  border:1px solid var(--ls-line);font-size:13px;
+}
+.picker .caret{margin-left:auto;width:14px;height:14px;flex:0 0 auto;opacity:.5}
+.picker .info-stack{display:flex;flex-direction:column;justify-content:center;min-width:0;flex:1}
+
+/* index rail */
+.index{
+  margin-top:10px;
+  display:flex;align-items:stretch;gap:0;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  border-radius:12px;padding:5px;position:relative;
+  overflow-x:auto;scroll-behavior:smooth;
+  scrollbar-width:none;
+}
+.index::-webkit-scrollbar{display:none}
+.index .step{
+  flex:0 0 auto;
+  display:flex;align-items:center;gap:6px;
+  padding:7px 8px;border-radius:8px;
+  font-family:var(--f-mono);font-size:11px;font-weight:500;
+  color:var(--ls-muted);
+  white-space:nowrap;cursor:pointer;
+  transition:background .15s, color .15s;
+  border:none;background:transparent;
+}
+.index .step:hover{color:var(--ls-charcoal)}
+.index .step .n{font-family:var(--f-mono);font-weight:500;font-size:10px;letter-spacing:.06em;color:var(--ls-muted-2)}
+.index .step .ic{font-family:var(--f-body);font-size:13px;line-height:1}
+.index .step .name{
+  display:none;font-family:var(--f-body);font-weight:600;font-size:12.5px;color:var(--ls-charcoal);
+  letter-spacing:-.005em;
+}
+.index .step.active{
+  background:var(--ls-charcoal);color:#fff;
+  box-shadow:0 1px 0 rgba(0,0,0,.04);
+}
+.index .step.active .n{color:var(--ls-gold-light)}
+.index .step.active .name{display:inline;color:#fff}
+.index .step.done{color:var(--ls-charcoal)}
+.index .step.done .n{color:var(--ls-gold-dark)}
+
+/* section meta */
+.section-meta{
+  display:flex;align-items:center;justify-content:space-between;gap:10px;
+  padding:14px 22px 6px;
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);
+}
+.section-meta .step-of b{color:var(--ls-charcoal);font-weight:600}
+
+/* section heading */
+.section-head{padding:0 22px 14px}
+.section-head .kicker{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-gold-dark);
+  display:flex;align-items:center;gap:8px;margin-bottom:6px;
+}
+.section-head .kicker::before{content:"";width:18px;height:1px;background:var(--ls-gold)}
+.section-head h2{
+  font-family:var(--f-display);font-weight:700;font-size:30px;line-height:1;letter-spacing:-.025em;margin:0 0 8px;
+}
+.section-head h2 .em{font-style:italic;font-weight:500;color:var(--ls-gold-dark)}
+.section-head p.lede{
+  font-family:var(--f-body);font-size:13.5px;line-height:1.5;color:var(--ls-muted);
+  margin:0;max-width:38ch;
+}
+
+/* body */
+.body{
+  flex:1 1 auto;overflow-y:auto;overflow-x:hidden;
+  padding:0 0 14px;position:relative;
+  scrollbar-width:thin;scrollbar-color:rgba(11,13,17,.2) transparent;
+  -webkit-mask-image:linear-gradient(180deg,#000 0,#000 calc(100% - 18px),transparent);
+          mask-image:linear-gradient(180deg,#000 0,#000 calc(100% - 18px),transparent);
+}
+.body::-webkit-scrollbar{width:0}
+.body-inner{padding:0 22px;transition:opacity .18s ease, transform .22s ease}
+.body-inner.swapping{opacity:0;transform:translateY(4px)}
+
+/* cards */
+.card{
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  border-radius:14px;padding:14px 16px;margin-bottom:10px;
+}
+.card h3{
+  font-family:var(--f-display);font-weight:700;font-size:18px;line-height:1.1;
+  letter-spacing:-.015em;margin:0 0 6px;
+}
+
+/* bottom nav */
+.botnav{
+  flex:0 0 auto;
+  background:rgba(251,247,240,.94);
+  backdrop-filter:saturate(140%) blur(12px);
+  border-top:1px solid var(--ls-line);
+  padding:10px 14px 22px;
+  display:flex;align-items:center;justify-content:space-between;gap:6px;
+}
+.btn-nav{
+  display:flex;align-items:center;gap:8px;flex:1;min-width:0;
+  padding:8px 10px;border-radius:10px;
+  font-family:var(--f-body);font-size:12px;font-weight:500;
+  color:var(--ls-charcoal);background:transparent;border:none;
+  cursor:pointer;text-align:left;
+}
+.btn-nav:disabled{opacity:.4;cursor:not-allowed}
+.btn-nav .arr{
+  width:28px;height:28px;border-radius:50%;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  display:flex;align-items:center;justify-content:center;flex:0 0 auto;
+}
+.btn-nav .lab{display:flex;flex-direction:column;line-height:1.2;min-width:0;flex:1}
+.btn-nav .lab small{font-family:var(--f-mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted)}
+.btn-nav .lab span{font-weight:600;font-size:12.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.btn-nav.next{flex-direction:row-reverse;text-align:right}
+.btn-nav.next .lab{align-items:flex-end}
+.dots{display:flex;align-items:center;gap:5px;padding:0 2px;flex:0 0 auto}
+.dots .d{width:5px;height:5px;border-radius:50%;background:rgba(11,13,17,.15);transition:background .2s, width .25s}
+.dots .d.on{background:var(--ls-gold);width:18px;border-radius:3px}
+.dots .d.done{background:var(--ls-gold-dark)}
+
+/* TRUTH */
+.truth{
+  background:var(--ls-charcoal);color:#fff;border-radius:18px;padding:18px 18px 16px;margin-bottom:12px;
+  position:relative;overflow:hidden;
+}
+.truth::before{
+  content:"";position:absolute;right:-30px;top:-30px;width:120px;height:120px;
+  background:radial-gradient(circle,rgba(201,168,76,.35),transparent 70%);pointer-events:none;
+}
+.truth .num{
+  font-family:var(--f-display);font-weight:700;font-size:54px;line-height:.9;color:var(--ls-gold);letter-spacing:-.04em;
+}
+.truth .kicker{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--ls-gold-light);margin-bottom:6px;
+}
+.truth .quote{
+  font-family:var(--f-display);font-weight:600;font-size:21px;line-height:1.15;letter-spacing:-.015em;margin:6px 0 0;
+}
+.truth .quote em{color:var(--ls-gold-light);font-style:italic;font-weight:500}
+.truth .by{font-family:var(--f-body);font-style:italic;font-size:12px;color:rgba(255,255,255,.55);margin-top:10px}
+.truth-row{display:grid;grid-template-columns:auto 1fr;gap:14px;align-items:flex-start}
+
+.truth-lite{
+  background:linear-gradient(180deg,#fff,var(--ls-surface2));
+  border:1px solid var(--ls-line);
+  border-radius:14px;padding:14px 16px;margin-bottom:10px;
+}
+.truth-lite .ctx{font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:4px}
+.truth-lite p{
+  font-family:var(--f-display);font-weight:600;font-size:19px;line-height:1.2;letter-spacing:-.015em;margin:0;
+}
+.truth-lite em{color:var(--ls-gold-dark);font-style:italic;font-weight:500}
+
+.errors-head{display:flex;align-items:baseline;justify-content:space-between;margin:18px 0 8px}
+.errors-head .label{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-coral-dark);
+  display:flex;align-items:center;gap:6px;
+}
+.errors-head .label::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--ls-coral)}
+.err{display:flex;align-items:flex-start;gap:12px;padding:11px 4px;border-top:1px solid var(--ls-line)}
+.err .n{font-family:var(--f-mono);font-size:11px;color:var(--ls-coral-dark);font-weight:500;width:22px;flex:0 0 auto;letter-spacing:.05em}
+.err .txt{font-size:13.5px;line-height:1.4;color:var(--ls-charcoal)}
+.err .txt .strike{color:var(--ls-muted);text-decoration:line-through;text-decoration-thickness:1px}
+
+/* MESSAGES */
+.platform-tabs{
+  display:flex;gap:6px;margin-bottom:14px;padding:4px;
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:11px;
+}
+.platform-tabs .tab{
+  flex:1;display:flex;flex-direction:column;align-items:center;gap:2px;
+  padding:7px 4px;border-radius:8px;
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.06em;text-transform:uppercase;
+  color:var(--ls-muted);cursor:pointer;background:transparent;border:none;
+  transition:background .15s, color .15s;
+}
+.platform-tabs .tab .ic{font-family:var(--f-body);font-size:15px;line-height:1}
+.platform-tabs .tab.on{background:var(--ls-charcoal);color:#fff}
+.platform-tabs .tab:hover:not(.on){background:var(--ls-surface2)}
+
+.script{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:14px;
+  padding:14px 16px;margin-bottom:10px;position:relative;
+  transition:border-color .2s;
+}
+.script.sent{border-color:rgba(45,212,191,.5);box-shadow:0 0 0 3px rgba(45,212,191,.08)}
+.script .head{display:flex;align-items:center;gap:8px;margin-bottom:10px}
+.script .head .glyph{
+  width:26px;height:26px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:14px;
+  background:var(--ls-surface2);border:1px solid var(--ls-line);
+}
+.script .head h4{font-family:var(--f-display);font-weight:700;font-size:16px;margin:0;letter-spacing:-.01em}
+.script .head .sub{font-family:var(--f-mono);font-size:9.5px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted)}
+.script .ctx{font-family:var(--f-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:6px;display:flex;align-items:center;gap:6px}
+.script .ctx::before{content:"";width:14px;height:1px;background:var(--ls-line-2)}
+
+.lang-switch{
+  display:inline-flex;align-items:center;gap:0;
+  background:var(--ls-surface2);border:1px solid var(--ls-line);border-radius:99px;padding:2px;
+  font-family:var(--f-mono);font-size:10px;font-weight:500;letter-spacing:.02em;margin-left:auto;
+}
+.lang-switch button{
+  border:none;background:transparent;padding:4px 9px;border-radius:99px;color:var(--ls-muted);cursor:pointer;font:inherit;
+  transition:background .15s, color .15s;
+}
+.lang-switch button.on{background:var(--ls-charcoal);color:#fff}
+
+.msg-body{
+  font-family:var(--f-body);font-size:14px;line-height:1.55;color:var(--ls-charcoal);
+  padding:12px 0 4px;border-top:1px dashed var(--ls-line-2);
+}
+.msg-body p{margin:0 0 8px}
+.msg-body p:last-child{margin-bottom:0}
+.var{
+  display:inline-block;font-family:var(--f-body);font-weight:600;font-size:13.5px;
+  color:var(--ls-gold-dark);background:rgba(201,168,76,.12);
+  padding:1px 7px;border-radius:4px;border:1px dashed rgba(201,168,76,.5);
+  margin:0 1px;line-height:1.2;
+}
+.var.teal{color:var(--ls-teal-dark);background:rgba(45,212,191,.13);border-color:rgba(15,118,110,.4)}
+
+.trad-line{
+  font-family:var(--f-body);font-style:italic;font-size:12.5px;line-height:1.5;color:var(--ls-muted);
+  padding:8px 0 0;border-top:1px dashed var(--ls-line);margin-top:8px;
+}
+.trad-line::before{
+  content:"FR";font-family:var(--f-mono);font-style:normal;font-size:9px;letter-spacing:.14em;
+  background:var(--ls-surface2);padding:2px 5px;border-radius:3px;color:var(--ls-muted);
+  margin-right:7px;vertical-align:1px;
+}
+
+.script-actions{
+  display:flex;align-items:center;gap:6px;margin-top:10px;
+  padding-top:8px;border-top:1px solid var(--ls-line);
+}
+.btn{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:7px 11px;border-radius:8px;
+  font-family:var(--f-body);font-weight:600;font-size:12px;
+  border:1px solid var(--ls-line);background:var(--ls-surface);
+  color:var(--ls-charcoal);cursor:pointer;line-height:1;
+  transition:background .15s, border-color .15s, transform .1s;
+}
+.btn:hover{border-color:var(--ls-line-2)}
+.btn:active{transform:scale(.97)}
+.btn.copy{background:var(--ls-charcoal);color:#fff;border-color:transparent}
+.btn.copy .ic{color:var(--ls-gold-light)}
+.btn.send{background:var(--ls-surface);border-color:var(--ls-gold);color:var(--ls-gold-dark)}
+.btn.send.done{background:var(--ls-teal-dark);color:#fff;border-color:transparent}
+.btn .ic{font-family:var(--f-mono);font-size:11px;line-height:1}
+.btn.ghost{background:transparent;border-color:transparent;color:var(--ls-muted);padding:7px 8px}
+.script-actions .spacer{flex:1}
+.script-actions .stat-mini{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted);
+  display:flex;align-items:center;gap:5px;
+}
+.script-actions .stat-mini b{font-family:var(--f-body);font-weight:700;font-size:12px;letter-spacing:0;text-transform:none;color:var(--ls-charcoal)}
+
+/* OBJ */
+.obj{border-bottom:1px solid var(--ls-line);padding:16px 0 18px}
+.obj:first-child{padding-top:6px}
+.obj:last-child{border-bottom:none}
+.obj .quote{display:flex;gap:10px;align-items:flex-start}
+.obj .quote .n{font-family:var(--f-display);font-weight:700;font-size:24px;line-height:1;color:var(--ls-charcoal);letter-spacing:-.03em;flex:0 0 auto;width:34px}
+.obj .quote .n small{font-family:var(--f-mono);font-size:9px;letter-spacing:.14em;color:var(--ls-muted);font-weight:500;display:block;line-height:1.6}
+.obj .quote q{
+  font-family:var(--f-display);font-weight:600;font-style:italic;font-size:18px;line-height:1.2;letter-spacing:-.01em;quotes:none;color:var(--ls-charcoal);
+}
+.obj .quote q::before{content:"«\00a0"}
+.obj .quote q::after{content:"\00a0»"}
+.obj-row{display:grid;grid-template-columns:24px 1fr;gap:10px;align-items:flex-start;margin-top:10px}
+.obj-row .badge{
+  display:inline-flex;align-items:center;justify-content:center;
+  width:22px;height:22px;border-radius:6px;font-family:var(--f-mono);font-size:11px;font-weight:600;margin-top:2px;
+}
+.obj-row.bad .badge{background:rgba(251,113,133,.14);color:var(--ls-coral-dark);border:1px solid rgba(251,113,133,.3)}
+.obj-row.good .badge{background:rgba(45,212,191,.16);color:var(--ls-teal-dark);border:1px solid rgba(15,118,110,.25)}
+.obj-row .lbl{font-family:var(--f-mono);font-size:9px;letter-spacing:.16em;text-transform:uppercase;font-weight:600}
+.obj-row.bad .lbl{color:var(--ls-coral-dark)}
+.obj-row.good .lbl{color:var(--ls-teal-dark)}
+.obj-row p{margin:2px 0 0;font-size:13.5px;line-height:1.45;color:var(--ls-charcoal)}
+.obj-row.bad p{color:var(--ls-muted);text-decoration:line-through;text-decoration-color:rgba(251,113,133,.35);text-decoration-thickness:1px}
+.obj-row.good p .var{font-weight:600}
+.obj-actions{display:flex;gap:6px;margin-top:12px;align-items:center}
+
+/* TROUVER */
+.flags{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:14px}
+.flag-col{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:12px;padding:11px 12px;
+}
+.flag-col.green{background:linear-gradient(180deg,rgba(45,212,191,.07),transparent 60%),#fff}
+.flag-col.red{background:linear-gradient(180deg,rgba(251,113,133,.07),transparent 60%),#fff}
+.flag-col h5{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+  margin:0 0 8px;display:flex;align-items:center;gap:6px;
+}
+.flag-col.green h5{color:var(--ls-teal-dark)}
+.flag-col.red h5{color:var(--ls-coral-dark)}
+.flag-col h5 .dot{width:7px;height:7px;border-radius:50%}
+.flag-col.green h5 .dot{background:var(--ls-teal);box-shadow:0 0 0 3px rgba(45,212,191,.2)}
+.flag-col.red h5 .dot{background:var(--ls-coral);box-shadow:0 0 0 3px rgba(251,113,133,.2)}
+.flag-col ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px}
+.flag-col li{font-size:12.5px;line-height:1.35;color:var(--ls-charcoal);display:flex;gap:6px;align-items:flex-start}
+.flag-col li::before{content:"";flex:0 0 auto;width:4px;height:4px;border-radius:50%;margin-top:7px}
+.flag-col.green li::before{background:var(--ls-teal-dark)}
+.flag-col.red li::before{background:var(--ls-coral-dark)}
+
+.scan-timer{
+  display:inline-flex;align-items:center;gap:6px;
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--ls-gold-dark);background:rgba(201,168,76,.12);padding:4px 9px;border-radius:99px;margin-bottom:10px;
+}
+.scan-timer .pulse{width:6px;height:6px;border-radius:50%;background:var(--ls-gold);box-shadow:0 0 0 3px rgba(201,168,76,.25)}
+
+.hashtag-card{background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:14px;padding:13px 14px;margin-bottom:10px}
+.hashtag-card .htag-head{display:flex;align-items:center;justify-content:space-between;font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:8px}
+.hashtag-card .htag-head b{color:var(--ls-charcoal);font-weight:600}
+.htag-row{display:flex;flex-wrap:wrap;gap:5px;margin-bottom:9px}
+.htag-row:last-child{margin-bottom:0}
+.htag-row .cat{font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted);align-self:center;margin-right:4px}
+.htag{font-family:var(--f-mono);font-size:11.5px;font-weight:500;padding:3px 8px;border-radius:99px;background:var(--ls-surface2);color:var(--ls-charcoal);border:1px solid var(--ls-line);cursor:pointer;transition:transform .1s, background .15s}
+.htag:active{transform:scale(.96)}
+.htag.gold{background:rgba(201,168,76,.13);border-color:rgba(201,168,76,.3);color:var(--ls-gold-dark)}
+.htag.teal{background:rgba(45,212,191,.13);border-color:rgba(15,118,110,.25);color:var(--ls-teal-dark)}
+.htag.purple{background:rgba(124,58,237,.10);border-color:rgba(124,58,237,.25);color:var(--ls-purple)}
+
+.src-card{background:var(--ls-charcoal);color:#fff;border-radius:14px;padding:14px 16px;margin-bottom:10px;position:relative;overflow:hidden}
+.src-card::before{content:"";position:absolute;left:-30px;bottom:-30px;width:100px;height:100px;background:radial-gradient(circle,rgba(201,168,76,.4),transparent 70%)}
+.src-card h4{font-family:var(--f-display);font-weight:700;font-size:16px;margin:0 0 4px;letter-spacing:-.01em;position:relative}
+.src-card .kk{font-family:var(--f-mono);font-size:9.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-gold-light);margin-bottom:8px}
+.src-row{display:grid;grid-template-columns:46px 1fr;gap:10px;align-items:flex-start;padding:8px 0;border-top:1px solid rgba(255,255,255,.10)}
+.src-row:first-of-type{border-top:none}
+.src-row .src-lab{font-family:var(--f-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ls-gold-light);font-weight:500;padding-top:2px}
+.src-row .src-body{font-size:13px;line-height:1.45;color:rgba(255,255,255,.86)}
+.src-row .src-body em{color:#fff;font-style:italic;font-weight:500}
+
+/* TREE */
+.tree-branch{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:14px;
+  padding:14px 16px;margin-bottom:10px;
+}
+.tree-branch .reaction{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--ls-muted);margin-bottom:6px;display:flex;align-items:center;gap:8px;
+}
+.tree-branch .reaction .pill{
+  background:var(--ls-surface2);padding:3px 8px;border-radius:99px;color:var(--ls-charcoal);
+  font-family:var(--f-mono);font-size:10px;font-weight:500;letter-spacing:.06em;text-transform:none;
+}
+.tree-branch .reaction .pill.warm{background:rgba(45,212,191,.13);color:var(--ls-teal-dark)}
+.tree-branch .reaction .pill.cold{background:rgba(251,113,133,.13);color:var(--ls-coral-dark)}
+.tree-branch .reaction .pill.maybe{background:rgba(201,168,76,.13);color:var(--ls-gold-dark)}
+.tree-branch q{
+  font-family:var(--f-display);font-style:italic;font-weight:600;font-size:16px;line-height:1.2;
+  color:var(--ls-charcoal);quotes:none;display:block;margin-bottom:6px;
+}
+.tree-branch q::before{content:"«\00a0"}.tree-branch q::after{content:"\00a0»"}
+.tree-branch .reply{
+  font-size:13.5px;line-height:1.45;color:var(--ls-charcoal);
+  padding:10px 0 0;border-top:1px dashed var(--ls-line-2);margin-top:6px;
+}
+.tree-branch .reply::before{
+  content:"→ tu réponds";display:block;font-family:var(--f-mono);font-size:9.5px;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--ls-teal-dark);margin-bottom:4px;font-weight:600;
+}
+.tree-branch .actions{display:flex;gap:6px;margin-top:10px;padding-top:8px;border-top:1px solid var(--ls-line)}
+
+/* TIMELINE */
+.timeline{position:relative;padding-left:28px;margin-bottom:10px}
+.timeline::before{
+  content:"";position:absolute;left:9px;top:6px;bottom:6px;width:1.5px;
+  background:linear-gradient(180deg,var(--ls-gold),var(--ls-line-2));
+}
+.t-step{margin-bottom:14px;position:relative}
+.t-step::before{
+  content:"";position:absolute;left:-24px;top:7px;width:13px;height:13px;border-radius:50%;
+  background:var(--ls-cream);border:2px solid var(--ls-gold);
+}
+.t-step.now::before{background:var(--ls-gold);box-shadow:0 0 0 4px rgba(201,168,76,.2)}
+.t-step.future::before{background:var(--ls-cream);border-color:var(--ls-line-2)}
+.t-step .when{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-gold-dark);font-weight:600;margin-bottom:4px;
+}
+.t-step.future .when{color:var(--ls-muted)}
+.t-step h4{font-family:var(--f-display);font-weight:700;font-size:16px;margin:0 0 4px;letter-spacing:-.01em}
+.t-step .msg{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:10px;padding:10px 12px;
+  font-size:13px;line-height:1.45;color:var(--ls-charcoal);margin-top:6px;
+}
+.t-step .msg + .actions{margin-top:8px;display:flex;gap:6px}
+
+/* CLOSING */
+.signal-card{
+  background:linear-gradient(180deg,rgba(45,212,191,.07),transparent 50%),#fff;
+  border:1px solid var(--ls-line);border-radius:14px;padding:13px 14px;margin-bottom:10px;
+}
+.signal-card h5{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-teal-dark);
+  margin:0 0 8px;display:flex;align-items:center;gap:6px;
+}
+.signal-card h5::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--ls-teal);box-shadow:0 0 0 3px rgba(45,212,191,.2)}
+.signal-list{display:flex;flex-direction:column;gap:6px}
+.signal-list .row{display:flex;gap:8px;font-size:13px;line-height:1.4;align-items:flex-start}
+.signal-list .row::before{content:"✓";color:var(--ls-teal-dark);font-weight:700;font-size:13px;margin-top:1px}
+
+.close-script{
+  background:#fff;border:1px solid var(--ls-line);border-radius:14px;padding:13px 16px;margin-bottom:10px;
+}
+.close-script h4{font-family:var(--f-display);font-weight:700;font-size:16px;margin:0 0 4px;letter-spacing:-.01em}
+.close-script .ctx{font-family:var(--f-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:8px}
+.close-script p{margin:0;font-size:13.5px;line-height:1.5}
+
+/* SPECIAL CASES */
+.case-tabs{display:flex;gap:6px;margin-bottom:12px;padding:4px;background:#fff;border:1px solid var(--ls-line);border-radius:11px}
+.case-tabs button{
+  flex:1;padding:8px 6px;border:none;background:transparent;border-radius:8px;cursor:pointer;
+  font-family:var(--f-body);font-weight:600;font-size:12px;color:var(--ls-muted);
+  transition:background .15s, color .15s;
+}
+.case-tabs button.on{background:var(--ls-charcoal);color:#fff}
+
+/* STORYTELLING */
+.story-struct{
+  display:grid;grid-template-columns:repeat(3,1fr);gap:6px;margin-bottom:14px;
+}
+.story-struct .seg{
+  background:#fff;border:1px solid var(--ls-line);border-radius:10px;padding:10px;
+  text-align:center;
+}
+.story-struct .seg .step{
+  font-family:var(--f-mono);font-size:9px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);font-weight:600;
+}
+.story-struct .seg h6{font-family:var(--f-display);font-weight:700;font-size:14px;margin:6px 0 4px;letter-spacing:-.01em}
+.story-struct .seg p{margin:0;font-size:11.5px;color:var(--ls-muted);line-height:1.35}
+.story-struct .seg.gold{background:linear-gradient(180deg,rgba(201,168,76,.15),transparent),#fff;border-color:rgba(201,168,76,.3)}
+
+.story-example{
+  background:#fff;border:1px solid var(--ls-line);border-radius:14px;padding:14px 16px;margin-bottom:10px;
+}
+.story-example .by{font-family:var(--f-mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:6px}
+.story-example p{margin:0 0 8px;font-size:13.5px;line-height:1.5}
+.story-example p:last-child{margin-bottom:0}
+.story-example p em{color:var(--ls-gold-dark);font-style:italic;font-weight:500}
+
+/* ROUTINE */
+.routine-summary{
+  background:var(--ls-charcoal);color:#fff;border-radius:14px;padding:14px 16px;margin-bottom:12px;
+  display:grid;grid-template-columns:auto 1fr;gap:14px;align-items:center;
+}
+.routine-summary .big{
+  font-family:var(--f-display);font-weight:700;font-size:42px;line-height:.9;color:var(--ls-gold);letter-spacing:-.04em;
+}
+.routine-summary .big small{font-family:var(--f-body);font-weight:500;font-size:14px;color:rgba(255,255,255,.6);display:block;letter-spacing:0;margin-top:4px}
+.routine-summary p{margin:0;font-size:13.5px;line-height:1.4;color:rgba(255,255,255,.86)}
+
+.checklist{background:#fff;border:1px solid var(--ls-line);border-radius:14px;padding:6px 14px;margin-bottom:10px}
+.check-item{
+  display:flex;align-items:flex-start;gap:10px;padding:11px 0;border-top:1px solid var(--ls-line);
+  cursor:pointer;
+}
+.check-item:first-child{border-top:none}
+.check-item .box{
+  flex:0 0 auto;width:20px;height:20px;border-radius:6px;border:1.5px solid var(--ls-line-2);
+  background:#fff;display:flex;align-items:center;justify-content:center;margin-top:1px;
+  transition:background .15s, border-color .15s;
+}
+.check-item.done .box{background:var(--ls-gold);border-color:var(--ls-gold)}
+.check-item.done .box::after{content:"✓";color:#fff;font-weight:700;font-size:12px}
+.check-item .txt{font-size:13.5px;line-height:1.4;color:var(--ls-charcoal);flex:1}
+.check-item.done .txt{color:var(--ls-muted);text-decoration:line-through;text-decoration-thickness:1px}
+.check-item .mins{font-family:var(--f-mono);font-size:10px;color:var(--ls-muted);letter-spacing:.1em;align-self:center}
+
+/* TOAST */
+.toast{
+  position:absolute;left:50%;bottom:96px;transform:translateX(-50%);
+  background:var(--ls-charcoal);color:#fff;
+  padding:9px 14px;border-radius:99px;
+  font-family:var(--f-body);font-size:12.5px;font-weight:500;
+  display:flex;align-items:center;gap:8px;
+  box-shadow:0 8px 20px rgba(11,13,17,.3);
+  z-index:40;opacity:0;pointer-events:none;
+  transition:opacity .2s ease, transform .2s ease;
+}
+.toast.show{opacity:1;pointer-events:auto;transform:translateX(-50%) translateY(0)}
+.toast.hide{opacity:0;transform:translateX(-50%) translateY(6px)}
+.toast .ic{color:var(--ls-gold-light);font-family:var(--f-mono);font-size:11px}
+
+/* BOTTOM SHEET */
+.sheet-backdrop{
+  position:absolute;inset:0;background:rgba(11,13,17,0);
+  opacity:0;pointer-events:none;transition:opacity .25s ease;
+  z-index:50;
+}
+.sheet-backdrop.open{background:rgba(11,13,17,.45);opacity:1;pointer-events:auto}
+.sheet{
+  position:absolute;left:0;right:0;bottom:0;
+  background:var(--ls-cream);border-radius:24px 24px 0 0;
+  transform:translateY(110%);transition:transform .3s cubic-bezier(.2,.85,.3,1);
+  z-index:55;max-height:80%;overflow:hidden;display:flex;flex-direction:column;
+}
+.sheet.open{transform:translateY(0)}
+.sheet .grab{
+  width:40px;height:5px;background:var(--ls-line-2);border-radius:3px;margin:10px auto 6px;
+}
+.sheet .sheet-head{
+  padding:6px 22px 14px;border-bottom:1px solid var(--ls-line);
+}
+.sheet .sheet-head .kicker{font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-gold-dark);margin-bottom:4px}
+.sheet .sheet-head h3{font-family:var(--f-display);font-weight:700;font-size:22px;margin:0;letter-spacing:-.02em}
+.sheet .sheet-body{padding:14px 18px 24px;overflow-y:auto}
+.sheet .opts{display:grid;gap:8px}
+.opts.cols-2{grid-template-columns:1fr 1fr}
+.opt{
+  display:flex;align-items:center;gap:12px;padding:11px 12px;
+  background:#fff;border:1px solid var(--ls-line);border-radius:12px;
+  cursor:pointer;text-align:left;width:100%;font:inherit;color:inherit;
+  transition:border-color .15s, background .15s;
+}
+.opt:hover{border-color:var(--ls-line-2)}
+.opt.on{
+  border-color:var(--ls-gold);background:linear-gradient(180deg,rgba(201,168,76,.08),transparent 60%),#fff;
+  box-shadow:0 0 0 2px rgba(201,168,76,.18);
+}
+.opt .flag,.opt .glyph{
+  display:inline-flex;align-items:center;justify-content:center;
+  width:34px;height:34px;border-radius:9px;font-size:18px;flex:0 0 auto;
+  background:var(--ls-surface2);border:1px solid var(--ls-line);
+}
+.opt .info{display:flex;flex-direction:column;line-height:1.2;min-width:0;flex:1}
+.opt .info b{font-family:var(--f-display);font-weight:700;font-size:15px;letter-spacing:-.01em}
+.opt .info small{font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted);margin-top:2px}
+.opt .check{width:18px;height:18px;border-radius:50%;border:1.5px solid var(--ls-line-2);flex:0 0 auto}
+.opt.on .check{background:var(--ls-gold);border-color:var(--ls-gold);position:relative}
+.opt.on .check::after{content:"";position:absolute;left:5px;top:2px;width:4px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}
+
+/* STAT SHEET specifics */
+.stat-sheet .big{
+  display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:12px;
+}
+.stat-sheet .big .stat{
+  background:#fff;border:1px solid var(--ls-line);border-radius:12px;padding:12px;
+}
+.stat-sheet .big .stat .v{font-family:var(--f-display);font-weight:700;font-size:32px;line-height:1;letter-spacing:-.03em}
+.stat-sheet .big .stat .v small{font-family:var(--f-mono);font-size:10px;color:var(--ls-muted);font-weight:500;letter-spacing:.12em;margin-left:4px;text-transform:uppercase}
+.stat-sheet .big .stat .k{font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);margin-top:6px}
+.stat-sheet .funnel{
+  background:#fff;border:1px solid var(--ls-line);border-radius:12px;padding:12px 14px;
+}
+.stat-sheet .fn-row{display:grid;grid-template-columns:90px 1fr 40px;align-items:center;gap:10px;font-size:13px;padding:6px 0}
+.stat-sheet .fn-row .lab{font-family:var(--f-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ls-muted)}
+.stat-sheet .fn-bar{height:8px;border-radius:99px;background:var(--ls-surface2)}
+.stat-sheet .fn-fill{height:100%;border-radius:99px;background:linear-gradient(90deg,var(--ls-gold),var(--ls-gold-light));transition:width .6s ease}
+.stat-sheet .fn-row .v{font-family:var(--f-body);font-weight:700;text-align:right}
+
+@media (prefers-reduced-motion: reduce){
+  *{transition:none !important;animation:none !important}
+}
+
+/* Small viewports — info panes collapse */
+@media (max-width: 1100px){
+  .stage-aside{display:none}
+  .stage{grid-template-columns:1fr;grid-template-areas:"phone"}
+}
+
+/* badges & helpers */
+.locale-tag{
+  display:inline-flex;align-items:center;gap:5px;
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--ls-muted);padding:3px 8px;border-radius:99px;background:rgba(11,13,17,.04);
+  margin-bottom:10px;
+}
+.locale-tag b{color:var(--ls-charcoal);font-weight:600}
+
+/* arrow nav (corner) — desktop hint */
+.nudge{
+  position:fixed;left:50%;bottom:8px;transform:translateX(-50%);
+  font-family:var(--f-mono);font-size:11px;color:var(--ls-muted);
+  display:flex;gap:14px;align-items:center;
+  pointer-events:none;
+  z-index:5;
+}
+@media (max-width: 700px){.nudge{display:none}}
+</style>
+</head>
+<body>
+
+<div class="stage">
+
+  <!-- LEFT INFO PANE -->
+  <aside class="stage-aside">
+    <div class="brand-mark"><span class="gem"></span>La Base 360</div>
+    <h6>Prototype interactif</h6>
+    <p style="margin:0 0 14px;font-family:var(--f-mono);font-size:11px;color:var(--ls-muted);line-height:1.6">
+      6 marchés × 4 profils × 10 modules.<br>
+      Tout est cliquable.
+    </p>
+    <h6>Raccourcis</h6>
+    <div class="hint-row"><kbd>←</kbd><kbd>→</kbd><span>module préc./suiv.</span></div>
+    <div class="hint-row"><kbd>1</kbd>—<kbd>9</kbd>,<kbd>0</kbd><span>aller au n° de module</span></div>
+    <div class="hint-row"><kbd>M</kbd><span>changer marché</span></div>
+    <div class="hint-row"><kbd>P</kbd><span>changer profil</span></div>
+    <div class="hint-row"><kbd>C</kbd><span>copier le bloc en focus</span></div>
+    <div class="hint-row"><kbd>Esc</kbd><span>fermer une feuille</span></div>
+  </aside>
+
+  <!-- PHONE -->
+  <div class="phone-wrap">
+    <div class="phone">
+      <div class="notch"></div>
+      <div class="screen" id="screen">
+        <div class="app">
+
+          <div class="status">
+            <span>9:41</span>
+            <div class="right">
+              <svg width="17" height="11" viewBox="0 0 17 11"><rect x="0" y="7" width="3" height="4" rx="1" fill="#0B0D11"/><rect x="4.5" y="5" width="3" height="6" rx="1" fill="#0B0D11"/><rect x="9" y="2.5" width="3" height="8.5" rx="1" fill="#0B0D11"/><rect x="13.5" y="0" width="3" height="11" rx="1" fill="#0B0D11"/></svg>
+              <svg width="16" height="11" viewBox="0 0 16 11"><path d="M8 10.5 9.5 8.6c-.8-.7-2.2-.7-3 0L8 10.5Z" fill="#0B0D11"/><path d="M3 4.6c2.9-2.7 7.2-2.7 10 0l-1.5 1.6c-1.9-1.7-5-1.7-7 0L3 4.6Z" fill="#0B0D11"/><path d="M5.5 7.2c1.4-1.3 3.6-1.3 5 0L9 8.7c-.6-.5-1.4-.5-2 0L5.5 7.2Z" fill="#0B0D11"/></svg>
+              <svg width="26" height="12" viewBox="0 0 26 12"><rect x="0.5" y="0.5" width="22" height="11" rx="3" stroke="#0B0D11" fill="none"/><rect x="23.5" y="3.5" width="2" height="5" rx="1" fill="#0B0D11"/><rect x="2" y="2" width="19" height="8" rx="1.5" fill="#0B0D11"/></svg>
+            </div>
+          </div>
+
+          <div class="hdr">
+            <div class="row1">
+              <div class="brand"><span class="gem"></span>La Base 360<small>· prospection</small></div>
+              <button class="stat-chip" id="statChip" type="button">
+                <span class="dot-live"></span>
+                <span><b id="stat-sent">12</b> envoyés · <b id="stat-rdv">3</b> RDV</span>
+                <span style="color:var(--ls-muted)">·&nbsp;7j</span>
+              </button>
+            </div>
+            <div class="pickers">
+              <button class="picker" id="market-picker" type="button">
+                <span class="flag" id="market-flag">🇫🇷</span>
+                <div class="info-stack"><span class="lbl">Marché</span><span class="val" id="market-val">France</span></div>
+                <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+              <button class="picker" id="profile-picker" type="button">
+                <span class="glyph" id="profile-glyph">⚖️</span>
+                <div class="info-stack"><span class="lbl">Profil cible</span><span class="val" id="profile-val">Perte de poids&nbsp;·&nbsp;F</span></div>
+                <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+            </div>
+            <nav class="index" id="index" aria-label="Index des 10 modules"></nav>
+          </div>
+
+          <div class="section-meta">
+            <span class="step-of"><b id="step-of">01</b>&nbsp;/&nbsp;10</span>
+            <span id="section-meta-r"></span>
+          </div>
+
+          <div class="section-head">
+            <div class="kicker" id="section-kicker">Module · Mindset</div>
+            <h2 id="section-h2">D'abord, <span class="em">le ton</span>.</h2>
+            <p class="lede" id="section-lede"></p>
+          </div>
+
+          <div class="body" id="body">
+            <div class="body-inner" id="body-inner"></div>
+          </div>
+
+          <nav class="botnav">
+            <button class="btn-nav prev" id="prev" type="button">
+              <span class="arr"><svg width="12" height="12" viewBox="0 0 12 12"><path d="M7.5 3 4 6l3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg></span>
+              <span class="lab"><small id="prev-small">Début</small><span id="prev-name">Index</span></span>
+            </button>
+            <div class="dots" id="dots" aria-hidden="true"></div>
+            <button class="btn-nav next" id="next" type="button">
+              <span class="arr"><svg width="12" height="12" viewBox="0 0 12 12"><path d="M4.5 3 8 6l-3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg></span>
+              <span class="lab"><small id="next-small">Suivant · 02</small><span id="next-name">Trouver</span></span>
+            </button>
+          </nav>
+
+          <!-- Toast -->
+          <div class="toast" id="toast"><span class="ic">✓</span><span id="toast-text">Copié !</span></div>
+
+          <!-- Bottom sheets -->
+          <div class="sheet-backdrop" id="backdrop"></div>
+          <div class="sheet" id="sheet" role="dialog" aria-modal="true">
+            <div class="grab"></div>
+            <div class="sheet-head">
+              <div class="kicker" id="sheet-kicker"></div>
+              <h3 id="sheet-title"></h3>
+            </div>
+            <div class="sheet-body" id="sheet-body"></div>
+          </div>
+        </div>
+        <div class="home-indicator"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- RIGHT INFO PANE -->
+  <aside class="stage-aside right">
+    <h6>État courant</h6>
+    <div class="live" id="live-market">🇫🇷 France</div>
+    <div class="live" id="live-profile">⚖️ Perte de poids · F</div>
+    <div class="live" id="live-module">01 · Mindset</div>
+    <h6 style="margin-top:18px">Activité 7j</h6>
+    <div style="font-family:var(--f-mono);font-size:11px;line-height:1.7">
+      <b id="aside-sent">12</b> messages envoyés<br>
+      <b id="aside-rdv">3</b> rendez-vous pris<br>
+      <span style="color:var(--ls-muted)">tape sur la pastille pour voir le funnel</span>
+    </div>
+    <h6 style="margin-top:18px">Système</h6>
+    <p style="margin:0;font-family:var(--f-mono);font-size:11px;line-height:1.7">
+      Sticky <b>136 px</b>·<br>
+      <b>1 tap</b> entre modules<br>
+      Toast copier · trad EN→FR inline · variables colorées
+    </p>
+  </aside>
+
+</div>
+
+<div class="nudge">
+  <span>↘ tout est cliquable</span>
+  <span><kbd style="font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;padding:1px 6px">←</kbd> <kbd style="font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;padding:1px 6px">→</kbd> modules</span>
+  <span><kbd style="font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;padding:1px 6px">M</kbd> marché · <kbd style="font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);background:#fff;border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:5px;padding:1px 6px">P</kbd> profil</span>
+</div>
+
+<script src="prototype-data.js"></script>
+<script src="prototype.js"></script>
+
+</body>
+</html>

--- a/docs/mockups/prospection-v4-prototype.js
+++ b/docs/mockups/prospection-v4-prototype.js
@@ -1,0 +1,684 @@
+/* ────────────────────────────────────────────────────────────
+   LA BASE 360 · Prospection — Prototype interactif
+   ──────────────────────────────────────────────────────────── */
+(function(){
+  const $ = (s, el=document) => el.querySelector(s);
+  const $$ = (s, el=document) => Array.from(el.querySelectorAll(s));
+  const REDUCED = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const state = {
+    market: 0,
+    profile: 0,
+    module: 0,
+    platform: 0,
+    lang: {},          // per-script lang: { 'insta':'native'|'fr', ... }
+    sent: 12,
+    rdv: 3,
+    sentMap: {},       // which scripts were marked sent in this session
+    checks: {},        // routine checkbox state
+    caseTab: 'ghost',
+    sheet: null,       // 'market' | 'profile' | 'stat' | null
+  };
+
+  /* ── FIT phone to viewport ─────────────────────────── */
+  function fit(){
+    const targetH = 870;
+    const h = window.innerHeight - 36;
+    const w = window.innerWidth - 36;
+    const sH = Math.min(1, h/targetH);
+    const sW = Math.min(1, w/440);
+    const s = Math.min(sH, sW);
+    document.documentElement.style.setProperty('--phone-scale', s);
+  }
+  window.addEventListener('resize', fit);
+  fit();
+
+  /* ── Toast ─────────────────────────────────────────── */
+  let toastT;
+  function toast(text='Copié !'){
+    const t = $('#toast');
+    $('#toast-text').innerHTML = text;
+    t.classList.remove('hide');
+    t.classList.add('show');
+    clearTimeout(toastT);
+    toastT = setTimeout(()=>{
+      t.classList.remove('show');
+      t.classList.add('hide');
+    }, 1500);
+  }
+
+  /* ── Sheet ─────────────────────────────────────────── */
+  function openSheet(kind){
+    state.sheet = kind;
+    const sheet = $('#sheet');
+    const back = $('#backdrop');
+    const body = $('#sheet-body');
+    const title = $('#sheet-title');
+    const kicker = $('#sheet-kicker');
+    sheet.classList.remove('stat-sheet');
+
+    if (kind === 'market'){
+      kicker.textContent = 'Choisir un marché';
+      title.textContent = 'Marché cible.';
+      body.innerHTML = `
+        <div class="opts cols-2">
+          ${MARKETS.map((m,i)=>`
+            <button class="opt ${i===state.market?'on':''}" data-i="${i}">
+              <span class="flag">${m.flag}</span>
+              <span class="info"><b>${m.name}</b><small>${m.sub} · ${m.lang}</small></span>
+              <span class="check"></span>
+            </button>
+          `).join('')}
+        </div>
+        <div style="font-family:var(--f-mono);font-size:10.5px;color:var(--ls-muted);line-height:1.6;margin-top:14px;padding:10px 12px;background:var(--ls-surface2);border-radius:10px">
+          Les scripts <b style="color:var(--ls-charcoal)">M1</b>, les <b style="color:var(--ls-charcoal)">hashtags</b> et les <b style="color:var(--ls-charcoal)">sources</b> se localisent automatiquement.
+        </div>`;
+      body.querySelectorAll('.opt').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          state.market = parseInt(btn.dataset.i,10);
+          closeSheet();
+          renderAll();
+          flash($('#market-picker'));
+        });
+      });
+    }
+
+    if (kind === 'profile'){
+      kicker.textContent = 'Choisir un profil';
+      title.textContent = 'Profil cible.';
+      body.innerHTML = `
+        <div class="opts">
+          ${PROFILES.map((p,i)=>`
+            <button class="opt ${i===state.profile?'on':''}" data-i="${i}">
+              <span class="glyph">${p.glyph}</span>
+              <span class="info"><b>${p.name}</b><small>${p.persona}</small></span>
+              <span class="check"></span>
+            </button>
+          `).join('')}
+        </div>`;
+      body.querySelectorAll('.opt').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          state.profile = parseInt(btn.dataset.i,10);
+          closeSheet();
+          renderAll();
+          flash($('#profile-picker'));
+        });
+      });
+    }
+
+    if (kind === 'stat'){
+      sheet.classList.add('stat-sheet');
+      kicker.textContent = '7 derniers jours';
+      title.textContent = 'Activité.';
+      const sent = state.sent;
+      const rdv  = state.rdv;
+      const reps = Math.round(sent * 0.42);
+      const clos = Math.max(1, Math.round(rdv * 0.4));
+      const pct = (v, max=sent) => Math.min(100, Math.round(v/max*100));
+      body.innerHTML = `
+        <div class="big">
+          <div class="stat"><div class="v">${sent}<small>↑</small></div><div class="k">M1 envoyés</div></div>
+          <div class="stat"><div class="v">${reps}<small>↑</small></div><div class="k">Réponses</div></div>
+          <div class="stat"><div class="v">${rdv}</div><div class="k">RDV pris</div></div>
+          <div class="stat"><div class="v">${clos}</div><div class="k">Closing</div></div>
+        </div>
+        <div class="funnel">
+          <div class="fn-row"><span class="lab">M1</span><div class="fn-bar"><div class="fn-fill" style="width:${pct(sent)}%"></div></div><span class="v">${sent}</span></div>
+          <div class="fn-row"><span class="lab">Réponses</span><div class="fn-bar"><div class="fn-fill" style="width:${pct(reps)}%"></div></div><span class="v">${reps}</span></div>
+          <div class="fn-row"><span class="lab">RDV</span><div class="fn-bar"><div class="fn-fill" style="width:${pct(rdv)}%"></div></div><span class="v">${rdv}</span></div>
+          <div class="fn-row"><span class="lab">Closing</span><div class="fn-bar"><div class="fn-fill" style="width:${pct(clos)}%"></div></div><span class="v">${clos}</span></div>
+        </div>
+        <p style="font-family:var(--f-mono);font-size:10.5px;color:var(--ls-muted);line-height:1.6;margin:14px 0 0">
+          Chaque <b>« J'ai envoyé »</b> incrémente. Les RDV s'incrémentent quand un script <b>WhatsApp</b> est envoyé (proxy démo).
+        </p>`;
+    }
+
+    back.classList.add('open');
+    sheet.classList.add('open');
+  }
+  function closeSheet(){
+    state.sheet = null;
+    $('#sheet').classList.remove('open');
+    $('#backdrop').classList.remove('open');
+  }
+  function flash(el){
+    el.classList.add('opening');
+    setTimeout(()=>el.classList.remove('opening'), 280);
+  }
+
+  /* ── Render header (picker labels, stat chip, index, dots) ── */
+  function renderHeader(){
+    const m = MARKETS[state.market], p = PROFILES[state.profile], md = MODULES[state.module];
+    $('#market-flag').textContent = m.flag;
+    $('#market-val').innerHTML = m.name;
+    $('#profile-glyph').textContent = p.glyph;
+    $('#profile-val').innerHTML = p.name;
+    $('#stat-sent').textContent = state.sent;
+    $('#stat-rdv').textContent = state.rdv;
+    $('#aside-sent') && ($('#aside-sent').textContent = state.sent);
+    $('#aside-rdv')  && ($('#aside-rdv').textContent  = state.rdv);
+    $('#live-market') && ($('#live-market').textContent = `${m.flag} ${m.name}`);
+    $('#live-profile') && ($('#live-profile').textContent = `${p.glyph} ${p.name}`);
+    $('#live-module')  && ($('#live-module').textContent  = `${String(state.module+1).padStart(2,'0')} · ${md.name}`);
+
+    /* index rail */
+    const rail = $('#index');
+    rail.innerHTML = MODULES.map((mod, i)=>{
+      const cls = i===state.module ? 'active' : (i<state.module ? 'done':'');
+      return `<button class="step ${cls}" data-i="${i}" type="button" aria-label="${mod.name}">
+        <span class="n">${String(i+1).padStart(2,'0')}</span>
+        <span class="ic">${mod.ic}</span>
+        <span class="name">${mod.name}</span>
+      </button>`;
+    }).join('');
+    rail.querySelectorAll('.step').forEach(s=>{
+      s.addEventListener('click', ()=> goModule(parseInt(s.dataset.i,10)));
+    });
+    /* center active */
+    requestAnimationFrame(()=>{
+      const active = rail.querySelector('.step.active');
+      if (active){
+        const railRect = rail.getBoundingClientRect();
+        const aRect = active.getBoundingClientRect();
+        const delta = (aRect.left + aRect.width/2) - (railRect.left + railRect.width/2);
+        rail.scrollBy({left:delta, behavior:'smooth'});
+      }
+    });
+
+    /* dots */
+    $('#dots').innerHTML = MODULES.map((_,i)=>{
+      const cls = i===state.module ? 'on' : (i<state.module ? 'done' : '');
+      return `<span class="d ${cls}"></span>`;
+    }).join('');
+
+    /* section meta + heading */
+    $('#step-of').textContent = String(state.module+1).padStart(2,'0');
+    $('#section-meta-r').innerHTML = md.meta;
+    $('#section-kicker').innerHTML = md.kicker;
+    $('#section-h2').innerHTML = `${md.h2[0]}<span class="em">${md.h2[1]}</span>${md.h2[2]||''}`;
+    $('#section-lede').innerHTML = md.lede;
+
+    /* prev/next */
+    const prev = state.module - 1;
+    const next = state.module + 1;
+    const prevBtn = $('#prev'), nextBtn = $('#next');
+    if (prev < 0){
+      prevBtn.disabled = true;
+      $('#prev-small').textContent = 'Début';
+      $('#prev-name').textContent  = 'Index';
+    } else {
+      prevBtn.disabled = false;
+      $('#prev-small').textContent = `Précédent · ${String(prev+1).padStart(2,'0')}`;
+      $('#prev-name').textContent  = MODULES[prev].name;
+    }
+    if (next > 9){
+      nextBtn.disabled = true;
+      $('#next-small').textContent = 'Fin';
+      $('#next-name').textContent  = '—';
+    } else {
+      nextBtn.disabled = false;
+      $('#next-small').textContent = `Suivant · ${String(next+1).padStart(2,'0')}`;
+      $('#next-name').textContent  = MODULES[next].name;
+    }
+  }
+
+  /* ── Render body (per module) ──────────────────────── */
+  function renderBody(){
+    const inner = $('#body-inner');
+    const html = MODULE_RENDERERS[state.module]();
+    inner.innerHTML = html;
+    /* scroll to top of module */
+    $('#body').scrollTop = 0;
+    /* wire up per-module interactions */
+    wireBody(inner);
+  }
+
+  function renderAll(animated=true){
+    renderHeader();
+    if (animated && !REDUCED){
+      const inner = $('#body-inner');
+      inner.classList.add('swapping');
+      setTimeout(()=>{
+        renderBody();
+        requestAnimationFrame(()=> inner.classList.remove('swapping'));
+      }, 120);
+    } else {
+      renderBody();
+    }
+  }
+
+  /* ── Navigation ────────────────────────────────────── */
+  function goModule(i){
+    if (i<0 || i>9 || i===state.module) return;
+    state.module = i;
+    renderAll(true);
+  }
+
+  $('#prev').addEventListener('click', ()=> goModule(state.module-1));
+  $('#next').addEventListener('click', ()=> goModule(state.module+1));
+  $('#market-picker').addEventListener('click', ()=> { flash($('#market-picker')); openSheet('market'); });
+  $('#profile-picker').addEventListener('click', ()=> { flash($('#profile-picker')); openSheet('profile'); });
+  $('#statChip').addEventListener('click', ()=> openSheet('stat'));
+  $('#backdrop').addEventListener('click', closeSheet);
+
+  /* keyboard */
+  window.addEventListener('keydown', (e)=>{
+    if (e.key === 'Escape'){ closeSheet(); return; }
+    if (state.sheet) return;
+    if (e.key === 'ArrowRight'){ goModule(state.module+1); }
+    if (e.key === 'ArrowLeft') { goModule(state.module-1); }
+    if (/^[1-9]$/.test(e.key))  goModule(parseInt(e.key,10)-1);
+    if (e.key === '0')          goModule(9);
+    if (e.key === 'm' || e.key === 'M') openSheet('market');
+    if (e.key === 'p' || e.key === 'P') openSheet('profile');
+    if (e.key === 'c' || e.key === 'C'){
+      const focus = document.activeElement;
+      const btn = focus && focus.classList && focus.classList.contains('btn') && focus.classList.contains('copy') ? focus : null;
+      if (btn){ btn.click(); }
+      else { const first = $('.btn.copy'); if (first) first.click(); }
+    }
+  });
+
+  /* ────────────────────────────────────────────────────
+     MODULE RENDERERS
+     ──────────────────────────────────────────────────── */
+  const MODULE_RENDERERS = [
+    renderMindset,
+    renderTrouver,
+    renderMessages,
+    renderTrees,
+    renderObjections,
+    renderPostcall,
+    renderClosing,
+    renderSpecial,
+    renderStory,
+    renderRoutine,
+  ];
+
+  function localeTag(extra=''){
+    const m = MARKETS[state.market], p = PROFILES[state.profile];
+    return `<span class="locale-tag">Localisé pour <b>${m.flag}&nbsp;${m.name}</b>&nbsp;·&nbsp;<b>${p.glyph}&nbsp;${p.short}</b>${extra?` · ${extra}`:''}</span>`;
+  }
+
+  function renderMindset(){
+    return `
+      <article class="truth">
+        <div class="truth-row">
+          <div class="num">01</div>
+          <div>
+            <div class="kicker">Vérité n°1 · posture</div>
+            <p class="quote">Tu ne <em>vends</em> pas. Tu invites quelqu'un à se transformer.</p>
+            <p class="by">— extrait <em>Méthode 360</em></p>
+          </div>
+        </div>
+      </article>
+
+      <article class="truth-lite">
+        <div class="ctx">Vérité n°2 · refus</div>
+        <p>Le <em>«&nbsp;non&nbsp;»</em> n'existe pas. Seulement <em>pas encore</em>, <em>pas comme ça</em>, <em>pas avec toi</em>.</p>
+      </article>
+
+      <article class="truth-lite">
+        <div class="ctx">Vérité n°3 · énergie</div>
+        <p>Ton <em>énergie</em> compte plus que ton script.</p>
+      </article>
+
+      <div class="errors-head">
+        <span class="label">5 erreurs à éviter</span>
+        <span style="font-family:var(--f-mono);font-size:10px;color:var(--ls-muted);letter-spacing:.1em">↓</span>
+      </div>
+      ${[
+        'Parler produit avant d\'avoir écouté le besoin.',
+        'Suivre tout le monde au lieu de cibler des profils qualifiés.',
+        'Disparaître après le M1 sans relance structurée.',
+        'Sortir le prix trop tôt dans la conversation.',
+        'Copier-coller sans personnaliser le prénom.'
+      ].map((t,i)=>`
+        <div class="err">
+          <span class="n">0${i+1}</span>
+          <div class="txt"><span class="strike">${t.split(' ').slice(0,3).join(' ')}</span> ${t.split(' ').slice(3).join(' ')}</div>
+        </div>`).join('')}
+
+      <div style="height:14px"></div>
+      ${localeTag(`vue 2× cette sem.`)}
+    `;
+  }
+
+  function renderTrouver(){
+    const m = MARKETS[state.market];
+    return `
+      <div class="scan-timer"><span class="pulse"></span>Scan en 30&nbsp;s · les 4 premières secondes</div>
+
+      <div class="flags">
+        <div class="flag-col green">
+          <h5><span class="dot"></span>Drapeaux verts</h5>
+          <ul>${m.flagsGreen.map(f=>`<li>${f}</li>`).join('')}</ul>
+        </div>
+        <div class="flag-col red">
+          <h5><span class="dot"></span>Drapeaux rouges</h5>
+          <ul>${m.flagsRed.map(f=>`<li>${f}</li>`).join('')}</ul>
+        </div>
+      </div>
+
+      <article class="hashtag-card">
+        <div class="htag-head">
+          <span>Hashtags · <b>${m.flag}&nbsp;${m.name}</b></span>
+          <span style="font-family:var(--f-mono);font-size:9.5px">3 catégories</span>
+        </div>
+        <div class="htag-row">
+          <span class="cat">Mainstream</span>
+          ${m.hashtags.mainstream.map(h=>`<button class="htag" type="button" data-copy="${h}">${h}</button>`).join('')}
+        </div>
+        <div class="htag-row">
+          <span class="cat">Niche</span>
+          ${m.hashtags.niche.map(h=>`<button class="htag gold" type="button" data-copy="${h}">${h}</button>`).join('')}
+        </div>
+        <div class="htag-row">
+          <span class="cat">Cross</span>
+          ${m.hashtags.cross.map((h,i)=>`<button class="htag ${i<2?'teal':'purple'}" type="button" data-copy="${h}">${h}</button>`).join('')}
+        </div>
+      </article>
+
+      <article class="src-card">
+        <div class="kk">3 sources hors-feed</div>
+        <h4>Là où les autres ne cherchent pas.</h4>
+        <div class="src-row"><div class="src-lab">FB</div><div class="src-body">${m.sources.fb}</div></div>
+        <div class="src-row"><div class="src-lab">IRL</div><div class="src-body">${m.sources.irl}</div></div>
+        <div class="src-row"><div class="src-lab">Reco</div><div class="src-body">${m.sources.reco}</div></div>
+      </article>
+
+      <div style="height:8px"></div>
+      ${localeTag()}
+    `;
+  }
+
+  function renderMessages(){
+    const market = MARKETS[state.market];
+    const scripts = M1_SCRIPTS[market.code] || M1_SCRIPTS.INTL;
+    const current = PLATFORMS[state.platform];
+    const data = scripts[current.code];
+    const langKey = `${market.code}-${current.code}`;
+    const lang = state.lang[langKey] || (market.code === 'FR' ? 'native' : 'native'); // default to native
+    const sent = !!state.sentMap[`m1-${langKey}`];
+
+    return `
+      <div class="platform-tabs" role="tablist">
+        ${PLATFORMS.map((pl,i)=>`
+          <button class="tab ${i===state.platform?'on':''}" data-i="${i}" type="button">
+            <span class="ic">${pl.ic}</span>${pl.name}
+          </button>`).join('')}
+      </div>
+
+      <article class="script ${sent?'sent':''}" data-key="${langKey}">
+        <div class="head">
+          <span class="glyph" style="${current.glyphStyle}">${current.ic}</span>
+          <div>
+            <h4>${current.name} · ${current.sub.split('·')[0].trim()}</h4>
+            <span class="sub">${current.sub.includes('·')? current.sub.split('·').slice(1).join('·').trim() : ''}</span>
+          </div>
+          ${market.code === 'FR' ? '' : `
+            <div class="lang-switch" data-key="${langKey}">
+              <button data-l="native" class="${lang==='native'?'on':''}">${market.lang}</button>
+              <button data-l="fr" class="${lang==='fr'?'on':''}">FR</button>
+            </div>`}
+        </div>
+        <div class="ctx">Contexte · ${data.ctx}</div>
+        <div class="msg-body">${lang==='fr' && data.trad ? `<p>${data.trad}</p>` : data.script}</div>
+        ${market.code !== 'FR' && lang === 'native' && data.trad ? `<div class="trad-line">${data.trad}</div>` : ''}
+        <div class="script-actions">
+          <button class="btn copy" type="button" data-msg="m1-${langKey}"><span class="ic">⌘C</span>Copier</button>
+          <button class="btn send ${sent?'done':''}" type="button" data-send="m1-${langKey}" data-platform="${current.code}">
+            <span class="ic">${sent?'✓':'↗'}</span>${sent?'Envoyé':'J\'ai envoyé'}
+          </button>
+          <div class="spacer"></div>
+          <span class="stat-mini">Taux réponse&nbsp; <b>${data.stat}</b>&nbsp; · &nbsp;n=<b>${data.n}</b></span>
+        </div>
+      </article>
+
+      <div style="height:6px"></div>
+      ${localeTag(`taux moyens des autres distri·s`)}
+    `;
+  }
+
+  function renderTrees(){
+    return `
+      ${TREES.map(t=>`
+        <article class="tree-branch">
+          <div class="reaction"><b>Réaction&nbsp;:</b><span class="pill ${t.reaction}">${t.emoji}&nbsp;${t.label}</span></div>
+          <q>${t.they}</q>
+          <div class="reply">${t.you}</div>
+          <div class="actions">
+            <button class="btn copy" type="button" data-msg="tree-${t.reaction}"><span class="ic">⌘C</span>Copier la réponse</button>
+            <button class="btn ghost" type="button">Variantes · ${t.variants}</button>
+          </div>
+        </article>`).join('')}
+      <div style="height:6px"></div>
+      ${localeTag()}
+    `;
+  }
+
+  function renderObjections(){
+    return `
+      ${OBJECTIONS.map((o,i)=>`
+        <article class="obj">
+          <div class="quote">
+            <div class="n">${String(i+1).padStart(2,'0')}<small>·&nbsp;${o.tag}</small></div>
+            <q>${o.quote}</q>
+          </div>
+          <div class="obj-row bad">
+            <span class="badge">✕</span>
+            <div><span class="lbl">À ne pas dire</span><p>${o.bad}</p></div>
+          </div>
+          <div class="obj-row good">
+            <span class="badge">✓</span>
+            <div><span class="lbl">Ce qui ouvre</span><p>${o.good}</p></div>
+          </div>
+          <div class="obj-actions">
+            <button class="btn copy" type="button" data-msg="obj-${i}"><span class="ic">⌘C</span>Copier la réponse</button>
+            <button class="btn ghost" type="button">Variantes · ${o.variants}</button>
+          </div>
+        </article>`).join('')}
+      <div style="height:6px"></div>
+      ${localeTag(`8 objections en France · variantes/marché`)}
+    `;
+  }
+
+  function renderPostcall(){
+    return `
+      <div class="timeline">
+        ${POSTCALL.map((s,i)=>`
+          <div class="t-step ${s.state||''}">
+            <div class="when">${s.when}</div>
+            <h4>${s.title}</h4>
+            <div class="msg">${s.msg}</div>
+            <div class="actions">
+              <button class="btn copy" type="button" data-msg="pc-${i}"><span class="ic">⌘C</span>Copier</button>
+              ${s.state!=='future' ? `<button class="btn send" type="button" data-send="pc-${i}"><span class="ic">↗</span>Programmé</button>` : ''}
+            </div>
+          </div>`).join('')}
+      </div>
+      <div class="card" style="background:linear-gradient(180deg,var(--ls-surface2),transparent),#fff">
+        <div style="font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);margin-bottom:4px">Règle</div>
+        <p style="margin:0;font-family:var(--f-display);font-weight:600;font-size:17px;line-height:1.2;letter-spacing:-.01em">
+          Quatre touches <em style="color:var(--ls-gold-dark);font-style:italic;font-weight:500">maximum</em>. Pas une de plus.
+        </p>
+      </div>
+      ${localeTag()}
+    `;
+  }
+
+  function renderClosing(){
+    return `
+      <article class="signal-card">
+        <h5>Les 5 signaux qui montrent que c'est mûr</h5>
+        <div class="signal-list">
+          ${CLOSING.signals.map(s=>`<div class="row">${s}</div>`).join('')}
+        </div>
+      </article>
+      ${CLOSING.scripts.map((s,i)=>`
+        <article class="close-script">
+          <h4>${s.name}</h4>
+          <div class="ctx">${s.ctx}</div>
+          <p>${s.body}</p>
+          <div class="script-actions" style="margin-top:10px;padding-top:8px">
+            <button class="btn copy" type="button" data-msg="close-${i}"><span class="ic">⌘C</span>Copier</button>
+            <button class="btn ghost" type="button">Variante</button>
+          </div>
+        </article>`).join('')}
+      ${localeTag()}
+    `;
+  }
+
+  function renderSpecial(){
+    const cases = [
+      {k:'ghost', label:'Ghost'},
+      {k:'reactivation', label:'Réactivation'},
+      {k:'reco', label:'Recommandation'}
+    ];
+    const active = state.caseTab;
+    const data = SPECIAL[active];
+    return `
+      <div class="case-tabs">
+        ${cases.map(c=>`<button class="${c.k===active?'on':''}" data-case="${c.k}" type="button">${c.label}</button>`).join('')}
+      </div>
+      <article class="card">
+        <h3 style="font-family:var(--f-display);font-weight:700;font-size:18px;letter-spacing:-.015em">${data.title}</h3>
+        <div style="font-size:13.5px;line-height:1.5;color:var(--ls-charcoal);margin:8px 0 10px;padding:12px 14px;background:var(--ls-surface2);border-radius:10px">
+          ${data.body}
+        </div>
+        <div style="font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-gold-dark);margin-bottom:6px">Règles</div>
+        <ul style="margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:6px">
+          ${data.tips.map(t=>`<li style="display:flex;gap:8px;font-size:13px;line-height:1.4"><span style="color:var(--ls-gold);font-weight:700">·</span>${t}</li>`).join('')}
+        </ul>
+        <div class="script-actions" style="margin-top:12px">
+          <button class="btn copy" type="button" data-msg="case-${active}"><span class="ic">⌘C</span>Copier</button>
+          <button class="btn ghost" type="button">Variante</button>
+        </div>
+      </article>
+      ${localeTag()}
+    `;
+  }
+
+  function renderStory(){
+    return `
+      <div class="story-struct">
+        ${STORY.acts.map(a=>`
+          <div class="seg ${a.gold?'gold':''}">
+            <div class="step">${a.step}</div>
+            <h6>${a.title}</h6>
+            <p>${a.body}</p>
+          </div>`).join('')}
+      </div>
+      ${STORY.examples.map((ex,i)=>`
+        <article class="story-example">
+          <div class="by">${ex.by}</div>
+          ${ex.body}
+          <div class="script-actions" style="margin-top:10px;padding-top:8px">
+            <button class="btn copy" type="button" data-msg="story-${i}"><span class="ic">⌘C</span>Copier l'exemple</button>
+          </div>
+        </article>`).join('')}
+      ${localeTag()}
+    `;
+  }
+
+  function renderRoutine(){
+    const done = Object.values(state.checks).filter(Boolean).length;
+    const total = ROUTINE.length;
+    return `
+      <article class="routine-summary">
+        <div class="big">${done}<span>/${total}</span><small>aujourd'hui</small></div>
+        <p>30 minutes par jour, <em style="color:var(--ls-gold-light);font-style:italic;font-weight:500">tous les jours</em>. Pas de routine = pas de pipeline.</p>
+      </article>
+      <article class="checklist">
+        ${ROUTINE.map((r,i)=>`
+          <div class="check-item ${state.checks[i]?'done':''}" data-i="${i}">
+            <div class="box"></div>
+            <div class="txt">${r.txt}</div>
+            <div class="mins">${r.mins}</div>
+          </div>`).join('')}
+      </article>
+      ${localeTag()}
+    `;
+  }
+
+  /* ── Wire body interactions ────────────────────────── */
+  function wireBody(root){
+    /* COPY buttons */
+    root.querySelectorAll('.btn.copy').forEach(btn=>{
+      btn.addEventListener('click', ()=>{
+        const text = btn.closest('article, .t-step, .check-item, .obj')?.innerText?.trim() || '';
+        try { navigator.clipboard?.writeText(text); } catch(e){}
+        toast('Copié ! <span style="color:rgba(255,255,255,.55);font-family:var(--f-mono);font-size:11px;margin-left:4px">— pense au prénom</span>');
+      });
+    });
+    /* J'ai envoyé */
+    root.querySelectorAll('.btn.send').forEach(btn=>{
+      btn.addEventListener('click', ()=>{
+        const key = btn.dataset.send;
+        if (!key || state.sentMap[key]) return;
+        state.sentMap[key] = true;
+        state.sent += 1;
+        const platform = btn.dataset.platform;
+        if (platform === 'wa') state.rdv += 1; // proxy for warm contact converting
+        $('#stat-sent').textContent = state.sent;
+        $('#stat-sent').classList.add('bumped');
+        $('#stat-rdv').textContent = state.rdv;
+        if (platform === 'wa') $('#stat-rdv').classList.add('bumped');
+        setTimeout(()=>{
+          $('#stat-sent').classList.remove('bumped');
+          $('#stat-rdv').classList.remove('bumped');
+        }, 1200);
+        $('#aside-sent') && ($('#aside-sent').textContent = state.sent);
+        $('#aside-rdv')  && ($('#aside-rdv').textContent  = state.rdv);
+        btn.classList.add('done');
+        btn.innerHTML = `<span class="ic">✓</span>Envoyé`;
+        const card = btn.closest('.script');
+        if (card) card.classList.add('sent');
+        toast(`Envoyé&nbsp;! <span style="color:rgba(255,255,255,.55);font-family:var(--f-mono);font-size:11px;margin-left:4px">+1 cette sem.</span>`);
+      });
+    });
+    /* Hashtag copy */
+    root.querySelectorAll('.htag[data-copy]').forEach(h=>{
+      h.addEventListener('click', ()=>{
+        try { navigator.clipboard?.writeText(h.dataset.copy); } catch(e){}
+        toast(`Copié&nbsp;: ${h.textContent}`);
+      });
+    });
+    /* Lang switch */
+    root.querySelectorAll('.lang-switch').forEach(ls=>{
+      ls.querySelectorAll('button').forEach(b=>{
+        b.addEventListener('click', ()=>{
+          const key = ls.dataset.key;
+          state.lang[key] = b.dataset.l;
+          renderBody();
+        });
+      });
+    });
+    /* Platform tabs */
+    root.querySelectorAll('.platform-tabs .tab').forEach(t=>{
+      t.addEventListener('click', ()=>{
+        state.platform = parseInt(t.dataset.i,10);
+        renderBody();
+      });
+    });
+    /* Special case tabs */
+    root.querySelectorAll('.case-tabs button').forEach(b=>{
+      b.addEventListener('click', ()=>{
+        state.caseTab = b.dataset.case;
+        renderBody();
+      });
+    });
+    /* Routine checks */
+    root.querySelectorAll('.check-item').forEach(it=>{
+      it.addEventListener('click', ()=>{
+        const i = parseInt(it.dataset.i,10);
+        state.checks[i] = !state.checks[i];
+        renderBody();
+      });
+    });
+  }
+
+  /* INIT */
+  renderAll(false);
+
+})();

--- a/docs/mockups/prospection-v4-refonte-design.html
+++ b/docs/mockups/prospection-v4-refonte-design.html
@@ -1,0 +1,1665 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Prospection · La Base 360 — Refonte</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Syne:wght@500;600;700;800&family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+<style>
+/* ─────────────────────────────────────────────────────────────────
+   TOKENS
+   ───────────────────────────────────────────────────────────────── */
+:root{
+  --ls-gold:#C9A84C;
+  --ls-gold-light:#E5C97D;
+  --ls-gold-dark:#8E7430;
+  --ls-teal:#2DD4BF;
+  --ls-teal-dark:#0F766E;
+  --ls-coral:#FB7185;
+  --ls-coral-dark:#BE3242;
+  --ls-purple:#7C3AED;
+  --ls-charcoal:#0B0D11;
+  --ls-cream:#FBF7F0;
+  --ls-surface:#FFFFFF;
+  --ls-surface2:#F7F3EC;
+  --ls-line:rgba(11,13,17,.08);
+  --ls-line-2:rgba(11,13,17,.14);
+  --ls-muted:rgba(11,13,17,.56);
+  --ls-muted-2:rgba(11,13,17,.40);
+
+  --f-display:"Syne", "Times New Roman", serif;
+  --f-body:"DM Sans", system-ui, sans-serif;
+  --f-mono:"JetBrains Mono", ui-monospace, Menlo, monospace;
+}
+
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{
+  font-family:var(--f-body);
+  background:#EFE9DC;
+  color:var(--ls-charcoal);
+  -webkit-font-smoothing:antialiased;
+  text-rendering:optimizeLegibility;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   CANVAS (the deliverable shell)
+   ───────────────────────────────────────────────────────────────── */
+.canvas-head{
+  padding:48px 56px 32px;
+  display:flex;align-items:flex-end;justify-content:space-between;gap:32px;
+  border-bottom:1px solid rgba(11,13,17,.08);
+}
+.canvas-head h1{
+  font-family:var(--f-display);font-weight:700;font-size:42px;line-height:1.05;letter-spacing:-.02em;margin:0 0 6px;
+}
+.canvas-head .sub{
+  font-family:var(--f-mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);margin:0;
+}
+.canvas-head .meta{
+  display:grid;grid-template-columns:auto auto auto auto;gap:0 28px;
+  font-family:var(--f-mono);font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted);
+  align-items:end;
+}
+.canvas-head .meta b{display:block;color:var(--ls-charcoal);font-weight:600;font-size:13px;letter-spacing:0;text-transform:none;font-family:var(--f-body);margin-top:4px}
+
+.stage{
+  padding:48px 56px 80px;
+  display:flex;gap:48px;
+  overflow-x:auto;
+  scroll-snap-type:x proximity;
+}
+.frame{
+  scroll-snap-align:start;
+  flex:0 0 auto;
+  display:flex;flex-direction:column;gap:18px;
+  width:413px;
+}
+.frame.frame-desktop{width:712px}
+
+/* iPhone bezel */
+.phone{
+  position:relative;
+  width:413px;height:850px;
+  background:#0B0D11;
+  border-radius:54px;
+  padding:10px;
+  box-shadow:
+    0 0 0 2px rgba(255,255,255,.06) inset,
+    0 30px 60px -20px rgba(11,13,17,.35),
+    0 60px 120px -40px rgba(11,13,17,.25);
+}
+.phone .screen{
+  position:relative;
+  width:100%;height:100%;
+  border-radius:44px;
+  overflow:hidden;
+  background:var(--ls-cream);
+  display:flex;flex-direction:column;
+}
+.phone .notch{
+  position:absolute;top:14px;left:50%;transform:translateX(-50%);
+  width:104px;height:32px;background:#0B0D11;border-radius:20px;z-index:30;
+}
+.phone .home-indicator{
+  position:absolute;left:50%;bottom:8px;transform:translateX(-50%);
+  width:130px;height:5px;border-radius:3px;background:rgba(11,13,17,.85);z-index:30;
+}
+
+/* Desktop window */
+.window{
+  width:712px;height:850px;
+  background:var(--ls-cream);
+  border-radius:18px;
+  overflow:hidden;
+  box-shadow:
+    0 30px 60px -20px rgba(11,13,17,.35),
+    0 60px 120px -40px rgba(11,13,17,.25);
+  display:flex;flex-direction:column;
+  border:1px solid rgba(11,13,17,.08);
+}
+.window .chrome{
+  flex:0 0 auto;
+  height:38px;background:#EDE5D2;
+  display:flex;align-items:center;padding:0 14px;gap:8px;
+  border-bottom:1px solid rgba(11,13,17,.06);
+}
+.window .chrome .dot{width:11px;height:11px;border-radius:50%}
+.window .chrome .dot.r{background:#EC6A5E}
+.window .chrome .dot.y{background:#F4BF4F}
+.window .chrome .dot.g{background:#61C554}
+.window .chrome .url{
+  margin-left:18px;font-family:var(--f-mono);font-size:11px;color:var(--ls-muted);
+  background:#F7F0DC;padding:5px 12px;border-radius:6px;
+  display:flex;align-items:center;gap:6px;
+}
+.window .chrome .url::before{content:"";width:8px;height:8px;border:1.5px solid var(--ls-muted);border-radius:50%}
+
+/* Annotation card */
+.annotation{
+  font-family:var(--f-mono);font-size:11.5px;line-height:1.7;color:var(--ls-charcoal);
+  background:var(--ls-surface);
+  border:1px solid var(--ls-line);
+  border-radius:14px;
+  padding:14px 18px;
+}
+.annotation .tag{
+  display:inline-block;
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--ls-gold-dark);
+  background:rgba(201,168,76,.12);
+  padding:3px 8px;border-radius:4px;margin-bottom:8px;
+}
+.annotation b{color:var(--ls-charcoal);font-weight:600}
+.annotation .hl{color:var(--ls-gold-dark);font-weight:500}
+.annotation .num{
+  font-family:var(--f-display);font-weight:700;font-size:18px;color:var(--ls-charcoal);
+  display:inline-block;margin-right:8px;line-height:1;vertical-align:-2px;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   APP — shared chrome
+   ───────────────────────────────────────────────────────────────── */
+.app{
+  width:100%;height:100%;
+  display:flex;flex-direction:column;
+  background:var(--ls-cream);
+  font-size:14px;line-height:1.45;color:var(--ls-charcoal);
+}
+
+/* Status bar (iOS) */
+.status{
+  flex:0 0 auto;height:54px;
+  display:flex;align-items:flex-end;justify-content:space-between;
+  padding:0 30px 8px;
+  font-family:var(--f-body);font-weight:600;font-size:15px;
+  background:var(--ls-cream);
+}
+.status .right{display:flex;gap:6px;align-items:center}
+.status .right svg{display:block}
+
+/* Sticky header */
+.hdr{
+  flex:0 0 auto;
+  background:var(--ls-cream);
+  padding:6px 18px 12px;
+  border-bottom:1px solid var(--ls-line);
+  position:relative;z-index:5;
+}
+.hdr .row1{
+  display:flex;align-items:center;justify-content:space-between;gap:10px;
+  padding:4px 2px 8px;
+}
+.brand{
+  display:flex;align-items:center;gap:8px;
+  font-family:var(--f-display);font-weight:700;font-size:15px;letter-spacing:-.01em;
+}
+.brand .gem{
+  width:18px;height:18px;border-radius:5px;
+  background:linear-gradient(135deg,var(--ls-gold) 0%,var(--ls-gold-light) 60%, #fff7d6 100%);
+  box-shadow:0 0 0 1px rgba(142,116,48,.3) inset;
+  position:relative;
+}
+.brand .gem::after{
+  content:"";position:absolute;inset:3px;border-radius:3px;
+  background:radial-gradient(circle at 30% 30%, rgba(255,255,255,.7), transparent 60%);
+}
+.brand small{
+  font-family:var(--f-mono);font-weight:400;font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--ls-muted);margin-left:4px;align-self:center;
+}
+
+.stat-chip{
+  display:flex;align-items:center;gap:7px;
+  padding:5px 10px 5px 8px;border-radius:99px;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  font-family:var(--f-mono);font-size:11px;
+}
+.stat-chip .dot-live{
+  width:6px;height:6px;border-radius:50%;background:var(--ls-teal);
+  box-shadow:0 0 0 3px rgba(45,212,191,.18);
+}
+.stat-chip b{font-weight:600;color:var(--ls-charcoal)}
+.stat-chip .delta{color:var(--ls-teal-dark);font-weight:600}
+
+/* Pickers row */
+.pickers{
+  display:flex;gap:8px;align-items:stretch;
+}
+.picker{
+  flex:1;min-width:0;
+  display:flex;align-items:center;gap:8px;
+  padding:9px 10px 9px 12px;
+  background:var(--ls-surface);
+  border:1px solid var(--ls-line);
+  border-radius:12px;
+  font-size:13px;font-weight:500;
+  position:relative;
+}
+.picker .lbl{
+  font-family:var(--f-mono);font-size:9px;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--ls-muted);display:block;
+}
+.picker .val{
+  font-family:var(--f-body);font-weight:600;font-size:13.5px;
+  color:var(--ls-charcoal);display:flex;align-items:center;gap:6px;line-height:1.15;margin-top:1px;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+.picker .flag{
+  display:inline-flex;align-items:center;justify-content:center;
+  width:22px;height:16px;border-radius:3px;overflow:hidden;font-size:14px;line-height:1;
+  background:#eee;flex:0 0 auto;
+}
+.picker .glyph{
+  width:22px;height:22px;border-radius:6px;flex:0 0 auto;
+  display:inline-flex;align-items:center;justify-content:center;
+  background:linear-gradient(135deg,#fff,#F7F0DC);
+  border:1px solid var(--ls-line);font-size:13px;
+}
+.picker .caret{
+  margin-left:auto;width:14px;height:14px;flex:0 0 auto;
+  opacity:.5;
+}
+.picker .info-stack{display:flex;flex-direction:column;justify-content:center;min-width:0;flex:1}
+
+/* index rail */
+.index{
+  margin-top:10px;
+  display:flex;align-items:stretch;gap:0;
+  background:var(--ls-surface);
+  border:1px solid var(--ls-line);
+  border-radius:12px;
+  padding:5px;
+  position:relative;
+  overflow:hidden;
+}
+.index .step{
+  flex:0 0 auto;
+  display:flex;align-items:center;gap:6px;
+  padding:7px 8px;border-radius:8px;
+  font-family:var(--f-mono);font-size:11px;font-weight:500;
+  color:var(--ls-muted);
+  white-space:nowrap;
+  cursor:pointer;
+  transition:background .15s, color .15s;
+}
+.index .step .n{
+  font-family:var(--f-mono);font-weight:500;font-size:10px;letter-spacing:.06em;color:var(--ls-muted-2);
+}
+.index .step .ic{font-family:var(--f-body);font-size:13px;line-height:1}
+.index .step .name{
+  display:none;font-family:var(--f-body);font-weight:600;font-size:12.5px;color:var(--ls-charcoal);
+  letter-spacing:-.005em;
+}
+.index .step.active{
+  background:var(--ls-charcoal);
+  color:#fff;
+  box-shadow:0 1px 0 rgba(0,0,0,.04);
+}
+.index .step.active .n{color:var(--ls-gold-light)}
+.index .step.active .name{display:inline;color:#fff}
+.index .step.dim{opacity:.6}
+.index .more{
+  flex:0 0 auto;align-self:center;
+  font-family:var(--f-mono);font-size:10px;color:var(--ls-muted);padding:0 6px;
+}
+
+/* Section meta row (under index) */
+.section-meta{
+  display:flex;align-items:center;justify-content:space-between;gap:10px;
+  padding:14px 22px 6px;
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);
+}
+.section-meta .step-of{display:flex;align-items:center;gap:6px}
+.section-meta .step-of b{color:var(--ls-charcoal);font-weight:600}
+
+/* Section heading */
+.section-head{
+  padding:0 22px 14px;
+}
+.section-head .kicker{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-gold-dark);
+  display:flex;align-items:center;gap:8px;margin-bottom:6px;
+}
+.section-head .kicker::before{
+  content:"";width:18px;height:1px;background:var(--ls-gold);
+}
+.section-head h2{
+  font-family:var(--f-display);font-weight:700;font-size:30px;line-height:1;letter-spacing:-.025em;
+  margin:0 0 8px;
+}
+.section-head h2 .em{font-style:italic;font-weight:500;color:var(--ls-gold-dark)}
+.section-head p.lede{
+  font-family:var(--f-body);font-size:13.5px;line-height:1.5;color:var(--ls-muted);
+  margin:0;max-width:38ch;
+}
+
+/* Body scroll area */
+.body{
+  flex:1 1 auto;overflow:hidden;
+  padding:0 0 14px;
+  position:relative;
+}
+.body-inner{padding:0 22px}
+
+/* Cards */
+.card{
+  background:var(--ls-surface);
+  border:1px solid var(--ls-line);
+  border-radius:14px;padding:14px 16px;
+  margin-bottom:10px;
+}
+.card h3{
+  font-family:var(--f-display);font-weight:700;font-size:18px;line-height:1.1;
+  letter-spacing:-.015em;margin:0 0 6px;
+}
+.card .meta{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);
+}
+
+/* Bottom sticky nav */
+.botnav{
+  flex:0 0 auto;
+  background:rgba(251,247,240,.94);
+  backdrop-filter:saturate(140%) blur(12px);
+  border-top:1px solid var(--ls-line);
+  padding:10px 14px 22px;
+  display:flex;align-items:center;justify-content:space-between;gap:6px;
+}
+.botnav .btn-nav{
+  display:flex;align-items:center;gap:8px;flex:1;min-width:0;
+  padding:8px 10px;border-radius:10px;
+  font-family:var(--f-body);font-size:12px;font-weight:500;
+  color:var(--ls-charcoal);
+  background:transparent;border:none;cursor:pointer;
+  text-align:left;
+}
+.botnav .btn-nav .arr{
+  width:28px;height:28px;border-radius:50%;
+  background:var(--ls-surface);border:1px solid var(--ls-line);
+  display:flex;align-items:center;justify-content:center;flex:0 0 auto;
+}
+.botnav .btn-nav .lab{display:flex;flex-direction:column;line-height:1.2;min-width:0;flex:1}
+.botnav .btn-nav .lab small{font-family:var(--f-mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted)}
+.botnav .btn-nav .lab span{font-weight:600;font-size:12.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.botnav .btn-nav.next{flex-direction:row-reverse;text-align:right}
+.botnav .btn-nav.next .lab{align-items:flex-end}
+.botnav .dots{
+  display:flex;align-items:center;gap:5px;padding:0 2px;flex:0 0 auto;
+}
+.botnav .dots .d{
+  width:5px;height:5px;border-radius:50%;background:rgba(11,13,17,.15);
+}
+.botnav .dots .d.on{background:var(--ls-gold);width:18px;border-radius:3px}
+
+/* ─────────────────────────────────────────────────────────────────
+   MINDSET CARDS
+   ───────────────────────────────────────────────────────────────── */
+.truth{
+  background:var(--ls-charcoal);
+  color:#fff;border-radius:18px;padding:18px 18px 16px;margin-bottom:12px;
+  position:relative;overflow:hidden;
+}
+.truth::before{
+  content:"";position:absolute;right:-30px;top:-30px;width:120px;height:120px;
+  background:radial-gradient(circle,rgba(201,168,76,.35),transparent 70%);
+  pointer-events:none;
+}
+.truth .num{
+  font-family:var(--f-display);font-weight:700;font-size:54px;line-height:.9;color:var(--ls-gold);
+  letter-spacing:-.04em;
+}
+.truth .kicker{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--ls-gold-light);margin-bottom:6px;
+}
+.truth .quote{
+  font-family:var(--f-display);font-weight:600;font-size:21px;line-height:1.15;
+  letter-spacing:-.015em;margin:6px 0 0;
+}
+.truth .quote em{color:var(--ls-gold-light);font-style:italic;font-weight:500}
+.truth .by{
+  font-family:var(--f-body);font-style:italic;font-size:12px;color:rgba(255,255,255,.55);margin-top:10px;
+}
+
+.truth-row{display:grid;grid-template-columns:auto 1fr;gap:14px;align-items:flex-start}
+
+.errors-head{
+  display:flex;align-items:baseline;justify-content:space-between;margin:18px 0 8px;
+}
+.errors-head .label{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-coral-dark);
+  display:flex;align-items:center;gap:6px;
+}
+.errors-head .label::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--ls-coral)}
+.err{
+  display:flex;align-items:flex-start;gap:12px;padding:11px 4px;
+  border-top:1px solid var(--ls-line);
+}
+.err .n{
+  font-family:var(--f-mono);font-size:11px;color:var(--ls-coral-dark);font-weight:500;
+  width:22px;flex:0 0 auto;letter-spacing:.05em;
+}
+.err .txt{font-size:13.5px;line-height:1.4;color:var(--ls-charcoal)}
+.err .txt .strike{color:var(--ls-muted);text-decoration:line-through;text-decoration-thickness:1px}
+
+/* ─────────────────────────────────────────────────────────────────
+   MESSAGES M1
+   ───────────────────────────────────────────────────────────────── */
+.platform-tabs{
+  display:flex;gap:6px;margin-bottom:14px;padding:4px;
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:11px;
+}
+.platform-tabs .tab{
+  flex:1;display:flex;flex-direction:column;align-items:center;gap:2px;
+  padding:7px 4px;border-radius:8px;
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.06em;text-transform:uppercase;
+  color:var(--ls-muted);cursor:pointer;
+}
+.platform-tabs .tab .ic{font-family:var(--f-body);font-size:15px;line-height:1}
+.platform-tabs .tab.on{background:var(--ls-charcoal);color:#fff}
+
+.script{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:14px;
+  padding:14px 16px;margin-bottom:10px;position:relative;
+}
+.script .head{
+  display:flex;align-items:center;gap:8px;margin-bottom:10px;
+}
+.script .head .glyph{
+  width:26px;height:26px;border-radius:8px;
+  display:flex;align-items:center;justify-content:center;font-size:14px;
+  background:var(--ls-surface2);border:1px solid var(--ls-line);
+}
+.script .head h4{
+  font-family:var(--f-display);font-weight:700;font-size:16px;margin:0;letter-spacing:-.01em;
+}
+.script .head .sub{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);
+}
+.script .ctx{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ls-muted);
+  margin-bottom:6px;display:flex;align-items:center;gap:6px;
+}
+.script .ctx::before{content:"";width:14px;height:1px;background:var(--ls-line-2)}
+
+.lang-switch{
+  display:inline-flex;align-items:center;gap:0;
+  background:var(--ls-surface2);border:1px solid var(--ls-line);border-radius:99px;padding:2px;
+  font-family:var(--f-mono);font-size:10px;font-weight:500;letter-spacing:.02em;
+  margin-left:auto;
+}
+.lang-switch button{
+  border:none;background:transparent;padding:4px 9px;border-radius:99px;color:var(--ls-muted);cursor:pointer;
+  font:inherit;
+}
+.lang-switch button.on{background:var(--ls-charcoal);color:#fff}
+
+.msg-body{
+  font-family:var(--f-body);font-size:14px;line-height:1.55;
+  color:var(--ls-charcoal);
+  padding:12px 0 4px;
+  border-top:1px dashed var(--ls-line-2);
+}
+.msg-body p{margin:0 0 8px}
+.msg-body p:last-child{margin-bottom:0}
+.var{
+  display:inline-block;
+  font-family:var(--f-body);font-weight:600;font-size:13.5px;
+  color:var(--ls-gold-dark);
+  background:rgba(201,168,76,.12);
+  padding:1px 7px;border-radius:4px;
+  border:1px dashed rgba(201,168,76,.5);
+  margin:0 1px;line-height:1.2;
+}
+.var.teal{color:var(--ls-teal-dark);background:rgba(45,212,191,.13);border-color:rgba(15,118,110,.4)}
+
+.trad-line{
+  font-family:var(--f-body);font-style:italic;font-size:12.5px;line-height:1.5;color:var(--ls-muted);
+  padding:8px 0 0;border-top:1px dashed var(--ls-line);
+  margin-top:8px;
+}
+.trad-line::before{
+  content:"FR";font-family:var(--f-mono);font-style:normal;font-size:9px;letter-spacing:.14em;
+  background:var(--ls-surface2);padding:2px 5px;border-radius:3px;color:var(--ls-muted);
+  margin-right:7px;vertical-align:1px;
+}
+
+.script-actions{
+  display:flex;align-items:center;gap:6px;margin-top:10px;
+  padding-top:8px;border-top:1px solid var(--ls-line);
+}
+.btn{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:7px 11px;border-radius:8px;
+  font-family:var(--f-body);font-weight:600;font-size:12px;
+  border:1px solid var(--ls-line);background:var(--ls-surface);
+  color:var(--ls-charcoal);cursor:pointer;line-height:1;
+}
+.btn:hover{border-color:var(--ls-line-2)}
+.btn.copy{background:var(--ls-charcoal);color:#fff;border-color:transparent}
+.btn.copy .ic{color:var(--ls-gold-light)}
+.btn.send{
+  background:var(--ls-surface);
+  border-color:var(--ls-gold);
+  color:var(--ls-gold-dark);
+}
+.btn .ic{font-family:var(--f-mono);font-size:11px;line-height:1}
+.btn.ghost{background:transparent;border-color:transparent;color:var(--ls-muted);padding:7px 8px}
+.script-actions .spacer{flex:1}
+.script-actions .stat-mini{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--ls-muted);
+  display:flex;align-items:center;gap:5px;
+}
+.script-actions .stat-mini b{font-family:var(--f-body);font-weight:700;font-size:12px;letter-spacing:0;text-transform:none;color:var(--ls-charcoal)}
+
+/* ─────────────────────────────────────────────────────────────────
+   OBJECTIONS
+   ───────────────────────────────────────────────────────────────── */
+.obj{
+  border-bottom:1px solid var(--ls-line);
+  padding:16px 0 18px;
+}
+.obj:first-child{padding-top:6px}
+.obj:last-child{border-bottom:none}
+.obj .quote{
+  display:flex;gap:10px;align-items:flex-start;
+}
+.obj .quote .n{
+  font-family:var(--f-display);font-weight:700;font-size:24px;line-height:1;
+  color:var(--ls-charcoal);letter-spacing:-.03em;flex:0 0 auto;width:34px;
+}
+.obj .quote .n small{font-family:var(--f-mono);font-size:9px;letter-spacing:.14em;color:var(--ls-muted);font-weight:500;display:block;line-height:1.6}
+.obj .quote q{
+  font-family:var(--f-display);font-weight:600;font-style:italic;font-size:18px;line-height:1.2;
+  letter-spacing:-.01em;quotes:none;color:var(--ls-charcoal);
+}
+.obj .quote q::before{content:"«\00a0"}
+.obj .quote q::after{content:"\00a0»"}
+
+.obj-row{
+  display:grid;grid-template-columns:24px 1fr;gap:10px;
+  align-items:flex-start;margin-top:10px;
+}
+.obj-row .badge{
+  display:inline-flex;align-items:center;justify-content:center;
+  width:22px;height:22px;border-radius:6px;font-family:var(--f-mono);font-size:11px;font-weight:600;
+  margin-top:2px;
+}
+.obj-row.bad .badge{background:rgba(251,113,133,.14);color:var(--ls-coral-dark);border:1px solid rgba(251,113,133,.3)}
+.obj-row.good .badge{background:rgba(45,212,191,.16);color:var(--ls-teal-dark);border:1px solid rgba(15,118,110,.25)}
+.obj-row .lbl{
+  font-family:var(--f-mono);font-size:9px;letter-spacing:.16em;text-transform:uppercase;
+  font-weight:600;
+}
+.obj-row.bad .lbl{color:var(--ls-coral-dark)}
+.obj-row.good .lbl{color:var(--ls-teal-dark)}
+.obj-row p{
+  margin:2px 0 0;font-size:13.5px;line-height:1.45;color:var(--ls-charcoal);
+}
+.obj-row.bad p{color:var(--ls-muted);text-decoration:line-through;text-decoration-color:rgba(251,113,133,.35);text-decoration-thickness:1px}
+.obj-row.good p .var{font-weight:600}
+
+.obj-actions{
+  display:flex;gap:6px;margin-top:12px;align-items:center;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   TROUVER
+   ───────────────────────────────────────────────────────────────── */
+.flags{
+  display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:14px;
+}
+.flag-col{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:12px;
+  padding:11px 12px;
+}
+.flag-col.green{background:linear-gradient(180deg,rgba(45,212,191,.07),transparent 60%),#fff}
+.flag-col.red{background:linear-gradient(180deg,rgba(251,113,133,.07),transparent 60%),#fff}
+.flag-col h5{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+  margin:0 0 8px;display:flex;align-items:center;gap:6px;
+}
+.flag-col.green h5{color:var(--ls-teal-dark)}
+.flag-col.red h5{color:var(--ls-coral-dark)}
+.flag-col h5 .dot{width:7px;height:7px;border-radius:50%}
+.flag-col.green h5 .dot{background:var(--ls-teal);box-shadow:0 0 0 3px rgba(45,212,191,.2)}
+.flag-col.red h5 .dot{background:var(--ls-coral);box-shadow:0 0 0 3px rgba(251,113,133,.2)}
+.flag-col ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px}
+.flag-col li{
+  font-size:12.5px;line-height:1.35;color:var(--ls-charcoal);
+  display:flex;gap:6px;align-items:flex-start;
+}
+.flag-col li::before{
+  content:"";flex:0 0 auto;width:4px;height:4px;border-radius:50%;margin-top:7px;
+}
+.flag-col.green li::before{background:var(--ls-teal-dark)}
+.flag-col.red li::before{background:var(--ls-coral-dark)}
+
+.scan-timer{
+  display:inline-flex;align-items:center;gap:6px;
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--ls-gold-dark);background:rgba(201,168,76,.12);padding:4px 9px;border-radius:99px;
+  margin-bottom:10px;
+}
+.scan-timer .pulse{
+  width:6px;height:6px;border-radius:50%;background:var(--ls-gold);
+  box-shadow:0 0 0 3px rgba(201,168,76,.25);
+}
+
+.hashtag-card{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:14px;
+  padding:13px 14px;margin-bottom:10px;
+}
+.hashtag-card .htag-head{
+  display:flex;align-items:center;justify-content:space-between;
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ls-muted);
+  margin-bottom:8px;
+}
+.hashtag-card .htag-head b{color:var(--ls-charcoal);font-weight:600}
+.htag-row{
+  display:flex;flex-wrap:wrap;gap:5px;margin-bottom:9px;
+}
+.htag-row:last-child{margin-bottom:0}
+.htag-row .cat{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--ls-muted);align-self:center;margin-right:4px;
+}
+.htag{
+  font-family:var(--f-mono);font-size:11.5px;font-weight:500;
+  padding:3px 8px;border-radius:99px;
+  background:var(--ls-surface2);color:var(--ls-charcoal);
+  border:1px solid var(--ls-line);
+}
+.htag.gold{background:rgba(201,168,76,.13);border-color:rgba(201,168,76,.3);color:var(--ls-gold-dark)}
+.htag.teal{background:rgba(45,212,191,.13);border-color:rgba(15,118,110,.25);color:var(--ls-teal-dark)}
+.htag.purple{background:rgba(124,58,237,.10);border-color:rgba(124,58,237,.25);color:var(--ls-purple)}
+
+.src-card{
+  background:var(--ls-charcoal);color:#fff;border-radius:14px;padding:14px 16px;margin-bottom:10px;
+  position:relative;overflow:hidden;
+}
+.src-card::before{
+  content:"";position:absolute;left:-30px;bottom:-30px;width:100px;height:100px;
+  background:radial-gradient(circle,rgba(201,168,76,.4),transparent 70%);
+}
+.src-card h4{
+  font-family:var(--f-display);font-weight:700;font-size:16px;margin:0 0 4px;letter-spacing:-.01em;
+  position:relative;
+}
+.src-card .kk{
+  font-family:var(--f-mono);font-size:9.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-gold-light);
+  margin-bottom:8px;
+}
+.src-row{
+  display:grid;grid-template-columns:46px 1fr;gap:10px;align-items:flex-start;
+  padding:8px 0;border-top:1px solid rgba(255,255,255,.10);
+}
+.src-row:first-of-type{border-top:none}
+.src-row .src-lab{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;
+  color:var(--ls-gold-light);font-weight:500;padding-top:2px;
+}
+.src-row .src-body{font-size:13px;line-height:1.45;color:rgba(255,255,255,.86)}
+.src-row .src-body em{color:#fff;font-style:italic;font-weight:500}
+
+/* ─────────────────────────────────────────────────────────────────
+   TOAST
+   ───────────────────────────────────────────────────────────────── */
+.toast{
+  position:absolute;left:50%;bottom:96px;transform:translateX(-50%);
+  background:var(--ls-charcoal);color:#fff;
+  padding:9px 14px;border-radius:99px;
+  font-family:var(--f-body);font-size:12.5px;font-weight:500;
+  display:flex;align-items:center;gap:8px;
+  box-shadow:0 8px 20px rgba(11,13,17,.3);
+  z-index:20;
+}
+.toast .ic{color:var(--ls-gold-light);font-family:var(--f-mono);font-size:11px}
+
+/* ─────────────────────────────────────────────────────────────────
+   DESKTOP (640 centered)
+   ───────────────────────────────────────────────────────────────── */
+.desktop-app{
+  flex:1;background:var(--ls-cream);
+  display:flex;justify-content:center;
+  overflow:hidden;
+  position:relative;
+}
+.desktop-shell{
+  width:640px;max-width:100%;padding:32px 24px 0;
+  display:flex;flex-direction:column;
+}
+.desktop-shell .hdr{
+  padding:0 0 16px;border-bottom:1px solid var(--ls-line);
+  background:transparent;
+}
+.desktop-shell .hdr .row1{padding:0 0 14px}
+.desktop-shell .index{padding:5px}
+.desktop-shell .section-meta{padding:18px 0 6px}
+.desktop-shell .section-head{padding:0 0 18px}
+.desktop-shell .section-head h2{font-size:38px}
+.desktop-shell .section-head p.lede{font-size:14.5px;max-width:48ch}
+.desktop-shell .body{padding:0;overflow:visible}
+.desktop-shell .body-inner{padding:0 0 24px}
+
+.desktop-shell .platform-tabs .tab .ic{font-size:17px}
+.desktop-shell .platform-tabs .tab{padding:9px 4px;font-size:10px}
+
+.desktop-shell .script .head h4{font-size:18px}
+.desktop-shell .msg-body{font-size:15px}
+
+.kbd-hint{
+  position:absolute;right:28px;bottom:20px;
+  display:flex;align-items:center;gap:8px;
+  font-family:var(--f-mono);font-size:11px;letter-spacing:.04em;color:var(--ls-muted);
+  background:rgba(255,255,255,.85);
+  border:1px solid var(--ls-line);
+  border-radius:99px;padding:7px 12px;
+}
+.kbd-hint kbd{
+  font-family:var(--f-mono);font-size:10px;font-weight:600;color:var(--ls-charcoal);
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-bottom-width:2px;
+  border-radius:5px;padding:2px 6px;line-height:1;
+}
+
+/* desktop two-col layout for messages */
+.dt-two-col{
+  display:grid;grid-template-columns:1.05fr .95fr;gap:14px;
+}
+.dt-two-col > * {min-width:0}
+.dt-rail{
+  background:var(--ls-surface);border:1px solid var(--ls-line);border-radius:14px;
+  padding:14px 16px;align-self:start;position:sticky;top:0;
+}
+.dt-rail h6{
+  font-family:var(--f-mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--ls-muted);
+  margin:0 0 10px;
+}
+.dt-rail .rail-item{
+  display:flex;align-items:center;gap:10px;padding:9px 8px;border-radius:9px;cursor:pointer;
+  font-size:13px;
+}
+.dt-rail .rail-item.on{background:var(--ls-surface2);font-weight:600}
+.dt-rail .rail-item .ic{width:22px;height:22px;display:flex;align-items:center;justify-content:center;font-size:14px;border-radius:6px;background:var(--ls-surface2);border:1px solid var(--ls-line)}
+.dt-rail .rail-item.on .ic{background:var(--ls-charcoal);color:#fff;border-color:transparent}
+.dt-rail .rail-item small{font-family:var(--f-mono);font-size:9.5px;color:var(--ls-muted);margin-left:auto;letter-spacing:.08em}
+
+/* tweak helpers */
+.spacer-12{height:12px}
+.spacer-16{height:16px}
+.spacer-20{height:20px}
+.row-gap{display:flex;align-items:center;gap:8px}
+
+/* footer fade in body to hint scroll */
+.body{
+  -webkit-mask-image:linear-gradient(180deg,#000 0,#000 calc(100% - 18px),transparent);
+          mask-image:linear-gradient(180deg,#000 0,#000 calc(100% - 18px),transparent);
+}
+
+@media (prefers-reduced-motion: reduce){
+  *{transition:none !important;animation:none !important}
+}
+</style>
+</head>
+<body>
+
+<header class="canvas-head">
+  <div>
+    <p class="sub">La Base 360 · /prospection · refonte v5</p>
+    <h1>L'index <em style="font-style:italic;font-weight:500">éditorial</em>.</h1>
+    <p class="sub" style="margin-top:8px;max-width:60ch;color:rgba(11,13,17,.6);letter-spacing:.06em;font-size:12px;text-transform:none">
+      Système&nbsp;: filtres jumeaux compacts → index numéroté des 10 modules → 1 module visible à la fois → nav précédent/suivant en bas. Mobile-first 393&nbsp;px, desktop centré 640&nbsp;px.
+    </p>
+  </div>
+  <div class="meta">
+    <div>Header <b>136 px</b></div>
+    <div>Modules <b>1 tap</b></div>
+    <div>Reduced motion <b>respecté</b></div>
+    <div>Frames <b>4 + 1</b></div>
+  </div>
+</header>
+
+<main class="stage">
+
+<!-- ════════════════════════════════════════════════════════════════
+     FRAME 1 — HOME · MINDSET
+     ════════════════════════════════════════════════════════════════ -->
+<section class="frame">
+  <div class="phone">
+    <div class="notch"></div>
+    <div class="screen">
+      <div class="app">
+
+        <!-- status bar -->
+        <div class="status">
+          <span>9:41</span>
+          <div class="right">
+            <!-- signal -->
+            <svg width="17" height="11" viewBox="0 0 17 11" fill="none"><rect x="0" y="7" width="3" height="4" rx="1" fill="#0B0D11"/><rect x="4.5" y="5" width="3" height="6" rx="1" fill="#0B0D11"/><rect x="9" y="2.5" width="3" height="8.5" rx="1" fill="#0B0D11"/><rect x="13.5" y="0" width="3" height="11" rx="1" fill="#0B0D11"/></svg>
+            <!-- wifi -->
+            <svg width="16" height="11" viewBox="0 0 16 11" fill="none"><path d="M8 10.5 9.5 8.6c-.8-.7-2.2-.7-3 0L8 10.5Z" fill="#0B0D11"/><path d="M3 4.6c2.9-2.7 7.2-2.7 10 0l-1.5 1.6c-1.9-1.7-5-1.7-7 0L3 4.6Z" fill="#0B0D11"/><path d="M5.5 7.2c1.4-1.3 3.6-1.3 5 0L9 8.7c-.6-.5-1.4-.5-2 0L5.5 7.2Z" fill="#0B0D11"/></svg>
+            <!-- battery -->
+            <svg width="26" height="12" viewBox="0 0 26 12" fill="none"><rect x="0.5" y="0.5" width="22" height="11" rx="3" stroke="#0B0D11"/><rect x="23.5" y="3.5" width="2" height="5" rx="1" fill="#0B0D11"/><rect x="2" y="2" width="19" height="8" rx="1.5" fill="#0B0D11"/></svg>
+          </div>
+        </div>
+
+        <!-- header -->
+        <div class="hdr">
+
+          <!-- row 1: brand + 7-day stat chip -->
+          <div class="row1">
+            <div class="brand">
+              <span class="gem"></span>
+              La Base 360<small>· prospection</small>
+            </div>
+            <div class="stat-chip" title="Activité 7 derniers jours">
+              <span class="dot-live"></span>
+              <span><b>12</b> envoyés · <b>3</b> RDV</span>
+              <span style="color:var(--ls-muted)">·&nbsp;7j</span>
+            </div>
+          </div>
+
+          <!-- row 2: twin pickers -->
+          <div class="pickers">
+            <div class="picker">
+              <span class="flag">🇫🇷</span>
+              <div class="info-stack">
+                <span class="lbl">Marché</span>
+                <span class="val">France</span>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+            <div class="picker">
+              <span class="glyph">⚖️</span>
+              <div class="info-stack">
+                <span class="lbl">Profil cible</span>
+                <span class="val">Perte de poids&nbsp;·&nbsp;F</span>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+          </div>
+
+          <!-- row 3: index rail -->
+          <nav class="index" aria-label="Index des 10 modules">
+            <div class="step active"><span class="n">01</span><span class="ic">🧠</span><span class="name">Mindset</span></div>
+            <div class="step"><span class="n">02</span><span class="ic">🔍</span></div>
+            <div class="step"><span class="n">03</span><span class="ic">📨</span></div>
+            <div class="step"><span class="n">04</span><span class="ic">🌳</span></div>
+            <div class="step"><span class="n">05</span><span class="ic">🛡️</span></div>
+            <div class="step"><span class="n">06</span><span class="ic">📞</span></div>
+            <div class="step dim"><span class="n">07</span><span class="ic">🎯</span></div>
+            <div class="more">→</div>
+          </nav>
+        </div>
+
+        <!-- section meta -->
+        <div class="section-meta">
+          <span class="step-of"><b>01</b>&nbsp;/&nbsp;10</span>
+          <span>≈&nbsp;4&nbsp;min · lu&nbsp;<b style="color:var(--ls-charcoal)">2&times;</b> cette&nbsp;sem.</span>
+        </div>
+
+        <!-- section heading -->
+        <div class="section-head">
+          <div class="kicker">Module · Mindset &amp; posture</div>
+          <h2>D'abord, <span class="em">le ton</span>.</h2>
+          <p class="lede">Trois vérités à intégrer avant le premier message. Cinq erreurs qui sabotent 80% des conversations.</p>
+        </div>
+
+        <!-- body -->
+        <div class="body"><div class="body-inner">
+
+          <!-- truth 1 -->
+          <article class="truth">
+            <div class="truth-row">
+              <div class="num">01</div>
+              <div>
+                <div class="kicker">Vérité n°1 · posture</div>
+                <p class="quote">Tu ne <em>vends</em> pas. Tu invites quelqu'un à se transformer.</p>
+                <p class="by">— extrait <em>Méthode 360</em></p>
+              </div>
+            </div>
+          </article>
+
+          <!-- truth 2 (lighter card hint of next) -->
+          <article class="card" style="border-style:solid;padding:14px 16px;background:linear-gradient(180deg,#fff,var(--ls-surface2));">
+            <div class="row-gap" style="margin-bottom:4px;color:var(--ls-muted)">
+              <span class="ctx" style="font-family:var(--f-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase">Vérité n°2 · refus</span>
+            </div>
+            <p style="font-family:var(--f-display);font-weight:600;font-size:19px;line-height:1.2;letter-spacing:-.015em;margin:0">
+              Le <em style="color:var(--ls-gold-dark);font-weight:500">«&nbsp;non&nbsp;»</em> n'existe pas. Seulement <em style="color:var(--ls-gold-dark);font-style:italic;font-weight:500">pas encore</em>, <em style="color:var(--ls-gold-dark);font-style:italic;font-weight:500">pas comme ça</em>, <em style="color:var(--ls-gold-dark);font-style:italic;font-weight:500">pas avec toi</em>.
+            </p>
+          </article>
+
+          <div class="errors-head">
+            <span class="label">5 erreurs à éviter</span>
+            <span style="font-family:var(--f-mono);font-size:10px;color:var(--ls-muted);letter-spacing:.1em">↓ scroll</span>
+          </div>
+          <div class="err">
+            <span class="n">01</span>
+            <div class="txt"><span class="strike">Parler produit</span> avant d'avoir écouté le besoin.</div>
+          </div>
+          <div class="err">
+            <span class="n">02</span>
+            <div class="txt"><span class="strike">Suivre tout le monde</span> au lieu de cibler des profils qualifiés.</div>
+          </div>
+
+        </div></div>
+
+        <!-- bottom nav -->
+        <nav class="botnav">
+          <button class="btn-nav prev" disabled style="opacity:.45">
+            <span class="arr">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M7.5 3 4 6l3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="lab"><small>Début</small><span>Index</span></span>
+          </button>
+          <div class="dots" aria-hidden="true">
+            <span class="d on"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span>
+          </div>
+          <button class="btn-nav next">
+            <span class="arr">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M4.5 3 8 6l-3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="lab"><small>Suivant · 02</small><span>Trouver</span></span>
+          </button>
+        </nav>
+
+      </div>
+      <div class="home-indicator"></div>
+    </div>
+  </div>
+
+  <footer class="annotation">
+    <span class="tag">Frame 01 · Home · Mindset</span>
+    <p style="margin:0">
+      <span class="num">A.</span> Le <b>header tient en 136&nbsp;px</b>&nbsp;: brand+stat 7j (28), <b>jumeau marché×profil</b> (44), <b>index numéroté</b> 01–10 (52). Aucune ligne de pills ne déborde&nbsp;; le module actif s'étale, les autres restent visibles en mode icône+numéro.<br />
+      <span class="num">B.</span> La <span class="hl">vérité n°1</span> est traitée comme une <b>pull-quote éditoriale</b> sur fond charcoal&nbsp;: ton magazine, pas ton coach. Le scroll révèle vérité 2 puis les 5 erreurs.<br />
+      <span class="num">C.</span> Bottom nav <b>précédent / suivant + dots</b> (1 dot par module, gold = actif) pour la lecture linéaire.
+    </p>
+  </footer>
+</section>
+
+<!-- ════════════════════════════════════════════════════════════════
+     FRAME 2 — MESSAGES M1
+     ════════════════════════════════════════════════════════════════ -->
+<section class="frame">
+  <div class="phone">
+    <div class="notch"></div>
+    <div class="screen">
+      <div class="app">
+
+        <div class="status">
+          <span>9:41</span>
+          <div class="right">
+            <svg width="17" height="11" viewBox="0 0 17 11" fill="none"><rect x="0" y="7" width="3" height="4" rx="1" fill="#0B0D11"/><rect x="4.5" y="5" width="3" height="6" rx="1" fill="#0B0D11"/><rect x="9" y="2.5" width="3" height="8.5" rx="1" fill="#0B0D11"/><rect x="13.5" y="0" width="3" height="11" rx="1" fill="#0B0D11"/></svg>
+            <svg width="16" height="11" viewBox="0 0 16 11" fill="none"><path d="M8 10.5 9.5 8.6c-.8-.7-2.2-.7-3 0L8 10.5Z" fill="#0B0D11"/><path d="M3 4.6c2.9-2.7 7.2-2.7 10 0l-1.5 1.6c-1.9-1.7-5-1.7-7 0L3 4.6Z" fill="#0B0D11"/><path d="M5.5 7.2c1.4-1.3 3.6-1.3 5 0L9 8.7c-.6-.5-1.4-.5-2 0L5.5 7.2Z" fill="#0B0D11"/></svg>
+            <svg width="26" height="12" viewBox="0 0 26 12" fill="none"><rect x="0.5" y="0.5" width="22" height="11" rx="3" stroke="#0B0D11"/><rect x="23.5" y="3.5" width="2" height="5" rx="1" fill="#0B0D11"/><rect x="2" y="2" width="19" height="8" rx="1.5" fill="#0B0D11"/></svg>
+          </div>
+        </div>
+
+        <div class="hdr">
+          <div class="row1">
+            <div class="brand">
+              <span class="gem"></span>
+              La Base 360<small>· prospection</small>
+            </div>
+            <div class="stat-chip">
+              <span class="dot-live"></span>
+              <span><b>12</b> envoyés · <b>3</b> RDV</span>
+              <span style="color:var(--ls-muted)">·&nbsp;7j</span>
+            </div>
+          </div>
+
+          <div class="pickers">
+            <div class="picker">
+              <span class="flag">🇬🇧</span>
+              <div class="info-stack">
+                <span class="lbl">Marché</span>
+                <span class="val">International · EN</span>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+            <div class="picker">
+              <span class="glyph">🏃</span>
+              <div class="info-stack">
+                <span class="lbl">Profil cible</span>
+                <span class="val">Sportif</span>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+          </div>
+
+          <nav class="index">
+            <div class="step"><span class="n">01</span><span class="ic">🧠</span></div>
+            <div class="step"><span class="n">02</span><span class="ic">🔍</span></div>
+            <div class="step active"><span class="n">03</span><span class="ic">📨</span><span class="name">Messages M1</span></div>
+            <div class="step"><span class="n">04</span><span class="ic">🌳</span></div>
+            <div class="step"><span class="n">05</span><span class="ic">🛡️</span></div>
+            <div class="step"><span class="n">06</span><span class="ic">📞</span></div>
+            <div class="more">→</div>
+          </nav>
+        </div>
+
+        <div class="section-meta">
+          <span class="step-of"><b>03</b>&nbsp;/&nbsp;10</span>
+          <span><b style="color:var(--ls-charcoal)">4</b>&nbsp;plateformes · trad.&nbsp;FR&nbsp;ON</span>
+        </div>
+
+        <div class="section-head">
+          <div class="kicker">Module · Premier contact</div>
+          <h2>Messages <span class="em">M1</span>.</h2>
+          <p class="lede">Sélectionne ta plateforme. Personnalise les variables en gold avant de copier.</p>
+        </div>
+
+        <div class="body"><div class="body-inner">
+
+          <!-- platform tabs -->
+          <div class="platform-tabs">
+            <div class="tab on"><span class="ic">📷</span>Insta</div>
+            <div class="tab"><span class="ic">f</span>Facebook</div>
+            <div class="tab"><span class="ic">💬</span>WhatsApp</div>
+            <div class="tab"><span class="ic">✉</span>SMS</div>
+          </div>
+
+          <!-- Insta script -->
+          <article class="script">
+            <div class="head">
+              <span class="glyph">📷</span>
+              <div>
+                <h4>Instagram · DM</h4>
+                <span class="sub">après vue de story</span>
+              </div>
+              <div class="lang-switch">
+                <button>EN</button><button class="on">FR</button>
+              </div>
+            </div>
+            <div class="ctx">Contexte · prospect a regardé ta story 2× cette semaine</div>
+            <div class="msg-body">
+              <p>Hey <span class="var">[prénom]</span>! Saw you were following <span class="var teal">[contexte&nbsp;/&nbsp;compte fitness]</span> — what are you working on right now on the training side?</p>
+            </div>
+            <div class="trad-line">
+              Hey <span class="var">[prénom]</span>&nbsp;! J'ai vu que tu suivais <span class="var teal">[contexte]</span> — tu bosses sur quoi côté entraînement en ce moment&nbsp;?
+            </div>
+            <div class="script-actions">
+              <button class="btn copy"><span class="ic">⌘C</span>Copier</button>
+              <button class="btn send"><span class="ic">↗</span>J'ai envoyé</button>
+              <div class="spacer"></div>
+              <span class="stat-mini">Taux réponse <b>42%</b></span>
+            </div>
+          </article>
+
+          <!-- Facebook script (collapsed-ish) -->
+          <article class="script">
+            <div class="head">
+              <span class="glyph" style="background:#1877F210;border-color:#1877F230;color:#1877F2;font-weight:700">f</span>
+              <div>
+                <h4>Facebook · Messenger</h4>
+                <span class="sub">via ami commun</span>
+              </div>
+              <div class="lang-switch">
+                <button>EN</button><button class="on">FR</button>
+              </div>
+            </div>
+            <div class="msg-body" style="padding-top:8px;border-top:none">
+              <p>Hey <span class="var">[prénom]</span>, I noticed we both know <span class="var teal">[ami commun]</span>. I work with athletes who want more morning energy — does that resonate with where you're at?</p>
+            </div>
+            <div class="script-actions">
+              <button class="btn copy"><span class="ic">⌘C</span>Copier</button>
+              <button class="btn send"><span class="ic">↗</span>J'ai envoyé</button>
+            </div>
+          </article>
+
+        </div></div>
+
+        <nav class="botnav">
+          <button class="btn-nav prev">
+            <span class="arr">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M7.5 3 4 6l3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="lab"><small>Précédent · 02</small><span>Trouver</span></span>
+          </button>
+          <div class="dots" aria-hidden="true">
+            <span class="d"></span><span class="d"></span><span class="d on"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span>
+          </div>
+          <button class="btn-nav next">
+            <span class="arr">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M4.5 3 8 6l-3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="lab"><small>Suivant · 04</small><span>Arbres M2/M3</span></span>
+          </button>
+        </nav>
+
+        <!-- toast peek (mid-flight) -->
+        <div class="toast">
+          <span class="ic">✓</span>
+          Copié&nbsp;! <span style="color:rgba(255,255,255,.55);font-family:var(--f-mono);font-size:11px;margin-left:4px">— pense au prénom</span>
+        </div>
+
+      </div>
+      <div class="home-indicator"></div>
+    </div>
+  </div>
+
+  <footer class="annotation">
+    <span class="tag">Frame 02 · Messages M1</span>
+    <p style="margin:0">
+      <span class="num">A.</span> <b>Plateforme = sous-tab segmenté</b> (Insta / FB / WA / SMS). Un script par plateforme, pas 4 cartes empilées&nbsp;: la prospection est <i>une</i> conversation par canal.<br />
+      <span class="num">B.</span> Les variables <span class="hl">[prénom]</span> et <span style="color:var(--ls-teal-dark)">[contexte]</span> sont des <b>pills cliquables gold/teal</b>&nbsp;: deux couleurs pour distinguer les deux familles (nom propre vs. contextuel).<br />
+      <span class="num">C.</span> <b>Toggle EN↔FR au niveau de la carte</b> + <b>traduction FR inline en italique</b> sous le script original. Le distri voit ce qu'il copie en EN <i>et</i> ce que ça veut dire.<br />
+      <span class="num">D.</span> Bouton <b>«&nbsp;J'ai envoyé&nbsp;»</b> à côté de «&nbsp;Copier&nbsp;»&nbsp;: déclenche le tracking 7&nbsp;j. Stat de taux de réponse exposée discrètement par script.
+    </p>
+  </footer>
+</section>
+
+<!-- ════════════════════════════════════════════════════════════════
+     FRAME 3 — OBJECTIONS
+     ════════════════════════════════════════════════════════════════ -->
+<section class="frame">
+  <div class="phone">
+    <div class="notch"></div>
+    <div class="screen">
+      <div class="app">
+
+        <div class="status">
+          <span>9:41</span>
+          <div class="right">
+            <svg width="17" height="11" viewBox="0 0 17 11" fill="none"><rect x="0" y="7" width="3" height="4" rx="1" fill="#0B0D11"/><rect x="4.5" y="5" width="3" height="6" rx="1" fill="#0B0D11"/><rect x="9" y="2.5" width="3" height="8.5" rx="1" fill="#0B0D11"/><rect x="13.5" y="0" width="3" height="11" rx="1" fill="#0B0D11"/></svg>
+            <svg width="16" height="11" viewBox="0 0 16 11" fill="none"><path d="M8 10.5 9.5 8.6c-.8-.7-2.2-.7-3 0L8 10.5Z" fill="#0B0D11"/><path d="M3 4.6c2.9-2.7 7.2-2.7 10 0l-1.5 1.6c-1.9-1.7-5-1.7-7 0L3 4.6Z" fill="#0B0D11"/><path d="M5.5 7.2c1.4-1.3 3.6-1.3 5 0L9 8.7c-.6-.5-1.4-.5-2 0L5.5 7.2Z" fill="#0B0D11"/></svg>
+            <svg width="26" height="12" viewBox="0 0 26 12" fill="none"><rect x="0.5" y="0.5" width="22" height="11" rx="3" stroke="#0B0D11"/><rect x="23.5" y="3.5" width="2" height="5" rx="1" fill="#0B0D11"/><rect x="2" y="2" width="19" height="8" rx="1.5" fill="#0B0D11"/></svg>
+          </div>
+        </div>
+
+        <div class="hdr">
+          <div class="row1">
+            <div class="brand">
+              <span class="gem"></span>
+              La Base 360<small>· prospection</small>
+            </div>
+            <div class="stat-chip">
+              <span class="dot-live"></span>
+              <span><b>12</b> envoyés · <b>3</b> RDV</span>
+              <span style="color:var(--ls-muted)">·&nbsp;7j</span>
+            </div>
+          </div>
+
+          <div class="pickers">
+            <div class="picker">
+              <span class="flag">🇫🇷</span>
+              <div class="info-stack">
+                <span class="lbl">Marché</span>
+                <span class="val">France</span>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+            <div class="picker">
+              <span class="glyph">💼</span>
+              <div class="info-stack">
+                <span class="lbl">Profil cible</span>
+                <span class="val">Business</span>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+          </div>
+
+          <nav class="index">
+            <div class="step"><span class="n">03</span><span class="ic">📨</span></div>
+            <div class="step"><span class="n">04</span><span class="ic">🌳</span></div>
+            <div class="step active"><span class="n">05</span><span class="ic">🛡️</span><span class="name">Objections</span></div>
+            <div class="step"><span class="n">06</span><span class="ic">📞</span></div>
+            <div class="step"><span class="n">07</span><span class="ic">🎯</span></div>
+            <div class="step"><span class="n">08</span><span class="ic">🔁</span></div>
+            <div class="more">→</div>
+          </nav>
+        </div>
+
+        <div class="section-meta">
+          <span class="step-of"><b>05</b>&nbsp;/&nbsp;10</span>
+          <span><b style="color:var(--ls-charcoal)">8</b>&nbsp;objections types</span>
+        </div>
+
+        <div class="section-head">
+          <div class="kicker">Module · Réponses aux refus</div>
+          <h2>Les huit <span class="em">non</span>.</h2>
+          <p class="lede">Pour chaque objection&nbsp;: ce qu'il ne faut pas dire, ce qui ouvre la porte.</p>
+        </div>
+
+        <div class="body"><div class="body-inner">
+
+          <!-- objection 1 -->
+          <article class="obj">
+            <div class="quote">
+              <div class="n">01<small>·&nbsp;budget</small></div>
+              <q>Je n'ai pas le budget pour ça.</q>
+            </div>
+            <div class="obj-row bad">
+              <span class="badge">✕</span>
+              <div><span class="lbl">À ne pas dire</span><p>«&nbsp;Mais c'est pas cher du tout en fait&nbsp;!&nbsp;»</p></div>
+            </div>
+            <div class="obj-row good">
+              <span class="badge">✓</span>
+              <div><span class="lbl">Ce qui ouvre</span><p>«&nbsp;Je comprends. C'est quoi le budget que tu te fixes pour <span class="var">[forme&nbsp;/&nbsp;objectif]</span> chaque mois en ce moment&nbsp;?&nbsp;»</p></div>
+            </div>
+            <div class="obj-actions">
+              <button class="btn copy"><span class="ic">⌘C</span>Copier la réponse</button>
+              <button class="btn ghost">Variantes&nbsp;·&nbsp;3</button>
+            </div>
+          </article>
+
+          <!-- objection 2 -->
+          <article class="obj">
+            <div class="quote">
+              <div class="n">02<small>·&nbsp;échec passé</small></div>
+              <q>J'connais quelqu'un, ça n'a pas marché pour lui.</q>
+            </div>
+            <div class="obj-row bad">
+              <span class="badge">✕</span>
+              <div><span class="lbl">À ne pas dire</span><p>«&nbsp;Bah il s'est mal pris alors.&nbsp;»</p></div>
+            </div>
+            <div class="obj-row good">
+              <span class="badge">✓</span>
+              <div><span class="lbl">Ce qui ouvre</span><p>«&nbsp;Intéressant. Tu sais ce qu'il a fait exactement&nbsp;? Souvent c'est un petit détail qui change tout — je te raconte&nbsp;?&nbsp;»</p></div>
+            </div>
+          </article>
+
+          <!-- objection 3 peek -->
+          <article class="obj">
+            <div class="quote">
+              <div class="n">03<small>·&nbsp;secte</small></div>
+              <q>C'est une secte ton truc, non&nbsp;?</q>
+            </div>
+          </article>
+
+        </div></div>
+
+        <nav class="botnav">
+          <button class="btn-nav prev">
+            <span class="arr">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M7.5 3 4 6l3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="lab"><small>Précédent · 04</small><span>Arbres M2/M3</span></span>
+          </button>
+          <div class="dots" aria-hidden="true">
+            <span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d on"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span>
+          </div>
+          <button class="btn-nav next">
+            <span class="arr">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M4.5 3 8 6l-3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="lab"><small>Suivant · 06</small><span>Post-appel</span></span>
+          </button>
+        </nav>
+
+      </div>
+      <div class="home-indicator"></div>
+    </div>
+  </div>
+
+  <footer class="annotation">
+    <span class="tag">Frame 03 · Objections</span>
+    <p style="margin:0">
+      <span class="num">A.</span> Format <b>quote + 2 réponses (rouge barrée / verte)</b>. La citation passe en <i>Syne italique</i> pour donner le ton voix-haute&nbsp;: tu lis ce que le prospect dit, pas une ligne de spec.<br />
+      <span class="num">B.</span> Le <span style="color:var(--ls-coral-dark);font-weight:600">«&nbsp;à ne pas dire&nbsp;»</span> est <b>barré</b> et muet (gris)&nbsp;: tu ne risques pas de copier-coller la mauvaise. Le <span style="color:var(--ls-teal-dark);font-weight:600">«&nbsp;ce qui ouvre&nbsp;»</span> a son bouton Copier dédié.<br />
+      <span class="num">C.</span> «&nbsp;Variantes · 3&nbsp;» en ghost button pour ouvrir un sheet d'alternatives — pas en accordéon vertical, pour rester dans le module.
+    </p>
+  </footer>
+</section>
+
+<!-- ════════════════════════════════════════════════════════════════
+     FRAME 4 — TROUVER
+     ════════════════════════════════════════════════════════════════ -->
+<section class="frame">
+  <div class="phone">
+    <div class="notch"></div>
+    <div class="screen">
+      <div class="app">
+
+        <div class="status">
+          <span>9:41</span>
+          <div class="right">
+            <svg width="17" height="11" viewBox="0 0 17 11" fill="none"><rect x="0" y="7" width="3" height="4" rx="1" fill="#0B0D11"/><rect x="4.5" y="5" width="3" height="6" rx="1" fill="#0B0D11"/><rect x="9" y="2.5" width="3" height="8.5" rx="1" fill="#0B0D11"/><rect x="13.5" y="0" width="3" height="11" rx="1" fill="#0B0D11"/></svg>
+            <svg width="16" height="11" viewBox="0 0 16 11" fill="none"><path d="M8 10.5 9.5 8.6c-.8-.7-2.2-.7-3 0L8 10.5Z" fill="#0B0D11"/><path d="M3 4.6c2.9-2.7 7.2-2.7 10 0l-1.5 1.6c-1.9-1.7-5-1.7-7 0L3 4.6Z" fill="#0B0D11"/><path d="M5.5 7.2c1.4-1.3 3.6-1.3 5 0L9 8.7c-.6-.5-1.4-.5-2 0L5.5 7.2Z" fill="#0B0D11"/></svg>
+            <svg width="26" height="12" viewBox="0 0 26 12" fill="none"><rect x="0.5" y="0.5" width="22" height="11" rx="3" stroke="#0B0D11"/><rect x="23.5" y="3.5" width="2" height="5" rx="1" fill="#0B0D11"/><rect x="2" y="2" width="19" height="8" rx="1.5" fill="#0B0D11"/></svg>
+          </div>
+        </div>
+
+        <div class="hdr">
+          <div class="row1">
+            <div class="brand">
+              <span class="gem"></span>
+              La Base 360<small>· prospection</small>
+            </div>
+            <div class="stat-chip">
+              <span class="dot-live"></span>
+              <span><b>12</b> envoyés · <b>3</b> RDV</span>
+              <span style="color:var(--ls-muted)">·&nbsp;7j</span>
+            </div>
+          </div>
+
+          <div class="pickers">
+            <div class="picker">
+              <span class="flag">🇲🇽</span>
+              <div class="info-stack">
+                <span class="lbl">Marché</span>
+                <span class="val">LatAm + Espagne</span>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+            <div class="picker">
+              <span class="glyph">⚖️</span>
+              <div class="info-stack">
+                <span class="lbl">Profil cible</span>
+                <span class="val">Perte de poids&nbsp;·&nbsp;F</span>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+          </div>
+
+          <nav class="index">
+            <div class="step"><span class="n">01</span><span class="ic">🧠</span></div>
+            <div class="step active"><span class="n">02</span><span class="ic">🔍</span><span class="name">Trouver</span></div>
+            <div class="step"><span class="n">03</span><span class="ic">📨</span></div>
+            <div class="step"><span class="n">04</span><span class="ic">🌳</span></div>
+            <div class="step"><span class="n">05</span><span class="ic">🛡️</span></div>
+            <div class="step"><span class="n">06</span><span class="ic">📞</span></div>
+            <div class="more">→</div>
+          </nav>
+        </div>
+
+        <div class="section-meta">
+          <span class="step-of"><b>02</b>&nbsp;/&nbsp;10</span>
+          <span>Scan <b style="color:var(--ls-charcoal)">30 s</b> · 3 sources alt.</span>
+        </div>
+
+        <div class="section-head">
+          <div class="kicker">Module · Trouver des prospects</div>
+          <h2>Le scan <span class="em">30 secondes</span>.</h2>
+          <p class="lede">Tu ouvres un profil&nbsp;: en 30&nbsp;s tu sais si tu lui écris. Drapeaux verts, drapeaux rouges, hashtags et sources hors-feed.</p>
+        </div>
+
+        <div class="body"><div class="body-inner">
+
+          <div class="scan-timer"><span class="pulse"></span>Scan en 30 s · les 4 premières secondes</div>
+
+          <div class="flags">
+            <div class="flag-col green">
+              <h5><span class="dot"></span>Drapeaux verts</h5>
+              <ul>
+                <li>Story sport régulière (3+&nbsp;/&nbsp;sem.)</li>
+                <li>Bio «&nbsp;mamá&nbsp;» / «&nbsp;emprendedora&nbsp;»</li>
+                <li>Avant/après visible</li>
+                <li>Hashtags forme + famille</li>
+                <li>Compte actif (3+ posts/sem.)</li>
+              </ul>
+            </div>
+            <div class="flag-col red">
+              <h5><span class="dot"></span>Drapeaux rouges</h5>
+              <ul>
+                <li>Compte privé, 0 interaction</li>
+                <li>Bio «&nbsp;no vendo nada&nbsp;»</li>
+                <li>Posts politiques only</li>
+                <li>Créé il y a &lt;&nbsp;1 mois</li>
+                <li>&gt;&nbsp;50k followers (saturé)</li>
+              </ul>
+            </div>
+          </div>
+
+          <article class="hashtag-card">
+            <div class="htag-head">
+              <span>Hashtags&nbsp;· <b>LatAm&nbsp;·&nbsp;ES</b></span>
+              <span style="font-family:var(--f-mono);font-size:9.5px">3 catégories</span>
+            </div>
+            <div class="htag-row">
+              <span class="cat">Mainstream</span>
+              <span class="htag">#perderpeso</span>
+              <span class="htag">#mamáfit</span>
+              <span class="htag">#bajardepeso2026</span>
+            </div>
+            <div class="htag-row">
+              <span class="cat">Niche</span>
+              <span class="htag gold">#rutinamañana</span>
+              <span class="htag gold">#desayunosaludable</span>
+              <span class="htag gold">#mamáocupada</span>
+            </div>
+            <div class="htag-row">
+              <span class="cat">Cross</span>
+              <span class="htag teal">#yogamatutino</span>
+              <span class="htag teal">#mealprep</span>
+              <span class="htag purple">#vidasana</span>
+            </div>
+          </article>
+
+          <article class="src-card">
+            <div class="kk">3 sources hors-feed</div>
+            <h4>Là où les autres ne cherchent pas.</h4>
+            <div class="src-row">
+              <div class="src-lab">FB</div>
+              <div class="src-body">Groupes <em>«&nbsp;Mamás emprendedoras CDMX&nbsp;»</em>, <em>«&nbsp;Reto 21 días&nbsp;»</em>. Commentaires &gt; messages directs.</div>
+            </div>
+            <div class="src-row">
+              <div class="src-lab">IRL</div>
+              <div class="src-body">Cours collectifs en salle, marchés bio le samedi, sorties d'école 14h&nbsp;–&nbsp;16h.</div>
+            </div>
+            <div class="src-row">
+              <div class="src-lab">Reco</div>
+              <div class="src-body">Anciennes clientes à 3 mois&nbsp;: «&nbsp;qui d'autre devrait essayer ça&nbsp;?&nbsp;»</div>
+            </div>
+          </article>
+
+        </div></div>
+
+        <nav class="botnav">
+          <button class="btn-nav prev">
+            <span class="arr">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M7.5 3 4 6l3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="lab"><small>Précédent · 01</small><span>Mindset</span></span>
+          </button>
+          <div class="dots" aria-hidden="true">
+            <span class="d"></span><span class="d on"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span><span class="d"></span>
+          </div>
+          <button class="btn-nav next">
+            <span class="arr">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M4.5 3 8 6l-3.5 3" stroke="#0B0D11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="lab"><small>Suivant · 03</small><span>Messages M1</span></span>
+          </button>
+        </nav>
+
+      </div>
+      <div class="home-indicator"></div>
+    </div>
+  </div>
+
+  <footer class="annotation">
+    <span class="tag">Frame 04 · Trouver les prospects</span>
+    <p style="margin:0">
+      <span class="num">A.</span> <b>Drapeaux verts / rouges en colonnes parallèles</b>, surlignés d'un wash de couleur. La promesse <span class="hl">«&nbsp;scan 30&nbsp;s&nbsp;»</span> est matérialisée en chip pulsant en haut.<br />
+      <span class="num">B.</span> Les <b>hashtags</b> ne sont pas une grosse soupe&nbsp;: 3 catégories (mainstream / niche / cross) avec <b>3 couleurs distinctes</b>. Le distri tape ce qu'il veut tester.<br />
+      <span class="num">C.</span> Carte <b>«&nbsp;sources hors-feed&nbsp;»</b> en charcoal&nbsp;: ce qui n'est pas Insta saute aux yeux. Les hashtags et exemples se localisent automatiquement (es-MX ici).
+    </p>
+  </footer>
+</section>
+
+<!-- ════════════════════════════════════════════════════════════════
+     FRAME 5 — DESKTOP 640
+     ════════════════════════════════════════════════════════════════ -->
+<section class="frame frame-desktop">
+  <div class="window">
+    <div class="chrome">
+      <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+      <span class="url">la-base-360.app/prospection</span>
+      <span style="margin-left:auto;font-family:var(--f-mono);font-size:11px;color:var(--ls-muted)">⌘&nbsp;K</span>
+    </div>
+
+    <div class="desktop-app">
+      <div class="desktop-shell">
+
+        <div class="hdr">
+          <div class="row1" style="gap:18px">
+            <div class="brand">
+              <span class="gem"></span>
+              La Base 360<small>· prospection internationale</small>
+            </div>
+            <div class="stat-chip">
+              <span class="dot-live"></span>
+              <span><b>12</b> envoyés cette semaine · <b>3</b> RDV pris</span>
+              <span style="color:var(--ls-muted)">·&nbsp;7j</span>
+            </div>
+          </div>
+
+          <div class="pickers" style="gap:12px">
+            <div class="picker">
+              <span class="flag">🇬🇧</span>
+              <div class="info-stack">
+                <span class="lbl">Marché</span>
+                <span class="val">International&nbsp;·&nbsp;EN</span>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+            <div class="picker">
+              <span class="glyph">🏃</span>
+              <div class="info-stack">
+                <span class="lbl">Profil cible</span>
+                <span class="val">Sportif&nbsp;·&nbsp;mixte</span>
+              </div>
+              <svg class="caret" viewBox="0 0 12 12" fill="none"><path d="M3 5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+          </div>
+
+          <!-- desktop full index (all 10 visible) -->
+          <nav class="index" style="margin-top:12px">
+            <div class="step"><span class="n">01</span><span class="ic">🧠</span></div>
+            <div class="step"><span class="n">02</span><span class="ic">🔍</span></div>
+            <div class="step active"><span class="n">03</span><span class="ic">📨</span><span class="name">Messages M1</span></div>
+            <div class="step"><span class="n">04</span><span class="ic">🌳</span></div>
+            <div class="step"><span class="n">05</span><span class="ic">🛡️</span></div>
+            <div class="step"><span class="n">06</span><span class="ic">📞</span></div>
+            <div class="step"><span class="n">07</span><span class="ic">🎯</span></div>
+            <div class="step"><span class="n">08</span><span class="ic">🔁</span></div>
+            <div class="step"><span class="n">09</span><span class="ic">📖</span></div>
+            <div class="step"><span class="n">10</span><span class="ic">⏰</span></div>
+          </nav>
+        </div>
+
+        <div class="section-meta">
+          <span class="step-of"><b>03</b>&nbsp;/&nbsp;10</span>
+          <span><b style="color:var(--ls-charcoal)">4</b>&nbsp;plateformes · trad.&nbsp;FR&nbsp;ON · raccourcis <kbd style="font-family:var(--f-mono);font-size:10px;background:var(--ls-surface);border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:4px;padding:1px 5px;color:var(--ls-charcoal)">←</kbd>&nbsp;<kbd style="font-family:var(--f-mono);font-size:10px;background:var(--ls-surface);border:1px solid var(--ls-line);border-bottom-width:2px;border-radius:4px;padding:1px 5px;color:var(--ls-charcoal)">→</kbd></span>
+        </div>
+
+        <div class="section-head">
+          <div class="kicker">Module · Premier contact</div>
+          <h2>Messages <span class="em">M1</span>.</h2>
+          <p class="lede">Sélectionne ta plateforme. Personnalise les variables en gold avant de copier. Les scripts sont localisés EN avec traduction française inline.</p>
+        </div>
+
+        <div class="body" style="-webkit-mask-image:none;mask-image:none"><div class="body-inner">
+
+          <div class="platform-tabs" style="max-width:380px">
+            <div class="tab on"><span class="ic">📷</span>Instagram</div>
+            <div class="tab"><span class="ic">f</span>Facebook</div>
+            <div class="tab"><span class="ic">💬</span>WhatsApp</div>
+            <div class="tab"><span class="ic">✉</span>SMS</div>
+          </div>
+
+          <article class="script">
+            <div class="head">
+              <span class="glyph">📷</span>
+              <div>
+                <h4>Instagram · DM after story view</h4>
+                <span class="sub">post-vue de story · prospect tiède</span>
+              </div>
+              <div class="lang-switch">
+                <button>EN</button><button class="on">FR</button>
+              </div>
+            </div>
+            <div class="ctx">Contexte · prospect a regardé ta story 2× cette semaine, suit un compte sport</div>
+            <div class="msg-body">
+              <p>Hey <span class="var">[first&nbsp;name]</span>! Saw you've been following <span class="var teal">[fitness account]</span> — what are you working on right now on the training side? Curious because I help athletes structure their nutrition around <span class="var teal">[their sport]</span>.</p>
+            </div>
+            <div class="trad-line">
+              Hey <span class="var">[prénom]</span>&nbsp;! J'ai vu que tu suivais <span class="var teal">[compte fitness]</span> — tu bosses sur quoi côté entraînement en ce moment&nbsp;? Je demande parce que j'aide des sportifs à structurer leur nutrition autour de <span class="var teal">[leur discipline]</span>.
+            </div>
+            <div class="script-actions">
+              <button class="btn copy"><span class="ic">⌘C</span>Copier le script</button>
+              <button class="btn send"><span class="ic">↗</span>J'ai envoyé</button>
+              <button class="btn ghost">Variantes&nbsp;·&nbsp;4</button>
+              <div class="spacer"></div>
+              <span class="stat-mini">Taux réponse 7j&nbsp; <b>42%</b>&nbsp; · &nbsp;n=<b>19</b></span>
+            </div>
+          </article>
+
+          <article class="script">
+            <div class="head">
+              <span class="glyph" style="background:#1877F210;border-color:#1877F230;color:#1877F2;font-weight:700">f</span>
+              <div>
+                <h4>Facebook · Messenger</h4>
+                <span class="sub">via ami commun</span>
+              </div>
+              <div class="lang-switch">
+                <button>EN</button><button class="on">FR</button>
+              </div>
+            </div>
+            <div class="ctx">Contexte · au moins 1 ami commun, intérêts sport visibles</div>
+            <div class="msg-body">
+              <p>Hey <span class="var">[first&nbsp;name]</span>, I noticed we both know <span class="var teal">[mutual friend]</span>. I work with athletes who want consistent morning energy without crashing at 3pm — does that resonate with where you're at right now?</p>
+            </div>
+            <div class="trad-line">
+              Salut <span class="var">[prénom]</span>&nbsp;! J'ai vu qu'on avait <span class="var teal">[ami commun]</span> en commun. Je bosse avec des sportifs qui veulent une énergie stable le matin sans baisse à 15h — ça te parle&nbsp;?
+            </div>
+            <div class="script-actions">
+              <button class="btn copy"><span class="ic">⌘C</span>Copier le script</button>
+              <button class="btn send"><span class="ic">↗</span>J'ai envoyé</button>
+              <button class="btn ghost">Variantes&nbsp;·&nbsp;3</button>
+              <div class="spacer"></div>
+              <span class="stat-mini">Taux réponse 7j&nbsp; <b>28%</b>&nbsp; · &nbsp;n=<b>11</b></span>
+            </div>
+          </article>
+
+        </div></div>
+
+        <div class="kbd-hint">
+          <kbd>←</kbd><kbd>→</kbd> modules · <kbd>1</kbd>—<kbd>4</kbd> plateformes · <kbd>C</kbd> copier
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <footer class="annotation">
+    <span class="tag">Bonus · Desktop 640&nbsp;px centré</span>
+    <p style="margin:0">
+      <span class="num">A.</span> Sur desktop, les <b>10 modules tiennent tous dans l'index</b> sans scroll. Pas de side rail&nbsp;: on garde la même ligne narrative que mobile, juste plus aérée.<br />
+      <span class="num">B.</span> Les scripts respirent (≈ 60-80&nbsp;ch de large), <b>les stats par script</b> se déploient (taux + n). <b>Raccourcis clavier</b> (←/→ modules, 1-4 plateformes, C copier) en hint persistent bas-droit.<br />
+      <span class="num">C.</span> Tous les tokens restent identiques&nbsp;: la même UI, deux densités. Aucune feature mobile-only ni desktop-only.
+    </p>
+  </footer>
+</section>
+
+</main>
+
+<script>
+/* tiny enhancement: simulate Copy → toast */
+document.querySelectorAll('.btn.copy').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const screen = btn.closest('.screen, .window');
+    if (!screen) return;
+    let t = screen.querySelector('.toast.live');
+    if (!t) {
+      t = document.createElement('div');
+      t.className = 'toast live';
+      t.innerHTML = '<span class="ic">✓</span>Copié&nbsp;!';
+      screen.appendChild(t);
+    }
+    t.style.opacity = '1';
+    clearTimeout(t._h);
+    t._h = setTimeout(()=>{ t.style.transition='opacity .4s'; t.style.opacity='0'; }, 1400);
+  });
+});
+</script>
+
+</body>
+</html>

--- a/src/components/prospection/ProspectionHub.tsx
+++ b/src/components/prospection/ProspectionHub.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   createProspectionAttempt,
+  fetchProspectionStats,
   filterByMarket,
   filterByMarketAndProfile,
   filterHashtags,
@@ -123,13 +124,13 @@ const PROFILE_GLYPHS: Record<string, string> = {
   "business": "💼",
 };
 
-// Plateformes M1 (4 onglets dans le module Premier message)
-const PLATFORM_ORDER: ProspectionPlatform[] = ["insta", "fb", "whatsapp", "sms"];
+// Plateformes M1 (5 onglets dans le module Premier message, TikTok 2026-05-19)
+const PLATFORM_ORDER: ProspectionPlatform[] = ["insta", "fb", "whatsapp", "sms", "tiktok"];
 const PLATFORM_GLYPH: Record<string, string> = {
-  insta: "📷", fb: "f", whatsapp: "💬", sms: "✉",
+  insta: "📷", fb: "f", whatsapp: "💬", sms: "✉", tiktok: "🎵",
 };
 const PLATFORM_SHORT: Record<string, string> = {
-  insta: "Insta", fb: "Facebook", whatsapp: "WhatsApp", sms: "SMS",
+  insta: "Insta", fb: "Facebook", whatsapp: "WhatsApp", sms: "SMS", tiktok: "TikTok",
 };
 
 // ────────────────────────────────────────────────────────────
@@ -169,8 +170,10 @@ export function ProspectionHub(p: Props) {
   const [scriptLang, setScriptLang] = useState<Record<string, "native" | "fr">>({});
   const [sheet, setSheet] = useState<"market" | "profile" | "stat" | null>(null);
   const [toast, setToast] = useState<string | null>(null);
-  const [sent7d, setSent7d] = useState<number>(12);
-  const [rdv7d, setRdv7d] = useState<number>(3);
+  // Stats 7j : initialisées à 0, fetch réel au mount via RPC get_prospection_stats
+  const [sent7d, setSent7d] = useState<number>(0);
+  const [rdv7d, setRdv7d] = useState<number>(0);
+  const [responses7d, setResponses7d] = useState<number>(0);
   const [bumpStat, setBumpStat] = useState<boolean>(false);
   const [swapping, setSwapping] = useState<boolean>(false);
   const [caseTab, setCaseTab] = useState<"ghost_after_exchange" | "reactivation_3_6m" | "referral_request">("ghost_after_exchange");
@@ -223,6 +226,22 @@ export function ProspectionHub(p: Props) {
     const m = Math.max(1, Math.round(words / 200));
     return `≈ ${m} min de lecture`;
   }, [moduleMeta.id, mindsetBlocks, scripts, replyTree, objections, followups, closing, specialCases, storytelling, routines, hashtags, flags, sources]);
+
+  // Fetch real stats au mount (RPC get_prospection_stats)
+  useEffect(() => {
+    if (!currentUser?.id) return;
+    let cancelled = false;
+    (async () => {
+      const s = await fetchProspectionStats(currentUser.id);
+      if (cancelled || !s) return;
+      setSent7d(s.total_7d ?? 0);
+      setResponses7d(s.responses_7d ?? 0);
+      // RDV proxy : nombre d'attempts WhatsApp dans la fenêtre 7j n'est pas
+      // exposé par le RPC — on garde positive_7d comme proxy "RDV pris"
+      setRdv7d(s.positive_7d ?? 0);
+    })();
+    return () => { cancelled = true; };
+  }, [currentUser?.id]);
 
   // Keyboard nav
   useEffect(() => {
@@ -535,25 +554,31 @@ export function ProspectionHub(p: Props) {
           </>
         )}
         {sheet === "stat" && (
-          <StatFunnelSheet sent={sent7d} rdv={rdv7d} />
+          <StatFunnelSheet sent={sent7d} rdv={rdv7d} responses={responses7d} />
         )}
       </div>
 
-      {/* Restart tunnel (discret) */}
+      {/* Restart tunnel — lien minuscule en footer, hors flow visuel */}
       <button
         type="button"
         onClick={p.onRestartTunnel}
         style={{
-          alignSelf: "center", margin: "16px 0 24px",
-          padding: "8px 14px", borderRadius: 999,
-          border: "1px dashed var(--hub-line)",
+          alignSelf: "center",
+          margin: "6px auto 18px",
+          padding: "4px 10px",
+          borderRadius: 999,
+          border: "none",
           background: "transparent",
-          color: "var(--hub-muted)",
-          fontSize: 12, fontFamily: "var(--hub-f-mono)",
+          color: "var(--hub-muted-2)",
+          fontSize: 10.5,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          fontFamily: "var(--hub-f-mono)",
           cursor: "pointer",
+          opacity: 0.6,
         }}
       >
-        🔁 Revoir le tunnel onboarding
+        ↺ Revoir le tunnel onboarding
       </button>
     </div>
   );
@@ -800,8 +825,9 @@ function ReplyModule({
       {nodes.map((n) => {
         const meta = branchLabel[n.branch] ?? { pill: n.branch, emoji: "·", cls: "maybe" };
         const body = marketCode !== "fr" && n.body_fr ? n.body_fr : n.body;
+        const isWarm = meta.cls === "warm";
         return (
-          <article key={n.id} className="ph-tree-branch">
+          <article key={n.id} className={`ph-tree-branch${isWarm ? " warm-branch" : ""}`}>
             <div className="reaction">
               <span>{meta.emoji} Il / elle réagit</span>
               <span className={`pill ${meta.cls}`}>{meta.pill}</span>
@@ -907,9 +933,14 @@ function ClosingModule({
   const scripts = items.filter((i) => i.kind !== "signal");
   if (items.length === 0) return <Empty>Aucun closing pour ce marché.</Empty>;
   const scriptTitle: Record<string, string> = {
-    propose: "Proposer la suite",
+    propose: "Proposer le passage à l'acte",
     hesitation: "Quand il hésite",
-    final_no: "Encaisser le non",
+    final_no: "Encaisser un non sereinement",
+  };
+  const scriptCtx: Record<string, string> = {
+    propose: "Fin d'appel · prospect mûr",
+    hesitation: "Avant la dernière phrase",
+    final_no: "Porte ouverte pour plus tard",
   };
   return (
     <>
@@ -928,7 +959,7 @@ function ClosingModule({
         return (
           <article key={s.id} className="ph-close-script">
             <h4>{s.title ?? scriptTitle[s.kind] ?? s.kind}</h4>
-            <div className="ctx">Kind · {s.kind}</div>
+            {scriptCtx[s.kind] && <div className="ctx">{scriptCtx[s.kind]}</div>}
             <p>{renderScriptBody(body)}</p>
             <div style={{ marginTop: 10, display: "flex", gap: 6 }}>
               <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
@@ -955,7 +986,7 @@ function SpecialCasesModule({
   const tabs = [
     { id: "ghost_after_exchange" as const, label: "Ghost" },
     { id: "reactivation_3_6m" as const, label: "Réactivation" },
-    { id: "referral_request" as const, label: "Recommandation" },
+    { id: "referral_request" as const, label: "Reco" },
   ];
   const active = items.find((i) => i.kind === caseTab);
   return (
@@ -1101,8 +1132,9 @@ function RoutineModule({
 // ────────────────────────────────────────────────────────────
 // Stat funnel sheet
 // ────────────────────────────────────────────────────────────
-function StatFunnelSheet({ sent, rdv }: { sent: number; rdv: number }) {
-  const reps = Math.round(sent * 0.42);
+function StatFunnelSheet({ sent, rdv, responses }: { sent: number; rdv: number; responses: number }) {
+  // Réponses : valeur réelle si dispo, sinon proxy 42% du sent.
+  const reps = responses > 0 ? responses : Math.round(sent * 0.42);
   const clos = Math.max(0, Math.round(rdv * 0.4));
   const pct = (v: number) => Math.min(100, Math.round((v / Math.max(1, sent)) * 100));
   return (

--- a/src/components/prospection/ProspectionHub.tsx
+++ b/src/components/prospection/ProspectionHub.tsx
@@ -1,41 +1,140 @@
-// Chantier #3 V4 — Hub Prospection (2026-05-19).
-// Affiché aux distri qui ont déjà fait le tunnel onboarding 1ère visite
-// (users.prospection_onboarded_at != null). Filtres Marché + Profil sticky
-// en haut. 10 modules en cards, accordéon-style : un module se déplie au
-// clic et affiche son contenu (lecture seule).
+// Chantier #3 V4 — Hub Prospection refonte design polish (2026-05-19).
 //
-// Le contenu vient du hook useProspectionData (V4). Le copy est multi-marché
-// (FR/EN/ES/PT/TR/HI) avec body_fr renseigné pour les non-FR.
+// Port pixel-near du design v3 (claude design + Thomas).
+// Source : docs/mockups/prospection-v4-prototype-v3.html
+// Styles : ./prospection-hub.css (scope .prospection-hub)
+//
+// Spec :
+//   - Sticky header 3 rows : brand+stat-chip / twin pickers / index rail
+//   - Section meta + heading (kicker + H2 italique accent + lede)
+//   - 10 modules renderers (1 module à la fois)
+//   - Bottom nav (prev / dots / next)
+//   - Bottom-sheets pour market picker, profile picker, stat funnel
+//   - Toast Copié
+//   - Toggle EN↔FR par script
+//   - Compteur 7j incrémenté à "J'ai envoyé" (+RDV si WhatsApp proxy)
+//   - Raccourcis clavier : ←/→ modules · 1-9/0 jump · M marché · P profil · Esc
+//   - Light + Dark via theme app existant. Accent gold en light, teal en dark.
 
-import { useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
-  PLATFORM_GRADIENTS,
-  PLATFORM_ICONS,
-  PLATFORM_LABELS,
-  PROSPECTION_MODULES,
+  createProspectionAttempt,
   filterByMarket,
   filterByMarketAndProfile,
   filterHashtags,
   filterScripts,
+  PLATFORM_LABELS,
+  type ProspectionClosingBlock,
+  type ProspectionFollowup,
   type ProspectionHashtag,
   type ProspectionMarket,
   type ProspectionMarketTip,
-  type ProspectionProfile,
-  type ProspectionScript,
-  type ProspectionMindsetBlock,
   type ProspectionMetric,
-  type ProspectionProfileFlag,
-  type ProspectionSource,
-  type ProspectionReplyNode,
+  type ProspectionMindsetBlock,
   type ProspectionObjection,
-  type ProspectionFollowup,
-  type ProspectionClosingBlock,
+  type ProspectionPlatform,
+  type ProspectionProfile,
+  type ProspectionProfileFlag,
+  type ProspectionReplyNode,
+  type ProspectionRoutineItem,
+  type ProspectionScript,
+  type ProspectionSource,
   type ProspectionSpecialCase,
   type ProspectionStoryBlock,
-  type ProspectionRoutineItem,
-  type ProspectionModuleId,
 } from "../../hooks/useProspectionData";
+import { useAppContext } from "../../context/AppContext";
+import "./prospection-hub.css";
 
+// ────────────────────────────────────────────────────────────
+// Module metadata (10 sections, naming sans M1/M2/M3)
+// ────────────────────────────────────────────────────────────
+type ModuleId =
+  | "mindset" | "find" | "first_msg" | "reply" | "objections"
+  | "post_call" | "closing" | "special" | "story" | "routine";
+
+interface ModuleMeta {
+  id: ModuleId;
+  ic: string;
+  name: string;        // Tab label
+  kicker: string;      // "Module · ..."
+  h2: [string, string, string]; // [prefix, italic accent, suffix]
+  lede: string;
+  meta: string;        // Right side of section-meta (auto reading-time)
+}
+
+const MODULES: ModuleMeta[] = [
+  { id: "mindset",   ic: "🧠", name: "Mindset",
+    kicker: "Module · Mindset & posture",
+    h2: ["D'abord, ", "le ton", "."],
+    lede: "Trois vérités à intégrer avant le premier message. Cinq erreurs qui sabotent 80 % des conversations.",
+    meta: "" },
+  { id: "find",      ic: "🔍", name: "Trouver",
+    kicker: "Module · Trouver des prospects",
+    h2: ["Le scan ", "30 secondes", "."],
+    lede: "Tu ouvres un profil : en 30 s tu sais si tu lui écris. Drapeaux verts/rouges, hashtags, sources hors-feed.",
+    meta: "" },
+  { id: "first_msg", ic: "📨", name: "Premier message",
+    kicker: "Module · Premier contact",
+    h2: ["Premier ", "message", "."],
+    lede: "Sélectionne ta plateforme. Personnalise les variables en gold avant de copier.",
+    meta: "" },
+  { id: "reply",     ic: "🌳", name: "Sa réponse",
+    kicker: "Module · Quand il/elle répond",
+    h2: ["Que répondre, ", "selon ce qu'il dit", "."],
+    lede: "Branches tiède, froid, indécis. Une réponse par branche, prête à copier.",
+    meta: "" },
+  { id: "objections",ic: "🛡️", name: "Objections",
+    kicker: "Module · Réponses aux refus",
+    h2: ["Les huit ", "non", "."],
+    lede: "Pour chaque objection : ce qu'il ne faut pas dire, ce qui ouvre la porte.",
+    meta: "" },
+  { id: "post_call", ic: "📞", name: "Post-appel",
+    kicker: "Module · Séquence post-appel",
+    h2: ["Après l'appel, ", "quatre touches", "."],
+    lede: "J0 – J+2 – J+5 – J+30. Une touche par jour, jamais une de plus.",
+    meta: "" },
+  { id: "closing",   ic: "🎯", name: "Closing",
+    kicker: "Module · Closing",
+    h2: ["Quand fermer, ", "et comment", "."],
+    lede: "Les signaux qui montrent que c'est mûr, les scripts pour passer à l'acte.",
+    meta: "" },
+  { id: "special",   ic: "🔁", name: "Cas spéciaux",
+    kicker: "Module · Cas spéciaux",
+    h2: ["Quand ça ", "sort des rails", "."],
+    lede: "Ghosting, réactivation, demande de recommandation. Trois playbooks distincts.",
+    meta: "" },
+  { id: "story",     ic: "📖", name: "Storytelling",
+    kicker: "Module · Storytelling",
+    h2: ["Raconte ton ", "avant", "."],
+    lede: "La structure en 3 actes qui marche. Deux exemples vivants.",
+    meta: "" },
+  { id: "routine",   ic: "⏰", name: "Routine",
+    kicker: "Module · Routine quotidienne",
+    h2: ["Trente minutes, ", "tous les jours", "."],
+    lede: "Sept actions à cocher chaque matin. Sans elles, le reste s'effondre.",
+    meta: "" },
+];
+
+// Ordre profil cible : weight-women → weight-men → sport → business
+const PROFILE_GLYPHS: Record<string, string> = {
+  "weight-women": "⚖️",
+  "weight-men": "💪",
+  "sport": "🏃",
+  "business": "💼",
+};
+
+// Plateformes M1 (4 onglets dans le module Premier message)
+const PLATFORM_ORDER: ProspectionPlatform[] = ["insta", "fb", "whatsapp", "sms"];
+const PLATFORM_GLYPH: Record<string, string> = {
+  insta: "📷", fb: "f", whatsapp: "💬", sms: "✉",
+};
+const PLATFORM_SHORT: Record<string, string> = {
+  insta: "Insta", fb: "Facebook", whatsapp: "WhatsApp", sms: "SMS",
+};
+
+// ────────────────────────────────────────────────────────────
+// Props
+// ────────────────────────────────────────────────────────────
 interface Props {
   markets: ProspectionMarket[];
   profiles: ProspectionProfile[];
@@ -53,24 +152,45 @@ interface Props {
   specialCases: ProspectionSpecialCase[];
   storytelling: ProspectionStoryBlock[];
   routines: ProspectionRoutineItem[];
-  /** Si Thomas veut revoir le tunnel onboarding manuellement. */
   onRestartTunnel: () => void;
 }
 
+// ────────────────────────────────────────────────────────────
+// Component
+// ────────────────────────────────────────────────────────────
 export function ProspectionHub(p: Props) {
-  // Sticky filters market + profile. Défaut = 1ers items dispo.
+  const { currentUser } = useAppContext();
+
+  // State
   const [marketCode, setMarketCode] = useState<string>(p.markets[0]?.code ?? "fr");
   const [profileSlug, setProfileSlug] = useState<string>(p.profiles[0]?.slug ?? "weight-women");
-  const [openModule, setOpenModule] = useState<ProspectionModuleId | null>(null);
+  const [moduleIdx, setModuleIdx] = useState<number>(0);
+  const [platform, setPlatform] = useState<ProspectionPlatform>("insta");
+  const [scriptLang, setScriptLang] = useState<Record<string, "native" | "fr">>({});
+  const [sheet, setSheet] = useState<"market" | "profile" | "stat" | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [sent7d, setSent7d] = useState<number>(12);
+  const [rdv7d, setRdv7d] = useState<number>(3);
+  const [bumpStat, setBumpStat] = useState<boolean>(false);
+  const [swapping, setSwapping] = useState<boolean>(false);
+  const [caseTab, setCaseTab] = useState<"ghost_after_exchange" | "reactivation_3_6m" | "referral_request">("ghost_after_exchange");
+  const [checks, setChecks] = useState<Record<string, boolean>>({});
+  const [sentScripts, setSentScripts] = useState<Record<string, boolean>>({});
+  const [pickerOpening, setPickerOpening] = useState<"market" | "profile" | null>(null);
 
+  const indexRailRef = useRef<HTMLDivElement>(null);
+  const bodyInnerRef = useRef<HTMLDivElement>(null);
+
+  // Derived
+  const market = useMemo(() => p.markets.find((m) => m.code === marketCode) ?? null, [p.markets, marketCode]);
   const profile = useMemo(() => p.profiles.find((pp) => pp.slug === profileSlug) ?? null, [p.profiles, profileSlug]);
   const marketTip = useMemo(() => p.marketTips.find((t) => t.market_code === marketCode) ?? null, [p.marketTips, marketCode]);
+  const moduleMeta = MODULES[moduleIdx];
 
-  // Filtered data par market+profil (pour les modules qui en ont besoin)
+  // Filtered data
   const hashtags = useMemo(() => filterHashtags(p.hashtags, marketCode, profileSlug), [p.hashtags, marketCode, profileSlug]);
   const scripts = useMemo(() => filterScripts(p.scripts, marketCode, profileSlug), [p.scripts, marketCode, profileSlug]);
   const mindsetBlocks = useMemo(() => filterByMarket(p.mindsetBlocks, marketCode), [p.mindsetBlocks, marketCode]);
-  const metrics = useMemo(() => filterByMarket(p.metrics, marketCode), [p.metrics, marketCode]);
   const flags = useMemo(
     () => p.profileFlags.filter((f) => f.market_code === marketCode && f.profile_slug === profileSlug),
     [p.profileFlags, marketCode, profileSlug],
@@ -93,167 +213,402 @@ export function ProspectionHub(p: Props) {
   );
   const routines = useMemo(() => filterByMarket(p.routines, marketCode), [p.routines, marketCode]);
 
+  // Reading-time auto pour le current module
+  const readingTime = useMemo(() => {
+    const text = collectModuleText({
+      mid: moduleMeta.id, mindsetBlocks, scripts, replyTree, objections, followups, closing,
+      specialCases, storytelling, routines, hashtags, flags, sources,
+    });
+    const words = text.split(/\s+/).filter(Boolean).length;
+    const m = Math.max(1, Math.round(words / 200));
+    return `≈ ${m} min de lecture`;
+  }, [moduleMeta.id, mindsetBlocks, scripts, replyTree, objections, followups, closing, specialCases, storytelling, routines, hashtags, flags, sources]);
+
+  // Keyboard nav
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) return;
+      if (sheet) {
+        if (e.key === "Escape") { setSheet(null); e.preventDefault(); }
+        return;
+      }
+      if (e.key === "ArrowLeft") { goModule(moduleIdx - 1); e.preventDefault(); }
+      else if (e.key === "ArrowRight") { goModule(moduleIdx + 1); e.preventDefault(); }
+      else if (/^[1-9]$/.test(e.key)) { goModule(parseInt(e.key, 10) - 1); e.preventDefault(); }
+      else if (e.key === "0") { goModule(9); e.preventDefault(); }
+      else if (e.key.toLowerCase() === "m") { setSheet("market"); e.preventDefault(); }
+      else if (e.key.toLowerCase() === "p") { setSheet("profile"); e.preventDefault(); }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [moduleIdx, sheet]);
+
+  // Auto-center active step in index rail
+  useEffect(() => {
+    const rail = indexRailRef.current;
+    if (!rail) return;
+    const active = rail.querySelector<HTMLElement>(".step.active");
+    if (!active) return;
+    const railRect = rail.getBoundingClientRect();
+    const aRect = active.getBoundingClientRect();
+    const delta = (aRect.left + aRect.width / 2) - (railRect.left + railRect.width / 2);
+    rail.scrollBy({ left: delta, behavior: "smooth" });
+  }, [moduleIdx]);
+
+  // Body swap animation
+  function goModule(idx: number) {
+    const clamped = Math.max(0, Math.min(MODULES.length - 1, idx));
+    if (clamped === moduleIdx) return;
+    setSwapping(true);
+    setTimeout(() => {
+      setModuleIdx(clamped);
+      setSwapping(false);
+      bodyInnerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+    }, 160);
+  }
+
+  function showToast(msg: string) {
+    setToast(msg);
+    setTimeout(() => setToast(null), 1500);
+  }
+
+  function copy(text: string, label = "Copié !") {
+    void navigator.clipboard.writeText(text).catch(() => {});
+    showToast(label);
+  }
+
+  async function markSent(scriptId: string, scriptPlatform: ProspectionPlatform) {
+    setSentScripts((m) => ({ ...m, [scriptId]: true }));
+    setSent7d((s) => s + 1);
+    if (scriptPlatform === "whatsapp") setRdv7d((r) => r + 1);
+    setBumpStat(true);
+    setTimeout(() => setBumpStat(false), 800);
+    showToast("Envoi noté · +1");
+    if (currentUser?.id && marketCode && profileSlug) {
+      void createProspectionAttempt({
+        coach_id: currentUser.id,
+        market_code: marketCode,
+        profile_slug: profileSlug,
+        platform: scriptPlatform,
+      });
+    }
+  }
+
+  function setLang(scriptId: string, lang: "native" | "fr") {
+    setScriptLang((m) => ({ ...m, [scriptId]: lang }));
+  }
+
+  function openPicker(kind: "market" | "profile") {
+    setPickerOpening(kind);
+    setTimeout(() => setPickerOpening(null), 320);
+    setSheet(kind);
+  }
+
+  const prevMod = moduleIdx > 0 ? MODULES[moduleIdx - 1] : null;
+  const nextMod = moduleIdx < MODULES.length - 1 ? MODULES[moduleIdx + 1] : null;
+
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 16, paddingBottom: 32 }}>
-      <style>{HUB_KEYFRAMES}</style>
-
-      {/* Sticky filter bar */}
-      <div style={STICKY_BAR}>
-        <div style={{ display: "flex", gap: 8, overflowX: "auto", paddingBottom: 4 }}>
-          {p.markets.map((m) => (
-            <button
-              key={m.code}
-              onClick={() => setMarketCode(m.code)}
-              style={{
-                ...PILL,
-                ...(m.code === marketCode ? PILL_ACTIVE : {}),
-                fontFamily:
-                  "'Twemoji Country Flags','Segoe UI Emoji','Apple Color Emoji','Noto Color Emoji',sans-serif",
-              }}
-            >
-              <span style={{ marginRight: 6 }}>{m.flag}</span>
-              {m.label}
-            </button>
-          ))}
-        </div>
-        <div style={{ display: "flex", gap: 8, overflowX: "auto", paddingBottom: 4 }}>
-          {p.profiles.map((pp) => (
-            <button
-              key={pp.slug}
-              onClick={() => setProfileSlug(pp.slug)}
-              style={{
-                ...PILL,
-                ...(pp.slug === profileSlug ? PILL_ACTIVE : {}),
-              }}
-            >
-              <span style={{ marginRight: 6 }}>{pp.emoji}</span>
-              {pp.label}
-            </button>
-          ))}
-        </div>
-        {marketTip ? (
-          <div style={MARKET_TIP_BANNER}>
-            <div style={{ fontSize: 12, color: "var(--ls-text-muted)" }}>{marketTip.timing}</div>
-            <div style={{ fontSize: 13, color: "var(--ls-text)" }}>{marketTip.cultural_tip}</div>
+    <div className="prospection-hub">
+      {/* Sticky header */}
+      <div className="ph-hdr">
+        <div className="ph-row1">
+          <div className="ph-brand">
+            <span className="ph-gem" />
+            La Base 360<small>· prospection</small>
           </div>
-        ) : null}
-      </div>
+          <button type="button" className="ph-stat-chip" onClick={() => setSheet("stat")}>
+            <span className="dot-live" />
+            <span>
+              <b className={bumpStat ? "bumped" : ""}>{sent7d}</b> envoyés ·{" "}
+              <b className={bumpStat ? "bumped" : ""}>{rdv7d}</b> RDV
+            </span>
+            <span className="muted">·&nbsp;7j</span>
+          </button>
+        </div>
 
-      {/* Modules grid */}
-      <div style={MODULES_GRID}>
-        {PROSPECTION_MODULES.map((mod) => {
-          const isOpen = openModule === mod.id;
-          return (
-            <div key={mod.id} style={{ ...MODULE_CARD, ...(isOpen ? MODULE_CARD_OPEN : {}) }}>
-              <button
-                onClick={() => setOpenModule(isOpen ? null : mod.id)}
-                style={MODULE_HEADER_BTN}
-                aria-expanded={isOpen}
-              >
-                <span style={{ fontSize: 22, marginRight: 10 }}>{mod.emoji}</span>
-                <span style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", flex: 1 }}>
-                  <span style={{ fontFamily: "Syne, serif", fontSize: 16, fontWeight: 600 }}>{mod.title}</span>
-                  <span style={{ fontSize: 12, color: "var(--ls-text-muted)", marginTop: 2 }}>{mod.subtitle}</span>
-                </span>
-                <span style={MODULE_CHIP}>{mod.section}</span>
-                <span style={{ fontSize: 18, color: "var(--ls-text-muted)", marginLeft: 8 }}>
-                  {isOpen ? "▾" : "▸"}
-                </span>
-              </button>
-              {isOpen ? (
-                <div style={MODULE_BODY}>
-                  {mod.id === "mindset"       && <MindsetModule blocks={mindsetBlocks} metrics={metrics} />}
-                  {mod.id === "find_prospects" && (
-                    <FindProspectsModule
-                      flags={flags}
-                      sources={sources}
-                      hashtags={hashtags}
-                      profile={profile}
-                    />
-                  )}
-                  {mod.id === "messages_m1"   && <MessagesM1Module scripts={scripts} marketCode={marketCode} />}
-                  {mod.id === "reply_tree"    && <ReplyTreeModule nodes={replyTree} marketCode={marketCode} />}
-                  {mod.id === "objections"    && <ObjectionsModule items={objections} marketCode={marketCode} />}
-                  {mod.id === "followups"     && <FollowupsModule items={followups} marketCode={marketCode} />}
-                  {mod.id === "closing"       && <ClosingModule items={closing} marketCode={marketCode} />}
-                  {mod.id === "special_cases" && <SpecialCasesModule items={specialCases} marketCode={marketCode} />}
-                  {mod.id === "storytelling"  && <StorytellingModule items={storytelling} />}
-                  {mod.id === "routine"       && <RoutineModule items={routines} />}
-                </div>
-              ) : null}
+        <div className="ph-pickers">
+          <button
+            type="button"
+            className={`ph-picker${pickerOpening === "market" ? " opening" : ""}`}
+            onClick={() => openPicker("market")}
+          >
+            <span className="flag">{market?.flag ?? "🌍"}</span>
+            <div className="info-stack">
+              <span className="lbl">Marché</span>
+              <span className="val">{market?.label ?? "Choisir"}</span>
             </div>
-          );
-        })}
+            <Caret />
+          </button>
+          <button
+            type="button"
+            className={`ph-picker${pickerOpening === "profile" ? " opening" : ""}`}
+            onClick={() => openPicker("profile")}
+          >
+            <span className="glyph">{profile?.emoji ?? PROFILE_GLYPHS[profileSlug] ?? "👤"}</span>
+            <div className="info-stack">
+              <span className="lbl">Profil cible</span>
+              <span className="val">{profile?.label ?? "Choisir"}</span>
+            </div>
+            <Caret />
+          </button>
+        </div>
+
+        <nav className="ph-index" ref={indexRailRef} aria-label="Index des 10 modules">
+          {MODULES.map((m, i) => {
+            const cls = i === moduleIdx ? "active" : (i < moduleIdx ? "done" : "");
+            return (
+              <button
+                key={m.id}
+                className={`step ${cls}`}
+                type="button"
+                aria-label={m.name}
+                onClick={() => goModule(i)}
+              >
+                <span className="n">{String(i + 1).padStart(2, "0")}</span>
+                <span className="ic">{m.ic}</span>
+                <span className="name">{m.name}</span>
+              </button>
+            );
+          })}
+        </nav>
       </div>
 
-      <button onClick={p.onRestartTunnel} style={RESTART_BTN}>
+      {/* Section meta */}
+      <div className="ph-section-meta">
+        <span><b>{String(moduleIdx + 1).padStart(2, "0")}</b>&nbsp;/&nbsp;10</span>
+        <span>{readingTime}</span>
+      </div>
+
+      {/* Section heading */}
+      <div className="ph-section-head">
+        <div className="kicker">{moduleMeta.kicker}</div>
+        <h2>
+          {moduleMeta.h2[0]}
+          <span className="em">{moduleMeta.h2[1]}</span>
+          {moduleMeta.h2[2]}
+        </h2>
+        <p className="lede">{moduleMeta.lede}</p>
+      </div>
+
+      {/* Body */}
+      <div className="ph-body">
+        <div className={`ph-body-inner${swapping ? " swapping" : ""}`} ref={bodyInnerRef}>
+          {moduleMeta.id === "mindset" && <MindsetModule blocks={mindsetBlocks} />}
+          {moduleMeta.id === "find" && (
+            <FindModule flags={flags} hashtags={hashtags} sources={sources} profile={profile} />
+          )}
+          {moduleMeta.id === "first_msg" && (
+            <FirstMessageModule
+              scripts={scripts}
+              platform={platform}
+              setPlatform={setPlatform}
+              marketCode={marketCode}
+              scriptLang={scriptLang}
+              setLang={setLang}
+              sentScripts={sentScripts}
+              onCopy={copy}
+              onSend={markSent}
+            />
+          )}
+          {moduleMeta.id === "reply" && (
+            <ReplyModule nodes={replyTree} marketCode={marketCode} onCopy={copy} />
+          )}
+          {moduleMeta.id === "objections" && (
+            <ObjectionsModule items={objections} marketCode={marketCode} onCopy={copy} />
+          )}
+          {moduleMeta.id === "post_call" && (
+            <PostCallModule items={followups} marketCode={marketCode} onCopy={copy} />
+          )}
+          {moduleMeta.id === "closing" && (
+            <ClosingModule items={closing} marketCode={marketCode} onCopy={copy} />
+          )}
+          {moduleMeta.id === "special" && (
+            <SpecialCasesModule items={specialCases} marketCode={marketCode} caseTab={caseTab} setCaseTab={setCaseTab} onCopy={copy} />
+          )}
+          {moduleMeta.id === "story" && <StorytellingModule items={storytelling} />}
+          {moduleMeta.id === "routine" && (
+            <RoutineModule items={routines} checks={checks} setChecks={setChecks} marketTip={marketTip} />
+          )}
+        </div>
+      </div>
+
+      {/* Bottom nav */}
+      <nav className="ph-botnav">
+        <button
+          type="button"
+          className="ph-btn-nav prev"
+          onClick={() => goModule(moduleIdx - 1)}
+          disabled={moduleIdx === 0}
+        >
+          <span className="arr"><ArrowLeft /></span>
+          <span className="lab">
+            <small>{prevMod ? "Précédent" : "Début"}</small>
+            <span>{prevMod?.name ?? "Index"}</span>
+          </span>
+        </button>
+        <div className="ph-dots" aria-hidden="true">
+          {MODULES.map((_, i) => (
+            <span key={i} className={`d ${i === moduleIdx ? "on" : i < moduleIdx ? "done" : ""}`} />
+          ))}
+        </div>
+        <button
+          type="button"
+          className="ph-btn-nav next"
+          onClick={() => goModule(moduleIdx + 1)}
+          disabled={moduleIdx === MODULES.length - 1}
+        >
+          <span className="arr"><ArrowRight /></span>
+          <span className="lab">
+            <small>{nextMod ? `Suivant · ${String(moduleIdx + 2).padStart(2, "0")}` : "Fin"}</small>
+            <span>{nextMod?.name ?? "—"}</span>
+          </span>
+        </button>
+      </nav>
+
+      {/* Toast */}
+      <div className={`ph-toast${toast ? " show" : ""}`} aria-live="polite">
+        <span className="ic">✓</span>
+        <span>{toast ?? ""}</span>
+      </div>
+
+      {/* Sheets */}
+      <div className={`ph-sheet-backdrop${sheet ? " open" : ""}`} onClick={() => setSheet(null)} />
+      <div className={`ph-sheet${sheet === "stat" ? " ph-stat-sheet" : ""}${sheet ? " open" : ""}`}>
+        <div className="grab" />
+        {sheet === "market" && (
+          <>
+            <div className="sheet-head">
+              <div className="kicker">Choisir un marché</div>
+              <h3>Marché cible.</h3>
+            </div>
+            <div className="sheet-body">
+              <div className="ph-opts cols-2">
+                {p.markets.map((m) => (
+                  <button
+                    key={m.code}
+                    className={`ph-opt${m.code === marketCode ? " on" : ""}`}
+                    type="button"
+                    onClick={() => { setMarketCode(m.code); setSheet(null); }}
+                  >
+                    <span className="flag">{m.flag}</span>
+                    <span className="info">
+                      <b>{m.label}</b>
+                      <small>{m.description ?? m.code}</small>
+                    </span>
+                    <span className="check" />
+                  </button>
+                ))}
+              </div>
+              <p style={{ fontFamily: "var(--hub-f-mono)", fontSize: 10.5, color: "var(--hub-muted)", lineHeight: 1.6, marginTop: 14, padding: "10px 12px", background: "var(--hub-surface2)", borderRadius: 10 }}>
+                Les scripts, hashtags et sources se localisent automatiquement.
+              </p>
+            </div>
+          </>
+        )}
+        {sheet === "profile" && (
+          <>
+            <div className="sheet-head">
+              <div className="kicker">Choisir un profil</div>
+              <h3>Profil cible.</h3>
+            </div>
+            <div className="sheet-body">
+              <div className="ph-opts">
+                {p.profiles.map((pp) => (
+                  <button
+                    key={pp.slug}
+                    className={`ph-opt${pp.slug === profileSlug ? " on" : ""}`}
+                    type="button"
+                    onClick={() => { setProfileSlug(pp.slug); setSheet(null); }}
+                  >
+                    <span className="glyph">{pp.emoji}</span>
+                    <span className="info">
+                      <b>{pp.label}</b>
+                      <small>{pp.description ?? ""}</small>
+                    </span>
+                    <span className="check" />
+                  </button>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+        {sheet === "stat" && (
+          <StatFunnelSheet sent={sent7d} rdv={rdv7d} />
+        )}
+      </div>
+
+      {/* Restart tunnel (discret) */}
+      <button
+        type="button"
+        onClick={p.onRestartTunnel}
+        style={{
+          alignSelf: "center", margin: "16px 0 24px",
+          padding: "8px 14px", borderRadius: 999,
+          border: "1px dashed var(--hub-line)",
+          background: "transparent",
+          color: "var(--hub-muted)",
+          fontSize: 12, fontFamily: "var(--hub-f-mono)",
+          cursor: "pointer",
+        }}
+      >
         🔁 Revoir le tunnel onboarding
       </button>
     </div>
   );
 }
 
-// ============================================================================
-// Module renderers — read-only display
-// ============================================================================
+// ────────────────────────────────────────────────────────────
+// Module renderers
+// ────────────────────────────────────────────────────────────
 
-function MindsetModule({
-  blocks, metrics,
-}: { blocks: ProspectionMindsetBlock[]; metrics: ProspectionMetric[] }) {
+function MindsetModule({ blocks }: { blocks: ProspectionMindsetBlock[] }) {
   const truths = blocks.filter((b) => b.kind === "truth");
   const errors = blocks.filter((b) => b.kind === "error");
-  const funnel = metrics.filter((m) => m.kind === "funnel_step");
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      <section>
-        <h4 style={H4}>Les vérités à accepter</h4>
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          {truths.map((t) => (
-            <article key={t.id} style={INFO_CARD}>
-              <div style={{ fontFamily: "Syne, serif", fontWeight: 600, fontSize: 14, marginBottom: 4 }}>{t.title}</div>
-              <div style={{ fontSize: 13, color: "var(--ls-text)", whiteSpace: "pre-wrap" }}>{t.body}</div>
-            </article>
-          ))}
+    <>
+      {truths[0] && (
+        <article className="ph-truth">
+          <div className="ph-truth-row">
+            <div className="num">01</div>
+            <div>
+              <div className="kicker">Vérité n°1 · posture</div>
+              <p className="quote">{renderTruthBody(truths[0].body)}</p>
+              <p style={{ fontFamily: "var(--hub-f-body)", fontStyle: "italic", fontSize: 12, color: "rgba(255,255,255,.55)", marginTop: 10 }}>
+                — extrait <em>Méthode 360</em>
+              </p>
+            </div>
+          </div>
+        </article>
+      )}
+      {truths.slice(1).map((t, i) => (
+        <div key={t.id} className="ph-truth-lite">
+          <div className="ctx">Vérité n°{i + 2} · {t.title.split(" ")[0].toLowerCase()}</div>
+          <p>{renderTruthBody(t.body)}</p>
         </div>
-      </section>
-      <section>
-        <h4 style={H4}>Erreurs du débutant</h4>
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          {errors.map((e, idx) => (
-            <article key={e.id} style={ERROR_CARD}>
-              <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 2 }}>{idx + 1}. {e.title}</div>
-              <div style={{ fontSize: 12, color: "var(--ls-text-muted)" }}>{e.body}</div>
-            </article>
-          ))}
+      ))}
+
+      <div className="ph-errors-head">
+        <span className="label">{errors.length} erreurs à éviter</span>
+        <span style={{ fontFamily: "var(--hub-f-mono)", fontSize: 10, color: "var(--hub-muted)", letterSpacing: "0.1em" }}>↓ scroll</span>
+      </div>
+      {errors.map((e, i) => (
+        <div key={e.id} className="ph-err">
+          <span className="n">{String(i + 1).padStart(2, "0")}</span>
+          <div className="txt">{e.body}</div>
         </div>
-      </section>
-      {funnel.length > 0 ? (
-        <section>
-          <h4 style={H4}>Métriques réalistes (débutant)</h4>
-          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
-            <tbody>
-              {funnel.map((f) => (
-                <tr key={f.id} style={{ borderBottom: "1px solid var(--ls-border)" }}>
-                  <td style={{ padding: "6px 4px" }}>{f.label}</td>
-                  <td style={{ padding: "6px 4px", textAlign: "right", fontFamily: "Syne, serif", fontWeight: 600 }}>
-                    {formatRange(f.value_min, f.value_max, f.value_unit)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </section>
-      ) : null}
-    </div>
+      ))}
+    </>
   );
 }
 
-function FindProspectsModule({
-  flags, sources, hashtags, profile,
+function FindModule({
+  flags, hashtags, sources, profile,
 }: {
   flags: ProspectionProfileFlag[];
-  sources: ProspectionSource[];
   hashtags: ProspectionHashtag[];
+  sources: ProspectionSource[];
   profile: ProspectionProfile | null;
 }) {
   const green = flags.filter((f) => f.flag_type === "green");
@@ -261,336 +616,372 @@ function FindProspectsModule({
   const mainstream = hashtags.filter((h) => h.category === "mainstream");
   const niche = hashtags.filter((h) => h.category === "niche");
   const cross = hashtags.filter((h) => h.category === "cross");
-  const advices = sources.filter((s) => s.kind === "hashtag_advanced");
-  const groupedSources = [
-    { key: "fb_groups",       label: "Groupes Facebook" },
-    { key: "irl",             label: "IRL" },
-    { key: "recommendations", label: "Recommandations" },
-    { key: "inbound_content", label: "Contenu entrant" },
-  ] as const;
+  const srcMap: Record<string, ProspectionSource[]> = {
+    fb_groups: sources.filter((s) => s.kind === "fb_groups"),
+    irl: sources.filter((s) => s.kind === "irl"),
+    recommendations: sources.filter((s) => s.kind === "recommendations"),
+    inbound_content: sources.filter((s) => s.kind === "inbound_content"),
+  };
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      <section style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-        <div style={GREEN_CARD}>
-          <div style={{ fontWeight: 600, marginBottom: 6 }}>✅ Green flags (envoie le M1)</div>
-          {green.map((f) => (
-            <div key={f.id} style={{ fontSize: 13, padding: "2px 0" }}>• {f.text}</div>
-          ))}
+    <>
+      <div className="ph-scan-timer">
+        <span className="pulse" />
+        Scan en 30 s · les 4 premières secondes
+      </div>
+
+      <div className="ph-flags">
+        <div className="ph-flag-col green">
+          <h5><span className="dot" />Drapeaux verts</h5>
+          <ul>
+            {green.map((f) => (<li key={f.id}>{f.text}</li>))}
+          </ul>
         </div>
-        <div style={RED_CARD}>
-          <div style={{ fontWeight: 600, marginBottom: 6 }}>❌ Red flags (passe ton chemin)</div>
-          {red.map((f) => (
-            <div key={f.id} style={{ fontSize: 13, padding: "2px 0" }}>• {f.text}</div>
-          ))}
+        <div className="ph-flag-col red">
+          <h5><span className="dot" />Drapeaux rouges</h5>
+          <ul>
+            {red.map((f) => (<li key={f.id}>{f.text}</li>))}
+          </ul>
         </div>
-      </section>
-      {advices.length > 0 ? (
-        <section>
-          <h4 style={H4}>Conseils transverses</h4>
-          {advices.map((a) => (
-            <article key={a.id} style={INFO_CARD}>
-              <div style={{ fontWeight: 600, fontSize: 13 }}>{a.label}</div>
-              {a.detail ? (
-                <div style={{ fontSize: 12, color: "var(--ls-text-muted)", whiteSpace: "pre-wrap", marginTop: 4 }}>
-                  {a.detail}
-                </div>
-              ) : null}
-            </article>
-          ))}
-        </section>
-      ) : null}
-      <section>
-        <h4 style={H4}>Hashtags par catégorie</h4>
-        <HashtagRow title="Mainstream (large)" items={mainstream} accent="var(--ls-text-muted)" />
-        <HashtagRow title="Niche (segment précis)" items={niche} accent="var(--ls-teal)" />
-        <HashtagRow title="Cross (à croiser)" items={cross} accent="var(--ls-gold)" showHint />
-        {profile?.hashtag_advice ? (
-          <div style={{ ...INFO_CARD, marginTop: 8 }}>
-            <div style={{ fontWeight: 600, fontSize: 13 }}>Astuce pour ce profil</div>
-            <div style={{ fontSize: 12, color: "var(--ls-text-muted)", marginTop: 4 }}>{profile.hashtag_advice}</div>
+      </div>
+
+      <div className="ph-hashtag-card">
+        <div className="htag-head">
+          <span>Hashtags · 3 <b>catégories</b></span>
+        </div>
+        {mainstream.length > 0 && (
+          <div className="ph-htag-row">
+            <span className="cat">Mainstream</span>
+            {mainstream.map((h) => (<span key={h.id} className="ph-htag">{h.hashtag}</span>))}
           </div>
-        ) : null}
-      </section>
-      <section>
-        <h4 style={H4}>Sources alternatives</h4>
-        {groupedSources.map(({ key, label }) => {
-          const items = sources.filter((s) => s.kind === key);
-          if (items.length === 0) return null;
-          return (
-            <div key={key} style={{ marginBottom: 8 }}>
-              <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 4 }}>{label}</div>
-              {items.map((it) => (
-                <div key={it.id} style={INFO_CARD_TIGHT}>
-                  <div style={{ fontSize: 13 }}>{it.label}</div>
-                  {it.detail ? <div style={{ fontSize: 12, color: "var(--ls-text-muted)", marginTop: 2 }}>{it.detail}</div> : null}
-                </div>
-              ))}
-            </div>
-          );
-        })}
-      </section>
-    </div>
+        )}
+        {niche.length > 0 && (
+          <div className="ph-htag-row">
+            <span className="cat">Niche</span>
+            {niche.map((h) => (<span key={h.id} className="ph-htag teal">{h.hashtag}</span>))}
+          </div>
+        )}
+        {cross.length > 0 && (
+          <div className="ph-htag-row">
+            <span className="cat">Cross</span>
+            {cross.map((h) => (<span key={h.id} className="ph-htag gold">{h.hashtag}</span>))}
+          </div>
+        )}
+        {profile?.hashtag_advice && (
+          <p style={{ fontFamily: "var(--hub-f-mono)", fontSize: 10.5, color: "var(--hub-muted)", lineHeight: 1.5, marginTop: 8, paddingTop: 8, borderTop: "1px dashed var(--hub-line)" }}>
+            {profile.hashtag_advice}
+          </p>
+        )}
+      </div>
+
+      <article className="ph-src-card">
+        <div className="kk">Sources hors-feed</div>
+        <h4>Là où on n'écrit pas en premier</h4>
+        {srcMap.fb_groups[0] && (
+          <div className="ph-src-row">
+            <span className="lab">Facebook</span>
+            <div className="body">{srcMap.fb_groups[0].detail ?? srcMap.fb_groups[0].label}</div>
+          </div>
+        )}
+        {srcMap.irl[0] && (
+          <div className="ph-src-row">
+            <span className="lab">IRL</span>
+            <div className="body">{srcMap.irl[0].detail ?? srcMap.irl[0].label}</div>
+          </div>
+        )}
+        {srcMap.recommendations[0] && (
+          <div className="ph-src-row">
+            <span className="lab">Reco</span>
+            <div className="body">{srcMap.recommendations[0].detail ?? srcMap.recommendations[0].label}</div>
+          </div>
+        )}
+        {srcMap.inbound_content[0] && (
+          <div className="ph-src-row">
+            <span className="lab">Inbound</span>
+            <div className="body">{srcMap.inbound_content[0].detail ?? srcMap.inbound_content[0].label}</div>
+          </div>
+        )}
+      </article>
+    </>
   );
 }
 
-function HashtagRow({
-  title, items, accent, showHint,
-}: { title: string; items: ProspectionHashtag[]; accent: string; showHint?: boolean }) {
-  if (items.length === 0) return null;
+function FirstMessageModule({
+  scripts, platform, setPlatform, marketCode, scriptLang, setLang, sentScripts, onCopy, onSend,
+}: {
+  scripts: ProspectionScript[];
+  platform: ProspectionPlatform;
+  setPlatform: (p: ProspectionPlatform) => void;
+  marketCode: string;
+  scriptLang: Record<string, "native" | "fr">;
+  setLang: (id: string, lang: "native" | "fr") => void;
+  sentScripts: Record<string, boolean>;
+  onCopy: (text: string, label?: string) => void;
+  onSend: (id: string, platform: ProspectionPlatform) => void;
+}) {
+  const m1 = scripts.filter((s) => s.kind === "first_contact" && s.platform === platform);
   return (
-    <div style={{ marginBottom: 8 }}>
-      <div style={{ fontSize: 12, color: "var(--ls-text-muted)", marginBottom: 4 }}>{title}</div>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-        {items.map((h) => (
-          <span key={h.id} style={{ ...TAG, color: accent, borderColor: accent }}>{h.hashtag}</span>
+    <>
+      <div className="ph-platform-tabs">
+        {PLATFORM_ORDER.map((pl) => (
+          <button
+            key={pl}
+            className={`tab${platform === pl ? " on" : ""}`}
+            type="button"
+            onClick={() => setPlatform(pl)}
+          >
+            <span className="ic">{PLATFORM_GLYPH[pl]}</span>
+            <span>{PLATFORM_SHORT[pl]}</span>
+          </button>
         ))}
       </div>
-      {showHint
-        ? items.filter((h) => h.crossover_hint).map((h) => (
-            <div key={h.id + "-hint"} style={{ fontSize: 11, color: "var(--ls-text-muted)", marginTop: 4 }}>
-              {h.hashtag} — {h.crossover_hint}
+
+      {m1.length === 0 && (
+        <Empty>Aucun script pour cette plateforme sur ce marché × profil.</Empty>
+      )}
+
+      {m1.map((s) => {
+        const isSent = !!sentScripts[s.id];
+        const showFr = marketCode !== "fr" && !!s.body_fr && (scriptLang[s.id] ?? "native") === "native";
+        const langActive = scriptLang[s.id] ?? "native";
+        const body = langActive === "fr" && s.body_fr ? s.body_fr : s.body;
+        return (
+          <article key={s.id} className={`ph-script${isSent ? " sent" : ""}`}>
+            <div className="head">
+              <span className="glyph">{PLATFORM_GLYPH[s.platform]}</span>
+              <h4>{s.label ?? PLATFORM_LABELS[s.platform]}</h4>
+              {marketCode !== "fr" && s.body_fr && (
+                <div className="ph-lang-switch">
+                  <button type="button" className={langActive === "native" ? "on" : ""} onClick={() => setLang(s.id, "native")}>{s.language_label?.split(" ")[0] ?? "EN"}</button>
+                  <button type="button" className={langActive === "fr" ? "on" : ""} onClick={() => setLang(s.id, "fr")}>FR</button>
+                </div>
+              )}
             </div>
-          ))
-        : null}
-    </div>
+            {s.tip && (
+              <div className="ctx">{s.tip}</div>
+            )}
+            <div className="ph-msg-body">{renderScriptBody(body)}</div>
+            {showFr && s.body_fr && (
+              <div className="ph-trad-line">{s.body_fr}</div>
+            )}
+            <div className="ph-script-actions">
+              <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
+                <span className="ic">⌘C</span>Copier le script
+              </button>
+              <button
+                className={`ph-btn send${isSent ? " done" : ""}`}
+                type="button"
+                onClick={() => onSend(s.id, s.platform)}
+              >
+                {isSent ? "✓ Envoyé" : "→ J'ai envoyé"}
+              </button>
+            </div>
+          </article>
+        );
+      })}
+    </>
   );
 }
 
-function MessagesM1Module({
-  scripts, marketCode,
-}: { scripts: ProspectionScript[]; marketCode: string }) {
-  const m1 = scripts.filter((s) => s.kind === "first_contact");
-  if (m1.length === 0) {
-    return <Empty>Aucun script M1 pour ce profil sur ce marché.</Empty>;
-  }
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-      {m1.map((s) => (
-        <ScriptCard key={s.id} script={s} marketCode={marketCode} />
-      ))}
-    </div>
-  );
-}
-
-function ScriptCard({ script, marketCode }: { script: ProspectionScript; marketCode: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <article style={SCRIPT_CARD}>
-      <header style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
-        <span
-          style={{
-            width: 26, height: 26, borderRadius: 8, display: "inline-flex",
-            alignItems: "center", justifyContent: "center", fontSize: 14, color: "#fff",
-            background: PLATFORM_GRADIENTS[script.platform],
-          }}
-        >
-          {PLATFORM_ICONS[script.platform]}
-        </span>
-        <span style={{ fontWeight: 600, fontSize: 13 }}>{script.label ?? PLATFORM_LABELS[script.platform]}</span>
-        {script.language_label ? <span style={{ marginLeft: "auto", fontSize: 11, color: "var(--ls-text-muted)" }}>{script.language_label}</span> : null}
-      </header>
-      <pre style={SCRIPT_BODY}>{script.body}</pre>
-      {marketCode !== "fr" && script.body_fr ? (
-        <details style={{ marginTop: 6 }}>
-          <summary style={{ fontSize: 12, color: "var(--ls-text-muted)", cursor: "pointer" }}>🇫🇷 Voir la traduction française</summary>
-          <pre style={{ ...SCRIPT_BODY, marginTop: 4 }}>{script.body_fr}</pre>
-        </details>
-      ) : null}
-      {script.tip ? (
-        <div style={TIP_BOX}>💡 {script.tip}</div>
-      ) : null}
-      <button
-        onClick={() => {
-          void navigator.clipboard.writeText(script.body);
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
-        }}
-        style={COPY_BTN}
-      >
-        {copied ? "✓ Copié" : "Copier le message"}
-      </button>
-    </article>
-  );
-}
-
-function ReplyTreeModule({
-  nodes, marketCode,
-}: { nodes: ProspectionReplyNode[]; marketCode: string }) {
-  if (nodes.length === 0) return <Empty>Aucune arborescence pour ce profil sur ce marché.</Empty>;
-  const m2 = nodes.filter((n) => n.level === "M2");
-  const m3 = nodes.filter((n) => n.level === "M3");
-  const branchOrder: Record<string, number> = {
-    positive: 1, vague: 2, negative: 3, question: 4, hot: 1, lukewarm: 2,
+function ReplyModule({
+  nodes, marketCode, onCopy,
+}: { nodes: ProspectionReplyNode[]; marketCode: string; onCopy: (t: string) => void }) {
+  // Map branches → pill labels
+  const branchLabel: Record<string, { pill: string; emoji: string; cls: string }> = {
+    positive: { pill: "Tiède", emoji: "🔥", cls: "warm" },
+    hot:      { pill: "Très chaude", emoji: "🔥", cls: "warm" },
+    negative: { pill: "Froid", emoji: "❄️", cls: "cold" },
+    vague:    { pill: "Indécis", emoji: "🤔", cls: "maybe" },
+    lukewarm: { pill: "Tiède", emoji: "🌡️", cls: "maybe" },
+    question: { pill: "Curieux", emoji: "❓", cls: "maybe" },
   };
-  const branchLabel: Record<string, string> = {
-    positive: "✅ Réponse positive",
-    vague: "🤔 Réponse vague",
-    negative: "❌ Réponse négative",
-    question: "❓ Question",
-    hot: "🔥 Conv qui chauffe",
-    lukewarm: "🌡️ Conv tiède",
-  };
-  const sort = (arr: ProspectionReplyNode[]) =>
-    [...arr].sort((a, b) => (branchOrder[a.branch] ?? 9) - (branchOrder[b.branch] ?? 9));
+  if (nodes.length === 0) return <Empty>Aucune branche pour ce marché × profil.</Empty>;
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      <section>
-        <h4 style={H4}>M2 — Après ton M1</h4>
-        {sort(m2).map((n) => <ReplyNodeCard key={n.id} node={n} label={branchLabel[n.branch]} marketCode={marketCode} />)}
-      </section>
-      {m3.length > 0 ? (
-        <section>
-          <h4 style={H4}>M3 — La conversation continue</h4>
-          {sort(m3).map((n) => <ReplyNodeCard key={n.id} node={n} label={branchLabel[n.branch]} marketCode={marketCode} />)}
-        </section>
-      ) : null}
-    </div>
+    <>
+      {nodes.map((n) => {
+        const meta = branchLabel[n.branch] ?? { pill: n.branch, emoji: "·", cls: "maybe" };
+        const body = marketCode !== "fr" && n.body_fr ? n.body_fr : n.body;
+        return (
+          <article key={n.id} className="ph-tree-branch">
+            <div className="reaction">
+              <span>{meta.emoji} Il / elle réagit</span>
+              <span className={`pill ${meta.cls}`}>{meta.pill}</span>
+              <span style={{ marginLeft: "auto", fontFamily: "var(--hub-f-mono)", fontSize: 9.5, color: "var(--hub-muted)" }}>{n.level}</span>
+            </div>
+            <q>{n.tip ?? "—"}</q>
+            <div className="reply">{renderScriptBody(body)}</div>
+            <div className="actions">
+              <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
+                <span className="ic">⌘C</span>Copier
+              </button>
+            </div>
+          </article>
+        );
+      })}
+    </>
   );
 }
 
-function ReplyNodeCard({ node, label, marketCode }: { node: ProspectionReplyNode; label: string; marketCode: string }) {
-  return (
-    <article style={INFO_CARD}>
-      <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 6 }}>{label}</div>
-      <pre style={SCRIPT_BODY}>{node.body}</pre>
-      {marketCode !== "fr" && node.body_fr ? (
-        <details style={{ marginTop: 6 }}>
-          <summary style={{ fontSize: 12, color: "var(--ls-text-muted)", cursor: "pointer" }}>🇫🇷 Traduction</summary>
-          <pre style={{ ...SCRIPT_BODY, marginTop: 4 }}>{node.body_fr}</pre>
-        </details>
-      ) : null}
-      {node.tip ? <div style={TIP_BOX}>💡 {node.tip}</div> : null}
-    </article>
-  );
-}
-
-function ObjectionsModule({ items, marketCode }: { items: ProspectionObjection[]; marketCode: string }) {
+function ObjectionsModule({
+  items, marketCode, onCopy,
+}: { items: ProspectionObjection[]; marketCode: string; onCopy: (t: string) => void }) {
   if (items.length === 0) return <Empty>Aucune objection pour ce marché.</Empty>;
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-      {items.map((o) => (
-        <article key={o.id} style={INFO_CARD}>
-          <div style={{ fontFamily: "Syne, serif", fontWeight: 600, fontSize: 15, marginBottom: 6 }}>
-            « {o.title} »
+    <>
+      {items.map((o, i) => {
+        const goodBody = marketCode !== "fr" && o.good_response_fr ? o.good_response_fr : o.good_response;
+        return (
+          <div key={o.id} className="ph-obj">
+            <div className="quote">
+              <div className="n">{String(i + 1).padStart(2, "0")}<small>{o.slug}</small></div>
+              <q>{o.title}</q>
+            </div>
+            <div className="ph-obj-row bad">
+              <span className="badge">✕</span>
+              <div>
+                <div className="lbl">À ne pas dire</div>
+                <p>{o.bad_response}</p>
+              </div>
+            </div>
+            <div className="ph-obj-row good">
+              <span className="badge">✓</span>
+              <div>
+                <div className="lbl">Ce qui ouvre</div>
+                <p>{renderScriptBody(goodBody)}</p>
+              </div>
+            </div>
+            {o.warning && (
+              <div className="ph-obj-row bad" style={{ marginTop: 6 }}>
+                <span className="badge">!</span>
+                <div>
+                  <div className="lbl" style={{ color: "var(--hub-accent-dark)" }}>Attention</div>
+                  <p style={{ color: "var(--hub-text)", textDecoration: "none" }}>{o.warning}</p>
+                </div>
+              </div>
+            )}
+            <div className="ph-obj-actions">
+              <button className="ph-btn copy" type="button" onClick={() => onCopy(goodBody)}>
+                <span className="ic">⌘C</span>Copier la réponse
+              </button>
+            </div>
           </div>
-          <div style={{ fontSize: 12, color: "var(--ls-text-muted)", marginBottom: 8 }}>
-            <strong>Ce qu'elle veut dire :</strong> {o.meaning}
-          </div>
-          <div style={{ fontSize: 12, color: "var(--ls-coral, #e57373)", marginBottom: 8 }}>
-            <strong>❌ Mauvaise réponse :</strong> {o.bad_response}
-          </div>
-          <div style={{ fontSize: 13, marginBottom: 6 }}>
-            <strong>✅ Bonne réponse :</strong>
-          </div>
-          <pre style={SCRIPT_BODY}>{o.good_response}</pre>
-          {marketCode !== "fr" && o.good_response_fr ? (
-            <details style={{ marginTop: 6 }}>
-              <summary style={{ fontSize: 12, color: "var(--ls-text-muted)", cursor: "pointer" }}>🇫🇷 Traduction</summary>
-              <pre style={{ ...SCRIPT_BODY, marginTop: 4 }}>{o.good_response_fr}</pre>
-            </details>
-          ) : null}
-          {o.warning ? <div style={WARNING_BOX}>⚠️ {o.warning}</div> : null}
-        </article>
-      ))}
-    </div>
+        );
+      })}
+    </>
   );
 }
 
-function FollowupsModule({ items, marketCode }: { items: ProspectionFollowup[]; marketCode: string }) {
-  if (items.length === 0) return <Empty>Aucune séquence pour ce marché.</Empty>;
-  const groups = [
-    { kind: "post_call", label: "📞 Après un appel / Zoom" },
-    { kind: "client_onboarding", label: "🎉 Suivi client (après achat)" },
-    { kind: "reactivation_old", label: "🔁 Réactivation prospect ancien" },
-  ] as const;
+function PostCallModule({
+  items, marketCode, onCopy,
+}: { items: ProspectionFollowup[]; marketCode: string; onCopy: (t: string) => void }) {
+  const postCall = items.filter((i) => i.kind === "post_call").sort((a, b) => a.day_offset - b.day_offset);
+  if (postCall.length === 0) return <Empty>Pas de séquence post-appel pour ce marché.</Empty>;
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      {groups.map(({ kind, label }) => {
-        const list = items.filter((i) => i.kind === kind).sort((a, b) => a.day_offset - b.day_offset);
-        if (list.length === 0) return null;
+    <div className="ph-timeline">
+      {postCall.map((f, idx) => {
+        const state = idx === 0 ? "now" : "future";
+        const body = marketCode !== "fr" && f.body_fr ? f.body_fr : f.body;
         return (
-          <section key={kind}>
-            <h4 style={H4}>{label}</h4>
-            {list.map((f) => (
-              <article key={f.id} style={INFO_CARD}>
-                <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 6 }}>{f.title}</div>
-                <pre style={SCRIPT_BODY}>{f.body}</pre>
-                {marketCode !== "fr" && f.body_fr ? (
-                  <details style={{ marginTop: 6 }}>
-                    <summary style={{ fontSize: 12, color: "var(--ls-text-muted)", cursor: "pointer" }}>🇫🇷 Traduction</summary>
-                    <pre style={{ ...SCRIPT_BODY, marginTop: 4 }}>{f.body_fr}</pre>
-                  </details>
-                ) : null}
-                {f.warning ? <div style={WARNING_BOX}>⚠️ {f.warning}</div> : null}
-              </article>
-            ))}
-          </section>
+          <div key={f.id} className={`ph-t-step ${state}`}>
+            <div className="when">{f.title}</div>
+            <h4>Touche {idx + 1}</h4>
+            <div className="msg">{renderScriptBody(body)}</div>
+            <div style={{ marginTop: 8, display: "flex", gap: 6 }}>
+              <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
+                <span className="ic">⌘C</span>Copier
+              </button>
+              {f.warning && (
+                <span style={{ fontFamily: "var(--hub-f-mono)", fontSize: 10, color: "var(--hub-accent-dark)", alignSelf: "center" }}>⚠ {f.warning}</span>
+              )}
+            </div>
+          </div>
         );
       })}
     </div>
   );
 }
 
-function ClosingModule({ items, marketCode }: { items: ProspectionClosingBlock[]; marketCode: string }) {
-  if (items.length === 0) return <Empty>Aucun closing pour ce marché.</Empty>;
+function ClosingModule({
+  items, marketCode, onCopy,
+}: { items: ProspectionClosingBlock[]; marketCode: string; onCopy: (t: string) => void }) {
   const signals = items.filter((i) => i.kind === "signal");
   const scripts = items.filter((i) => i.kind !== "signal");
-  const scriptLabel: Record<string, string> = {
-    propose: "Proposer le passage à l'achat",
-    hesitation: "Si elle hésite",
-    final_no: "Encaisser un non final",
+  if (items.length === 0) return <Empty>Aucun closing pour ce marché.</Empty>;
+  const scriptTitle: Record<string, string> = {
+    propose: "Proposer la suite",
+    hesitation: "Quand il hésite",
+    final_no: "Encaisser le non",
   };
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      {signals.length > 0 ? (
-        <section>
-          <h4 style={H4}>Signaux d'achat (elle est prête)</h4>
-          {signals.map((s) => (
-            <div key={s.id} style={INFO_CARD_TIGHT}>
-              <div style={{ fontWeight: 600, fontSize: 13 }}>{s.title ?? "Signal"}</div>
-              <div style={{ fontSize: 12, color: "var(--ls-text-muted)", marginTop: 2 }}>{s.body}</div>
+    <>
+      {signals.length > 0 && (
+        <div className="ph-signal-card">
+          <h5>Signaux d'achat ({signals.length})</h5>
+          <div className="ph-signal-list">
+            {signals.map((s) => (
+              <div key={s.id} className="row">{s.title ?? s.body}</div>
+            ))}
+          </div>
+        </div>
+      )}
+      {scripts.map((s) => {
+        const body = marketCode !== "fr" && s.body_fr ? s.body_fr : s.body;
+        return (
+          <article key={s.id} className="ph-close-script">
+            <h4>{s.title ?? scriptTitle[s.kind] ?? s.kind}</h4>
+            <div className="ctx">Kind · {s.kind}</div>
+            <p>{renderScriptBody(body)}</p>
+            <div style={{ marginTop: 10, display: "flex", gap: 6 }}>
+              <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
+                <span className="ic">⌘C</span>Copier
+              </button>
             </div>
-          ))}
-        </section>
-      ) : null}
-      <section>
-        <h4 style={H4}>Scripts</h4>
-        {scripts.map((s) => (
-          <article key={s.id} style={INFO_CARD}>
-            <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 6 }}>
-              {s.title ?? scriptLabel[s.kind] ?? s.kind}
-            </div>
-            <pre style={SCRIPT_BODY}>{s.body}</pre>
-            {marketCode !== "fr" && s.body_fr ? (
-              <details style={{ marginTop: 6 }}>
-                <summary style={{ fontSize: 12, color: "var(--ls-text-muted)", cursor: "pointer" }}>🇫🇷 Traduction</summary>
-                <pre style={{ ...SCRIPT_BODY, marginTop: 4 }}>{s.body_fr}</pre>
-              </details>
-            ) : null}
           </article>
-        ))}
-      </section>
-    </div>
+        );
+      })}
+    </>
   );
 }
 
-function SpecialCasesModule({ items, marketCode }: { items: ProspectionSpecialCase[]; marketCode: string }) {
+function SpecialCasesModule({
+  items, marketCode, caseTab, setCaseTab, onCopy,
+}: {
+  items: ProspectionSpecialCase[];
+  marketCode: string;
+  caseTab: "ghost_after_exchange" | "reactivation_3_6m" | "referral_request";
+  setCaseTab: (k: "ghost_after_exchange" | "reactivation_3_6m" | "referral_request") => void;
+  onCopy: (t: string) => void;
+}) {
   if (items.length === 0) return <Empty>Aucun cas spécial pour ce marché.</Empty>;
+  const tabs = [
+    { id: "ghost_after_exchange" as const, label: "Ghost" },
+    { id: "reactivation_3_6m" as const, label: "Réactivation" },
+    { id: "referral_request" as const, label: "Recommandation" },
+  ];
+  const active = items.find((i) => i.kind === caseTab);
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-      {items.map((s) => (
-        <article key={s.id} style={INFO_CARD}>
-          <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 6 }}>{s.title}</div>
-          <pre style={SCRIPT_BODY}>{s.body}</pre>
-          {marketCode !== "fr" && s.body_fr ? (
-            <details style={{ marginTop: 6 }}>
-              <summary style={{ fontSize: 12, color: "var(--ls-text-muted)", cursor: "pointer" }}>🇫🇷 Traduction</summary>
-              <pre style={{ ...SCRIPT_BODY, marginTop: 4 }}>{s.body_fr}</pre>
-            </details>
-          ) : null}
+    <>
+      <div className="ph-case-tabs">
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            className={caseTab === t.id ? "on" : ""}
+            onClick={() => setCaseTab(t.id)}
+          >{t.label}</button>
+        ))}
+      </div>
+      {active && (
+        <article className="ph-close-script">
+          <h4>{active.title}</h4>
+          <p>{renderScriptBody(marketCode !== "fr" && active.body_fr ? active.body_fr : active.body)}</p>
+          <div style={{ marginTop: 10, display: "flex", gap: 6 }}>
+            <button className="ph-btn copy" type="button" onClick={() => onCopy(active.body)}>
+              <span className="ic">⌘C</span>Copier
+            </button>
+          </div>
         </article>
-      ))}
-    </div>
+      )}
+    </>
   );
 }
 
@@ -599,322 +990,243 @@ function StorytellingModule({ items }: { items: ProspectionStoryBlock[] }) {
   const structure = items.filter((i) => i.kind === "structure_step");
   const examples = items.filter((i) => i.kind === "example");
   const rules = items.filter((i) => i.kind === "rule");
+  // 3 actes max (Avant / Déclic / Après) — on prend les 3 premiers structure_steps
+  const acts = structure.slice(0, 3);
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      {structure.length > 0 ? (
-        <section>
-          <h4 style={H4}>Structure en 4 temps</h4>
-          {structure.map((s, idx) => (
-            <div key={s.id} style={INFO_CARD_TIGHT}>
-              <div style={{ fontWeight: 600, fontSize: 13 }}>{idx + 1}. {s.title}</div>
-              <div style={{ fontSize: 12, color: "var(--ls-text-muted)", marginTop: 2 }}>{s.body}</div>
+    <>
+      {acts.length > 0 && (
+        <div className="ph-story-struct">
+          {acts.map((s, i) => (
+            <div key={s.id} className={`seg${i === 1 ? " gold" : ""}`}>
+              <div className="step">Acte {["I","II","III"][i]}</div>
+              <h6>{s.title}</h6>
+              <p>{s.body.length > 60 ? s.body.slice(0, 60) + "…" : s.body}</p>
             </div>
           ))}
-        </section>
-      ) : null}
-      {examples.length > 0 ? (
-        <section>
-          <h4 style={H4}>Exemples</h4>
-          {examples.map((e) => (
-            <article key={e.id} style={INFO_CARD}>
-              <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 6 }}>{e.title}</div>
-              <pre style={SCRIPT_BODY}>{e.body}</pre>
-            </article>
-          ))}
-        </section>
-      ) : null}
-      {rules.length > 0 ? (
-        <section>
-          <h4 style={H4}>Règles pour ton storytelling</h4>
+        </div>
+      )}
+      {examples.map((ex) => (
+        <article key={ex.id} className="ph-story-example">
+          <div className="by">{ex.title}</div>
+          <p>{ex.body}</p>
+        </article>
+      ))}
+      {rules.length > 0 && (
+        <div className="ph-truth-lite" style={{ marginTop: 14 }}>
+          <div className="ctx">Règles d'or</div>
           {rules.map((r) => (
-            <div key={r.id} style={INFO_CARD_TIGHT}>
-              <div style={{ fontWeight: 600, fontSize: 13 }}>• {r.title}</div>
-              <div style={{ fontSize: 12, color: "var(--ls-text-muted)", marginTop: 2 }}>{r.body}</div>
-            </div>
+            <p key={r.id} style={{ fontSize: 15, marginBottom: 6, lineHeight: 1.35 }}>
+              <em>{r.title}</em> — <span style={{ fontWeight: 400, fontSize: 13, color: "var(--hub-muted)" }}>{r.body}</span>
+            </p>
           ))}
-        </section>
-      ) : null}
-    </div>
+        </div>
+      )}
+    </>
   );
 }
 
-function RoutineModule({ items }: { items: ProspectionRoutineItem[] }) {
-  if (items.length === 0) return <Empty>Aucune routine pour ce marché.</Empty>;
+function RoutineModule({
+  items, checks, setChecks, marketTip,
+}: {
+  items: ProspectionRoutineItem[];
+  checks: Record<string, boolean>;
+  setChecks: (m: Record<string, boolean>) => void;
+  marketTip: ProspectionMarketTip | null;
+}) {
+  const checklist = items.filter((i) => i.kind === "pre_send_checklist");
   const r30 = items.filter((i) => i.kind === "routine_30m");
-  const r1h = items.filter((i) => i.kind === "routine_1h");
-  const check = items.filter((i) => i.kind === "pre_send_checklist");
+  const totalMins = r30.reduce((sum, r) => sum + (r.duration_minutes ?? 0), 0) || 30;
+  if (items.length === 0) return <Empty>Aucune routine pour ce marché.</Empty>;
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      {r30.length > 0 ? (
-        <section>
-          <h4 style={H4}>Routine 30 minutes / jour (débutant)</h4>
-          {r30.map((r) => (
-            <div key={r.id} style={INFO_CARD_TIGHT}>
-              <div style={{ display: "flex", justifyContent: "space-between" }}>
-                <span style={{ fontWeight: 600, fontSize: 13 }}>{r.title}</span>
-                {r.duration_minutes ? <span style={{ fontSize: 12, color: "var(--ls-text-muted)" }}>{r.duration_minutes} min</span> : null}
+    <>
+      <div className="ph-routine-summary">
+        <div>
+          <div className="big">{totalMins}<small>min/jour</small></div>
+        </div>
+        <p>
+          {r30.length} actions matinales pour {checklist.length} points de vigilance avant chaque envoi.
+          {marketTip && (<><br /><span style={{ fontFamily: "var(--hub-f-mono)", fontSize: 11, opacity: 0.8 }}>{marketTip.timing}</span></>)}
+        </p>
+      </div>
+      <div className="ph-checklist">
+        {r30.map((r) => {
+          const id = `r30-${r.id}`;
+          const done = !!checks[id];
+          return (
+            <div
+              key={id}
+              className={`ph-check-item${done ? " done" : ""}`}
+              onClick={() => setChecks({ ...checks, [id]: !done })}
+            >
+              <div className="box" />
+              <div className="txt">
+                <strong style={{ fontWeight: 600 }}>{r.title}</strong>
+                {r.detail && <div style={{ fontSize: 12, color: "var(--hub-muted)", marginTop: 2 }}>{r.detail}</div>}
               </div>
-              {r.detail ? <div style={{ fontSize: 12, color: "var(--ls-text-muted)", marginTop: 2 }}>{r.detail}</div> : null}
+              {r.duration_minutes && <div className="mins">{r.duration_minutes} min</div>}
             </div>
-          ))}
-        </section>
-      ) : null}
-      {r1h.length > 0 ? (
-        <section>
-          <h4 style={H4}>Routine 1 heure / jour (intermédiaire)</h4>
-          {r1h.map((r) => (
-            <div key={r.id} style={INFO_CARD_TIGHT}>
-              <div style={{ display: "flex", justifyContent: "space-between" }}>
-                <span style={{ fontWeight: 600, fontSize: 13 }}>{r.title}</span>
-                {r.duration_minutes ? <span style={{ fontSize: 12, color: "var(--ls-text-muted)" }}>{r.duration_minutes} min</span> : null}
-              </div>
-              {r.detail ? <div style={{ fontSize: 12, color: "var(--ls-text-muted)", marginTop: 2 }}>{r.detail}</div> : null}
-            </div>
-          ))}
-        </section>
-      ) : null}
-      {check.length > 0 ? (
-        <section>
-          <h4 style={H4}>Checklist avant d'envoyer un M1</h4>
-          {check.map((c) => (
-            <label key={c.id} style={{ display: "flex", alignItems: "flex-start", gap: 8, padding: "6px 0", cursor: "pointer" }}>
-              <input type="checkbox" style={{ marginTop: 3 }} />
-              <span style={{ fontSize: 13 }}>{c.title}</span>
-            </label>
-          ))}
-        </section>
-      ) : null}
+          );
+        })}
+      </div>
+      {checklist.length > 0 && (
+        <>
+          <div className="ph-errors-head" style={{ marginTop: 18 }}>
+            <span className="label" style={{ color: "var(--hub-accent-dark)" }}>
+              <span style={{ background: "var(--hub-accent)" }} />Avant chaque envoi
+            </span>
+            <span style={{ fontFamily: "var(--hub-f-mono)", fontSize: 10, color: "var(--hub-muted)" }}>{checklist.length} points</span>
+          </div>
+          <div className="ph-checklist">
+            {checklist.map((c) => {
+              const id = `chk-${c.id}`;
+              const done = !!checks[id];
+              return (
+                <div
+                  key={id}
+                  className={`ph-check-item${done ? " done" : ""}`}
+                  onClick={() => setChecks({ ...checks, [id]: !done })}
+                >
+                  <div className="box" />
+                  <div className="txt">{c.title}</div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+// ────────────────────────────────────────────────────────────
+// Stat funnel sheet
+// ────────────────────────────────────────────────────────────
+function StatFunnelSheet({ sent, rdv }: { sent: number; rdv: number }) {
+  const reps = Math.round(sent * 0.42);
+  const clos = Math.max(0, Math.round(rdv * 0.4));
+  const pct = (v: number) => Math.min(100, Math.round((v / Math.max(1, sent)) * 100));
+  return (
+    <>
+      <div className="sheet-head">
+        <div className="kicker">7 derniers jours</div>
+        <h3>Activité.</h3>
+      </div>
+      <div className="sheet-body">
+        <div className="big">
+          <div className="stat"><div className="v">{sent}</div><div className="k">M1 envoyés</div></div>
+          <div className="stat"><div className="v">{reps}</div><div className="k">Réponses</div></div>
+          <div className="stat"><div className="v">{rdv}</div><div className="k">RDV pris</div></div>
+          <div className="stat"><div className="v">{clos}</div><div className="k">Closing</div></div>
+        </div>
+        <div className="funnel">
+          <FnRow lab="Envoyés" v={sent} pct={pct(sent)} />
+          <FnRow lab="Réponses" v={reps} pct={pct(reps)} />
+          <FnRow lab="RDV" v={rdv} pct={pct(rdv)} />
+          <FnRow lab="Closing" v={clos} pct={pct(clos)} />
+        </div>
+        <p style={{ fontFamily: "var(--hub-f-mono)", fontSize: 10.5, color: "var(--hub-muted)", lineHeight: 1.6, marginTop: 14 }}>
+          Chaque <b style={{ color: "var(--hub-text)" }}>« J'ai envoyé »</b> incrémente le compteur.
+          Les RDV s'incrémentent quand un script <b style={{ color: "var(--hub-text)" }}>WhatsApp</b> est envoyé (proxy démo).
+        </p>
+      </div>
+    </>
+  );
+}
+
+function FnRow({ lab, v, pct }: { lab: string; v: number; pct: number }) {
+  return (
+    <div className="fn-row">
+      <span className="lab">{lab}</span>
+      <div className="fn-bar"><div className="fn-fill" style={{ width: `${pct}%` }} /></div>
+      <span className="v">{v}</span>
     </div>
   );
 }
 
-// ============================================================================
+// ────────────────────────────────────────────────────────────
 // Helpers
-// ============================================================================
-
-function formatRange(min: number | null, max: number | null, unit: string | null): string {
-  if (min == null && max == null) return "—";
-  const u = unit ? ` ${unit}` : "";
-  if (min != null && max != null && min !== max) return `${min} à ${max}${u}`;
-  if (min != null) return `${min}${u}`;
-  if (max != null) return `${max}${u}`;
-  return "—";
+// ────────────────────────────────────────────────────────────
+function Caret() {
+  return (
+    <svg className="caret" viewBox="0 0 12 12" fill="none">
+      <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function ArrowLeft() {
+  return <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M7.5 3 4 6l3.5 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
+}
+function ArrowRight() {
+  return <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M4.5 3 8 6l-3.5 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>;
 }
 
 function Empty({ children }: { children: ReactNode }) {
   return (
-    <div style={{ padding: 24, textAlign: "center", color: "var(--ls-text-muted)", fontSize: 13 }}>
+    <div style={{ padding: 24, textAlign: "center", color: "var(--hub-muted)", fontSize: 13, fontFamily: "var(--hub-f-mono)" }}>
       {children}
     </div>
   );
 }
 
-// ============================================================================
-// Styles
-// ============================================================================
-
-const STICKY_BAR: CSSProperties = {
-  position: "sticky",
-  top: 0,
-  zIndex: 10,
-  background: "var(--ls-surface)",
-  paddingBottom: 8,
-  borderBottom: "1px solid var(--ls-border)",
-  display: "flex",
-  flexDirection: "column",
-  gap: 8,
-};
-
-const PILL: CSSProperties = {
-  padding: "6px 12px",
-  borderRadius: 999,
-  border: "1px solid var(--ls-border)",
-  background: "var(--ls-surface2)",
-  color: "var(--ls-text)",
-  fontSize: 13,
-  cursor: "pointer",
-  whiteSpace: "nowrap",
-};
-
-const PILL_ACTIVE: CSSProperties = {
-  background: "color-mix(in srgb, var(--ls-gold) 18%, var(--ls-surface2))",
-  borderColor: "var(--ls-gold)",
-  color: "var(--ls-text)",
-};
-
-const MARKET_TIP_BANNER: CSSProperties = {
-  padding: "8px 12px",
-  borderRadius: 10,
-  background: "color-mix(in srgb, var(--ls-teal) 10%, var(--ls-surface2))",
-  border: "1px solid color-mix(in srgb, var(--ls-teal) 30%, transparent)",
-  display: "flex",
-  flexDirection: "column",
-  gap: 2,
-};
-
-const MODULES_GRID: CSSProperties = {
-  display: "flex",
-  flexDirection: "column",
-  gap: 8,
-};
-
-const MODULE_CARD: CSSProperties = {
-  background: "var(--ls-surface2)",
-  borderRadius: 14,
-  border: "1px solid var(--ls-border)",
-  overflow: "hidden",
-};
-
-const MODULE_CARD_OPEN: CSSProperties = {
-  borderColor: "color-mix(in srgb, var(--ls-gold) 50%, var(--ls-border))",
-  boxShadow: "0 4px 20px color-mix(in srgb, var(--ls-gold) 12%, transparent)",
-};
-
-const MODULE_HEADER_BTN: CSSProperties = {
-  width: "100%",
-  padding: "14px 16px",
-  display: "flex",
-  alignItems: "center",
-  background: "transparent",
-  border: "none",
-  color: "var(--ls-text)",
-  cursor: "pointer",
-  textAlign: "left",
-};
-
-const MODULE_CHIP: CSSProperties = {
-  padding: "2px 8px",
-  borderRadius: 8,
-  background: "color-mix(in srgb, var(--ls-gold) 12%, transparent)",
-  color: "var(--ls-gold)",
-  fontSize: 11,
-  fontWeight: 600,
-  marginLeft: 8,
-};
-
-const MODULE_BODY: CSSProperties = {
-  padding: "0 16px 16px",
-  animation: "lsHubFadeIn 200ms ease",
-};
-
-const H4: CSSProperties = {
-  fontFamily: "Syne, serif",
-  fontSize: 14,
-  fontWeight: 600,
-  margin: "0 0 8px",
-  color: "var(--ls-text)",
-};
-
-const INFO_CARD: CSSProperties = {
-  padding: 12,
-  borderRadius: 10,
-  background: "var(--ls-surface)",
-  border: "1px solid var(--ls-border)",
-  marginBottom: 8,
-};
-
-const INFO_CARD_TIGHT: CSSProperties = {
-  padding: "8px 10px",
-  borderRadius: 8,
-  background: "var(--ls-surface)",
-  border: "1px solid var(--ls-border)",
-  marginBottom: 6,
-};
-
-const ERROR_CARD: CSSProperties = {
-  padding: 10,
-  borderRadius: 10,
-  background: "color-mix(in srgb, var(--ls-coral, #e57373) 8%, var(--ls-surface))",
-  border: "1px solid color-mix(in srgb, var(--ls-coral, #e57373) 30%, var(--ls-border))",
-};
-
-const GREEN_CARD: CSSProperties = {
-  padding: 12,
-  borderRadius: 10,
-  background: "color-mix(in srgb, #4ade80 8%, var(--ls-surface))",
-  border: "1px solid color-mix(in srgb, #4ade80 30%, var(--ls-border))",
-};
-
-const RED_CARD: CSSProperties = {
-  padding: 12,
-  borderRadius: 10,
-  background: "color-mix(in srgb, #ef4444 8%, var(--ls-surface))",
-  border: "1px solid color-mix(in srgb, #ef4444 30%, var(--ls-border))",
-};
-
-const SCRIPT_CARD: CSSProperties = {
-  padding: 12,
-  borderRadius: 12,
-  background: "var(--ls-surface)",
-  border: "1px solid var(--ls-border)",
-};
-
-const SCRIPT_BODY: CSSProperties = {
-  fontFamily: "'DM Sans', system-ui, sans-serif",
-  fontSize: 13,
-  lineHeight: 1.5,
-  margin: 0,
-  padding: 10,
-  background: "color-mix(in srgb, var(--ls-gold) 4%, var(--ls-surface2))",
-  borderRadius: 8,
-  whiteSpace: "pre-wrap",
-  color: "var(--ls-text)",
-};
-
-const TIP_BOX: CSSProperties = {
-  marginTop: 8,
-  padding: "6px 10px",
-  borderRadius: 8,
-  background: "color-mix(in srgb, var(--ls-teal) 8%, transparent)",
-  fontSize: 12,
-  color: "var(--ls-text-muted)",
-};
-
-const WARNING_BOX: CSSProperties = {
-  marginTop: 8,
-  padding: "8px 10px",
-  borderRadius: 8,
-  background: "color-mix(in srgb, var(--ls-gold) 12%, transparent)",
-  border: "1px solid color-mix(in srgb, var(--ls-gold) 40%, transparent)",
-  fontSize: 12,
-};
-
-const COPY_BTN: CSSProperties = {
-  marginTop: 10,
-  padding: "8px 14px",
-  borderRadius: 999,
-  border: "1px solid var(--ls-border)",
-  background: "var(--ls-surface2)",
-  color: "var(--ls-text)",
-  fontSize: 13,
-  cursor: "pointer",
-  width: "100%",
-};
-
-const TAG: CSSProperties = {
-  display: "inline-block",
-  padding: "3px 10px",
-  borderRadius: 999,
-  border: "1px solid",
-  fontSize: 12,
-  background: "var(--ls-surface)",
-};
-
-const RESTART_BTN: CSSProperties = {
-  alignSelf: "center",
-  padding: "10px 18px",
-  borderRadius: 999,
-  border: "1px dashed var(--ls-border)",
-  background: "transparent",
-  color: "var(--ls-text-muted)",
-  fontSize: 13,
-  cursor: "pointer",
-  marginTop: 16,
-};
-
-const HUB_KEYFRAMES = `
-@keyframes lsHubFadeIn {
-  from { opacity: 0; transform: translateY(-4px); }
-  to   { opacity: 1; transform: translateY(0); }
+/** Render le body d'une vérité Mindset avec emphase sur les mots-clés italique gold. */
+function renderTruthBody(body: string): ReactNode {
+  // Stratégie simple : la 1ère phrase est traitée comme la pull-quote
+  const firstSentence = body.split(/(?<=[.!?])\s+/)[0];
+  return firstSentence;
 }
-`;
+
+/**
+ * Render le body d'un script en mettant en valeur les variables [prénom]
+ * (gold) et [contexte] (teal). On considère que [foo], [nom], [name],
+ * [first name], [isim], [nombre], [nome] = "primary" (gold). Les autres
+ * variables = teal.
+ */
+function renderScriptBody(body: string): ReactNode {
+  const VAR_RE = /\[([^\]]+)\]/g;
+  const PRIMARY = /^(pr[ée]nom|nom|name|first[ _]name|isim|nombre|nome|prénom)$/i;
+  const parts: ReactNode[] = [];
+  let lastIdx = 0;
+  let m: RegExpExecArray | null;
+  let key = 0;
+  while ((m = VAR_RE.exec(body)) !== null) {
+    if (m.index > lastIdx) parts.push(body.slice(lastIdx, m.index));
+    const label = m[1];
+    const isPrimary = PRIMARY.test(label.trim());
+    parts.push(
+      <span key={`v${key++}`} className={`ph-var${isPrimary ? "" : " teal"}`}>[{label}]</span>,
+    );
+    lastIdx = m.index + m[0].length;
+  }
+  if (lastIdx < body.length) parts.push(body.slice(lastIdx));
+  return parts;
+}
+
+/** Concatène le texte d'un module pour calculer le reading time. */
+function collectModuleText(args: {
+  mid: ModuleId;
+  mindsetBlocks: ProspectionMindsetBlock[];
+  scripts: ProspectionScript[];
+  replyTree: ProspectionReplyNode[];
+  objections: ProspectionObjection[];
+  followups: ProspectionFollowup[];
+  closing: ProspectionClosingBlock[];
+  specialCases: ProspectionSpecialCase[];
+  storytelling: ProspectionStoryBlock[];
+  routines: ProspectionRoutineItem[];
+  hashtags: ProspectionHashtag[];
+  flags: ProspectionProfileFlag[];
+  sources: ProspectionSource[];
+}): string {
+  switch (args.mid) {
+    case "mindset":   return args.mindsetBlocks.map((b) => b.body).join(" ");
+    case "find":      return args.flags.map((f) => f.text).concat(args.hashtags.map((h) => h.hashtag), args.sources.map((s) => s.detail ?? s.label)).join(" ");
+    case "first_msg": return args.scripts.filter((s) => s.kind === "first_contact").map((s) => s.body).join(" ");
+    case "reply":     return args.replyTree.map((n) => n.body).join(" ");
+    case "objections":return args.objections.map((o) => o.good_response + " " + o.meaning).join(" ");
+    case "post_call": return args.followups.map((f) => f.body).join(" ");
+    case "closing":   return args.closing.map((c) => c.body).join(" ");
+    case "special":   return args.specialCases.map((s) => s.body).join(" ");
+    case "story":     return args.storytelling.map((s) => s.body).join(" ");
+    case "routine":   return args.routines.map((r) => (r.title + " " + (r.detail ?? ""))).join(" ");
+  }
+}

--- a/src/components/prospection/prospection-hub.css
+++ b/src/components/prospection/prospection-hub.css
@@ -1573,19 +1573,25 @@
 
 /* ============================================================
    DESKTOP (≥ 880px) — index étalé, plus de respiration
-   ============================================================ */
+   ============================================================
+   Spec design v3 polish : sur desktop, l'index étale juste l'actif
+   avec son nom + autres en numéro+emoji seulement (comme mobile).
+   Ne PAS forcer .name { display:inline } pour tous, sinon overflow
+   visuel et calibrage cassé (cf. retour Thomas captures dark/light).
+*/
 @media (min-width: 880px) {
-  .prospection-hub { max-width: 760px; margin: 0 auto; }
-  .ph-hdr { padding: 10px 22px 14px; }
+  .prospection-hub { max-width: 920px; margin: 0 auto; }
+  .ph-hdr { padding: 10px 24px 14px; }
   .ph-section-head { padding: 0 28px 14px; }
   .ph-section-head h2 { font-size: 34px; }
   .ph-section-head p.lede { font-size: 14.5px; max-width: 54ch; }
   .ph-section-meta { padding: 14px 28px 6px; }
   .ph-body-inner { padding: 0 28px; }
   .ph-pickers { gap: 12px; }
-  .ph-index { margin-top: 12px; overflow: visible; }
-  .ph-index .step { padding: 8px 10px; font-size: 11.5px; }
-  .ph-index .step .name { display: inline; } /* All 10 modules visible */
+  .ph-index { margin-top: 12px; overflow-x: auto; }
+  .ph-index .step { padding: 8px 11px; font-size: 11.5px; }
+  /* L'actif a déjà display:inline via la règle .step.active .name;
+     les non-actifs restent en icône+numéro pour rester lisibles. */
   .ph-botnav { padding: 12px 22px 18px; }
 }
 

--- a/src/components/prospection/prospection-hub.css
+++ b/src/components/prospection/prospection-hub.css
@@ -1,0 +1,1602 @@
+/* ============================================================
+   Prospection Hub V4 — Design polish (2026-05-19)
+   ============================================================
+   Port pixel-near du design v3 polish (claude design).
+   Source : docs/mockups/prospection-v4-prototype-v3.html
+   Scope: tout est sous .prospection-hub. Tokens --hub-* dérivés
+   de --ls-* pour respecter le theme app coach (light/dark via
+   html.theme-light).
+   ============================================================ */
+
+.prospection-hub {
+  /* Tokens layout (dérivés de --ls-*) */
+  --hub-bg: var(--ls-bg);
+  --hub-surface: var(--ls-surface);
+  --hub-surface2: var(--ls-surface2);
+  --hub-text: var(--ls-text);
+  --hub-line: var(--ls-border);
+  --hub-line-2: color-mix(in srgb, var(--ls-text) 14%, transparent);
+  --hub-muted: var(--ls-text-muted, color-mix(in srgb, var(--ls-text) 56%, transparent));
+  --hub-muted-2: color-mix(in srgb, var(--ls-text) 40%, transparent);
+  /* Accent : gold en light, teal en dark (Thomas validé) */
+  --hub-accent: var(--ls-gold);
+  --hub-accent-light: var(--ls-gold-light, #E5C97D);
+  --hub-accent-dark: color-mix(in srgb, var(--ls-gold) 70%, var(--ls-text));
+  --hub-coral: #FB7185;
+  --hub-coral-dark: #BE3242;
+  --hub-teal: var(--ls-teal);
+  --hub-teal-dark: #0F766E;
+
+  /* Fonts */
+  --hub-f-display: 'Syne', 'Times New Roman', serif;
+  --hub-f-body: 'DM Sans', system-ui, sans-serif;
+  --hub-f-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+
+  font-family: var(--hub-f-body);
+  color: var(--hub-text);
+  background: var(--hub-bg);
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100dvh - 56px);
+  position: relative;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* En dark (theme app default = pas de .theme-light), accent bascule teal */
+:root:not(.theme-light) .prospection-hub,
+.dark .prospection-hub {
+  --hub-accent: var(--ls-teal);
+  --hub-accent-light: color-mix(in srgb, var(--ls-teal) 70%, white);
+  --hub-accent-dark: color-mix(in srgb, var(--ls-teal) 60%, var(--ls-text));
+  --hub-line: color-mix(in srgb, white 8%, transparent);
+  --hub-line-2: color-mix(in srgb, white 16%, transparent);
+}
+
+/* ============================================================
+   HEADER (sticky 3 rows)
+   ============================================================ */
+.ph-hdr {
+  flex: 0 0 auto;
+  background: var(--hub-bg);
+  padding: 10px 18px 12px;
+  border-bottom: 1px solid var(--hub-line);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+.ph-row1 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 4px 2px 8px;
+}
+.ph-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.ph-gem {
+  width: 18px; height: 18px; border-radius: 5px;
+  background: linear-gradient(135deg, var(--ls-gold) 0%, var(--ls-gold-light, #E5C97D) 60%, #fff7d6 100%);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ls-gold) 50%, transparent) inset;
+  position: relative;
+}
+.ph-gem::after {
+  content: ""; position: absolute; inset: 3px; border-radius: 3px;
+  background: radial-gradient(circle at 30% 30%, rgba(255,255,255,.7), transparent 60%);
+}
+.ph-brand small {
+  font-family: var(--hub-f-mono);
+  font-weight: 400;
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  margin-left: 4px;
+}
+
+.ph-stat-chip {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 10px 5px 8px;
+  border-radius: 99px;
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  font-family: var(--hub-f-mono);
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--hub-text);
+  transition: background .15s, border-color .15s;
+}
+.ph-stat-chip:hover { border-color: var(--hub-line-2); }
+.ph-stat-chip .dot-live {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--hub-teal);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hub-teal) 18%, transparent);
+}
+.ph-stat-chip b { font-weight: 600; color: var(--hub-text); transition: color .2s; }
+.ph-stat-chip b.bumped { color: var(--hub-accent-dark); }
+.ph-stat-chip .muted { color: var(--hub-muted); margin-left: 2px; }
+
+/* Pickers row */
+.ph-pickers {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+.ph-picker {
+  flex: 1; min-width: 0;
+  display: flex; align-items: center; gap: 8px;
+  padding: 9px 10px 9px 12px;
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 12px;
+  font-size: 13px; font-weight: 500;
+  cursor: pointer;
+  color: var(--hub-text);
+  font-family: inherit;
+  text-align: left;
+  transition: background .15s, border-color .15s, box-shadow .15s;
+}
+.ph-picker:hover { border-color: var(--hub-line-2); }
+.ph-picker:active { transform: scale(.985); }
+.ph-picker.opening {
+  border-color: var(--hub-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hub-accent) 15%, transparent);
+}
+.ph-picker .lbl {
+  font-family: var(--hub-f-mono);
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  display: block;
+}
+.ph-picker .val {
+  font-weight: 600;
+  font-size: 13.5px;
+  color: var(--hub-text);
+  display: flex; align-items: center; gap: 6px;
+  line-height: 1.15; margin-top: 1px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.ph-picker .flag {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 16px; border-radius: 3px;
+  font-size: 14px; line-height: 1;
+  background: var(--hub-surface2);
+  font-family: 'Twemoji Country Flags', 'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif;
+  flex: 0 0 auto;
+}
+.ph-picker .glyph {
+  width: 22px; height: 22px; border-radius: 6px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: linear-gradient(135deg, var(--hub-surface), var(--hub-surface2));
+  border: 1px solid var(--hub-line);
+  font-size: 13px;
+  flex: 0 0 auto;
+}
+.ph-picker .caret { margin-left: auto; width: 14px; height: 14px; opacity: 0.5; flex: 0 0 auto; }
+.ph-picker .info-stack { display: flex; flex-direction: column; min-width: 0; flex: 1; justify-content: center; }
+
+/* Index rail */
+.ph-index {
+  margin-top: 10px;
+  display: flex; align-items: stretch; gap: 0;
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 12px;
+  padding: 5px;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+}
+.ph-index::-webkit-scrollbar { display: none; }
+.ph-index .step {
+  flex: 0 0 auto;
+  display: flex; align-items: center; gap: 6px;
+  padding: 7px 8px;
+  border-radius: 8px;
+  font-family: var(--hub-f-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--hub-muted);
+  white-space: nowrap;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  transition: background .15s, color .15s;
+}
+.ph-index .step:hover { color: var(--hub-text); }
+.ph-index .step .n {
+  font-weight: 500;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--hub-muted-2);
+}
+.ph-index .step .ic { font-family: var(--hub-f-body); font-size: 13px; line-height: 1; }
+.ph-index .step .name {
+  display: none;
+  font-family: var(--hub-f-body);
+  font-weight: 600;
+  font-size: 12.5px;
+  color: var(--hub-text);
+  letter-spacing: -0.005em;
+}
+.ph-index .step.active {
+  background: var(--hub-text);
+  color: var(--hub-bg);
+}
+.ph-index .step.active .n { color: var(--hub-accent-light); }
+.ph-index .step.active .name { display: inline; color: var(--hub-bg); }
+.ph-index .step.done { color: var(--hub-text); }
+.ph-index .step.done .n { color: var(--hub-accent-dark); }
+
+/* ============================================================
+   SECTION META + HEADING
+   ============================================================ */
+.ph-section-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 14px 22px 6px;
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+}
+.ph-section-meta b { color: var(--hub-text); font-weight: 600; }
+
+.ph-section-head { padding: 0 22px 14px; }
+.ph-section-head .kicker {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--hub-accent-dark);
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 6px;
+}
+.ph-section-head .kicker::before {
+  content: "";
+  width: 18px;
+  height: 1px;
+  background: var(--hub-accent);
+}
+.ph-section-head h2 {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 1;
+  letter-spacing: -0.025em;
+  margin: 0 0 8px;
+}
+.ph-section-head h2 .em {
+  font-style: italic;
+  font-weight: 500;
+  color: var(--hub-accent-dark);
+}
+.ph-section-head p.lede {
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--hub-muted);
+  margin: 0;
+  max-width: 38ch;
+}
+
+/* ============================================================
+   BODY
+   ============================================================ */
+.ph-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0 0 14px;
+}
+.ph-body-inner {
+  padding: 0 22px;
+  transition: opacity .18s ease, transform .22s ease;
+}
+.ph-body-inner.swapping { opacity: 0; transform: translateY(4px); }
+
+/* ============================================================
+   BOTTOM NAV
+   ============================================================ */
+.ph-botnav {
+  flex: 0 0 auto;
+  background: color-mix(in srgb, var(--hub-bg) 94%, transparent);
+  backdrop-filter: saturate(140%) blur(12px);
+  -webkit-backdrop-filter: saturate(140%) blur(12px);
+  border-top: 1px solid var(--hub-line);
+  padding: 10px 14px 22px;
+  display: flex; align-items: center; justify-content: space-between; gap: 6px;
+  position: sticky;
+  bottom: 0;
+}
+.ph-btn-nav {
+  display: flex; align-items: center; gap: 8px;
+  flex: 1; min-width: 0;
+  padding: 8px 10px;
+  border-radius: 10px;
+  font-family: var(--hub-f-body);
+  font-size: 12px; font-weight: 500;
+  color: var(--hub-text);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+.ph-btn-nav:disabled { opacity: 0.4; cursor: not-allowed; }
+.ph-btn-nav .arr {
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  display: flex; align-items: center; justify-content: center;
+  flex: 0 0 auto;
+  color: var(--hub-text);
+}
+.ph-btn-nav .lab { display: flex; flex-direction: column; line-height: 1.2; min-width: 0; flex: 1; }
+.ph-btn-nav .lab small {
+  font-family: var(--hub-f-mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+}
+.ph-btn-nav .lab span {
+  font-weight: 600;
+  font-size: 12.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ph-btn-nav.next { flex-direction: row-reverse; text-align: right; }
+.ph-btn-nav.next .lab { align-items: flex-end; }
+
+.ph-dots {
+  display: flex; align-items: center; gap: 5px;
+  padding: 0 2px;
+  flex: 0 0 auto;
+}
+.ph-dots .d {
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--hub-text) 15%, transparent);
+  transition: background .2s, width .25s;
+}
+.ph-dots .d.on {
+  background: var(--hub-accent);
+  width: 18px;
+  border-radius: 3px;
+}
+.ph-dots .d.done { background: var(--hub-accent-dark); }
+
+/* ============================================================
+   MODULE — MINDSET
+   ============================================================ */
+.ph-truth {
+  background: var(--ls-charcoal, #0B0D11);
+  color: #fff;
+  border-radius: 18px;
+  padding: 18px 18px 16px;
+  margin-bottom: 12px;
+  position: relative;
+  overflow: hidden;
+}
+.ph-truth::before {
+  content: "";
+  position: absolute; right: -30px; top: -30px;
+  width: 120px; height: 120px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--hub-accent) 40%, transparent), transparent 70%);
+  pointer-events: none;
+}
+.ph-truth .num {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 54px;
+  line-height: 0.9;
+  color: var(--hub-accent);
+  letter-spacing: -0.04em;
+}
+.ph-truth .kicker {
+  font-family: var(--hub-f-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--hub-accent-light);
+  margin-bottom: 6px;
+}
+.ph-truth .quote {
+  font-family: var(--hub-f-display);
+  font-weight: 600;
+  font-size: 21px;
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+  margin: 6px 0 0;
+}
+.ph-truth .quote em {
+  color: var(--hub-accent-light);
+  font-style: italic;
+  font-weight: 500;
+}
+.ph-truth-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.ph-truth-lite {
+  background: linear-gradient(180deg, var(--hub-surface), var(--hub-surface2));
+  border: 1px solid var(--hub-line);
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin-bottom: 10px;
+}
+.ph-truth-lite .ctx {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  margin-bottom: 4px;
+}
+.ph-truth-lite p {
+  font-family: var(--hub-f-display);
+  font-weight: 600;
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+  margin: 0;
+}
+.ph-truth-lite em {
+  color: var(--hub-accent-dark);
+  font-style: italic;
+  font-weight: 500;
+}
+
+.ph-errors-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin: 18px 0 8px;
+}
+.ph-errors-head .label {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--hub-coral-dark);
+  display: flex; align-items: center; gap: 6px;
+}
+.ph-errors-head .label::before {
+  content: ""; width: 6px; height: 6px;
+  border-radius: 50%; background: var(--hub-coral);
+}
+.ph-err {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 11px 4px;
+  border-top: 1px solid var(--hub-line);
+}
+.ph-err .n {
+  font-family: var(--hub-f-mono);
+  font-size: 11px;
+  color: var(--hub-coral-dark);
+  font-weight: 500;
+  width: 22px;
+  flex: 0 0 auto;
+  letter-spacing: 0.05em;
+}
+.ph-err .txt { font-size: 13.5px; line-height: 1.4; color: var(--hub-text); }
+
+/* ============================================================
+   MODULE — MESSAGES (Premier message)
+   ============================================================ */
+.ph-platform-tabs {
+  display: flex; gap: 6px; padding: 4px; margin-bottom: 14px;
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 11px;
+}
+.ph-platform-tabs .tab {
+  flex: 1;
+  display: flex; flex-direction: column; align-items: center; gap: 2px;
+  padding: 7px 4px;
+  border-radius: 8px;
+  font-family: var(--hub-f-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  transition: background .15s, color .15s;
+}
+.ph-platform-tabs .tab .ic { font-family: var(--hub-f-body); font-size: 15px; line-height: 1; }
+.ph-platform-tabs .tab.on { background: var(--hub-text); color: var(--hub-bg); }
+
+.ph-script {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin-bottom: 10px;
+  transition: border-color .2s;
+}
+.ph-script.sent {
+  border-color: color-mix(in srgb, var(--hub-teal) 50%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hub-teal) 8%, transparent);
+}
+.ph-script .head {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 10px;
+}
+.ph-script .head .glyph {
+  width: 26px; height: 26px;
+  border-radius: 8px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 14px;
+  background: var(--hub-surface2);
+  border: 1px solid var(--hub-line);
+}
+.ph-script .head h4 {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 16px;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+.ph-script .ctx {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  margin-bottom: 6px;
+  display: flex; align-items: center; gap: 6px;
+}
+.ph-script .ctx::before {
+  content: "";
+  width: 14px; height: 1px;
+  background: var(--hub-line-2);
+}
+
+.ph-lang-switch {
+  display: inline-flex; align-items: center;
+  background: var(--hub-surface2);
+  border: 1px solid var(--hub-line);
+  border-radius: 99px;
+  padding: 2px;
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  margin-left: auto;
+}
+.ph-lang-switch button {
+  border: none;
+  background: transparent;
+  padding: 4px 9px;
+  border-radius: 99px;
+  color: var(--hub-muted);
+  cursor: pointer;
+  font: inherit;
+  transition: background .15s, color .15s;
+}
+.ph-lang-switch button.on {
+  background: var(--hub-text);
+  color: var(--hub-bg);
+}
+
+.ph-msg-body {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--hub-text);
+  padding: 12px 0 4px;
+  border-top: 1px dashed var(--hub-line-2);
+  white-space: pre-wrap;
+}
+.ph-var {
+  display: inline-block;
+  font-weight: 600;
+  font-size: 13.5px;
+  color: var(--hub-accent-dark);
+  background: color-mix(in srgb, var(--hub-accent) 12%, transparent);
+  padding: 1px 7px;
+  border-radius: 4px;
+  border: 1px dashed color-mix(in srgb, var(--hub-accent) 50%, transparent);
+  margin: 0 1px;
+  line-height: 1.2;
+}
+.ph-var.teal {
+  color: var(--hub-teal-dark);
+  background: color-mix(in srgb, var(--hub-teal) 13%, transparent);
+  border-color: color-mix(in srgb, var(--hub-teal-dark) 40%, transparent);
+}
+
+.ph-trad-line {
+  font-style: italic;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--hub-muted);
+  padding: 8px 0 0;
+  border-top: 1px dashed var(--hub-line);
+  margin-top: 8px;
+  white-space: pre-wrap;
+}
+.ph-trad-line::before {
+  content: "FR";
+  font-family: var(--hub-f-mono);
+  font-style: normal;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  background: var(--hub-surface2);
+  padding: 2px 5px;
+  border-radius: 3px;
+  color: var(--hub-muted);
+  margin-right: 7px;
+  vertical-align: 1px;
+}
+
+.ph-script-actions {
+  display: flex; align-items: center; gap: 6px;
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--hub-line);
+}
+.ph-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 7px 11px;
+  border-radius: 8px;
+  font-family: var(--hub-f-body);
+  font-weight: 600;
+  font-size: 12px;
+  border: 1px solid var(--hub-line);
+  background: var(--hub-surface);
+  color: var(--hub-text);
+  cursor: pointer;
+  line-height: 1;
+  transition: background .15s, border-color .15s, transform .1s;
+}
+.ph-btn:hover { border-color: var(--hub-line-2); }
+.ph-btn:active { transform: scale(.97); }
+.ph-btn.copy {
+  background: var(--hub-text);
+  color: var(--hub-bg);
+  border-color: transparent;
+}
+.ph-btn.send {
+  background: var(--hub-surface);
+  border-color: var(--hub-accent);
+  color: var(--hub-accent-dark);
+}
+.ph-btn.send.done {
+  background: var(--hub-teal-dark);
+  color: #fff;
+  border-color: transparent;
+}
+.ph-btn.ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--hub-muted);
+  padding: 7px 8px;
+}
+.ph-script-actions .spacer { flex: 1; }
+.ph-script-actions .stat-mini {
+  font-family: var(--hub-f-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  display: flex; align-items: center; gap: 5px;
+}
+.ph-script-actions .stat-mini b {
+  font-family: var(--hub-f-body);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--hub-text);
+}
+
+/* ============================================================
+   MODULE — OBJECTIONS
+   ============================================================ */
+.ph-obj {
+  border-bottom: 1px solid var(--hub-line);
+  padding: 16px 0 18px;
+}
+.ph-obj:first-child { padding-top: 6px; }
+.ph-obj:last-child { border-bottom: none; }
+.ph-obj .quote {
+  display: flex; gap: 10px; align-items: flex-start;
+}
+.ph-obj .quote .n {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1;
+  color: var(--hub-text);
+  letter-spacing: -0.03em;
+  flex: 0 0 auto;
+  width: 34px;
+}
+.ph-obj .quote .n small {
+  font-family: var(--hub-f-mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  color: var(--hub-muted);
+  font-weight: 500;
+  display: block;
+  line-height: 1.6;
+}
+.ph-obj .quote q {
+  font-family: var(--hub-f-display);
+  font-weight: 600;
+  font-style: italic;
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  quotes: none;
+  color: var(--hub-text);
+}
+.ph-obj .quote q::before { content: "«\00a0"; }
+.ph-obj .quote q::after { content: "\00a0»"; }
+.ph-obj-row {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 10px;
+  align-items: flex-start;
+  margin-top: 10px;
+}
+.ph-obj-row .badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px;
+  border-radius: 6px;
+  font-family: var(--hub-f-mono);
+  font-size: 11px;
+  font-weight: 600;
+  margin-top: 2px;
+}
+.ph-obj-row.bad .badge {
+  background: color-mix(in srgb, var(--hub-coral) 14%, transparent);
+  color: var(--hub-coral-dark);
+  border: 1px solid color-mix(in srgb, var(--hub-coral) 30%, transparent);
+}
+.ph-obj-row.good .badge {
+  background: color-mix(in srgb, var(--hub-teal) 16%, transparent);
+  color: var(--hub-teal-dark);
+  border: 1px solid color-mix(in srgb, var(--hub-teal-dark) 25%, transparent);
+}
+.ph-obj-row .lbl {
+  font-family: var(--hub-f-mono);
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.ph-obj-row.bad .lbl { color: var(--hub-coral-dark); }
+.ph-obj-row.good .lbl { color: var(--hub-teal-dark); }
+.ph-obj-row p { margin: 2px 0 0; font-size: 13.5px; line-height: 1.45; color: var(--hub-text); white-space: pre-wrap; }
+.ph-obj-row.bad p {
+  color: var(--hub-muted);
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in srgb, var(--hub-coral) 35%, transparent);
+  text-decoration-thickness: 1px;
+}
+.ph-obj-actions { display: flex; gap: 6px; margin-top: 12px; align-items: center; }
+
+/* ============================================================
+   MODULE — TROUVER (flags + hashtags + sources)
+   ============================================================ */
+.ph-flags {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+@media (max-width: 480px) {
+  .ph-flags { grid-template-columns: 1fr; }
+}
+.ph-flag-col {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 12px;
+  padding: 11px 12px;
+}
+.ph-flag-col.green {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--hub-teal) 7%, transparent), transparent 60%), var(--hub-surface);
+}
+.ph-flag-col.red {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--hub-coral) 7%, transparent), transparent 60%), var(--hub-surface);
+}
+.ph-flag-col h5 {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin: 0 0 8px;
+  display: flex; align-items: center; gap: 6px;
+}
+.ph-flag-col.green h5 { color: var(--hub-teal-dark); }
+.ph-flag-col.red h5 { color: var(--hub-coral-dark); }
+.ph-flag-col h5 .dot { width: 7px; height: 7px; border-radius: 50%; }
+.ph-flag-col.green h5 .dot { background: var(--hub-teal); box-shadow: 0 0 0 3px color-mix(in srgb, var(--hub-teal) 20%, transparent); }
+.ph-flag-col.red h5 .dot { background: var(--hub-coral); box-shadow: 0 0 0 3px color-mix(in srgb, var(--hub-coral) 20%, transparent); }
+.ph-flag-col ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.ph-flag-col li {
+  font-size: 12.5px;
+  line-height: 1.35;
+  color: var(--hub-text);
+  display: flex; gap: 6px; align-items: flex-start;
+}
+.ph-flag-col li::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 4px; height: 4px;
+  border-radius: 50%;
+  margin-top: 7px;
+}
+.ph-flag-col.green li::before { background: var(--hub-teal-dark); }
+.ph-flag-col.red li::before { background: var(--hub-coral-dark); }
+
+.ph-scan-timer {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--hub-accent-dark);
+  background: color-mix(in srgb, var(--hub-accent) 12%, transparent);
+  padding: 4px 9px;
+  border-radius: 99px;
+  margin-bottom: 10px;
+}
+.ph-scan-timer .pulse {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--hub-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hub-accent) 25%, transparent);
+}
+
+.ph-hashtag-card {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 14px;
+  padding: 13px 14px;
+  margin-bottom: 10px;
+}
+.ph-hashtag-card .htag-head {
+  display: flex; align-items: center; justify-content: space-between;
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  margin-bottom: 8px;
+}
+.ph-hashtag-card .htag-head b { color: var(--hub-text); font-weight: 600; }
+.ph-htag-row { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 9px; align-items: center; }
+.ph-htag-row:last-child { margin-bottom: 0; }
+.ph-htag-row .cat {
+  font-family: var(--hub-f-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  margin-right: 4px;
+}
+.ph-htag {
+  font-family: var(--hub-f-mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 99px;
+  background: var(--hub-surface2);
+  color: var(--hub-text);
+  border: 1px solid var(--hub-line);
+  cursor: pointer;
+  transition: transform .1s, background .15s;
+}
+.ph-htag:active { transform: scale(.96); }
+.ph-htag.gold {
+  background: color-mix(in srgb, var(--hub-accent) 13%, transparent);
+  border-color: color-mix(in srgb, var(--hub-accent) 30%, transparent);
+  color: var(--hub-accent-dark);
+}
+.ph-htag.teal {
+  background: color-mix(in srgb, var(--hub-teal) 13%, transparent);
+  border-color: color-mix(in srgb, var(--hub-teal-dark) 25%, transparent);
+  color: var(--hub-teal-dark);
+}
+
+.ph-src-card {
+  background: var(--ls-charcoal, #0B0D11);
+  color: #fff;
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin-bottom: 10px;
+  position: relative;
+  overflow: hidden;
+}
+.ph-src-card::before {
+  content: "";
+  position: absolute;
+  left: -30px; bottom: -30px;
+  width: 100px; height: 100px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--hub-accent) 40%, transparent), transparent 70%);
+}
+.ph-src-card h4 {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 16px;
+  margin: 0 0 4px;
+  letter-spacing: -0.01em;
+  position: relative;
+}
+.ph-src-card .kk {
+  font-family: var(--hub-f-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--hub-accent-light);
+  margin-bottom: 8px;
+}
+.ph-src-row {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 8px 0;
+  border-top: 1px solid rgba(255,255,255,.10);
+}
+.ph-src-row:first-of-type { border-top: none; }
+.ph-src-row .lab {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--hub-accent-light);
+  font-weight: 500;
+  padding-top: 2px;
+}
+.ph-src-row .body {
+  font-size: 13px;
+  line-height: 1.45;
+  color: rgba(255,255,255,.86);
+}
+
+/* ============================================================
+   MODULE — SA RÉPONSE (arbres M2/M3)
+   ============================================================ */
+.ph-tree-branch {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin-bottom: 10px;
+}
+.ph-tree-branch .reaction {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  margin-bottom: 6px;
+  display: flex; align-items: center; gap: 8px;
+}
+.ph-tree-branch .reaction .pill {
+  padding: 3px 8px;
+  border-radius: 99px;
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: none;
+  background: var(--hub-surface2);
+  color: var(--hub-text);
+}
+.ph-tree-branch .reaction .pill.warm { background: color-mix(in srgb, var(--hub-teal) 13%, transparent); color: var(--hub-teal-dark); }
+.ph-tree-branch .reaction .pill.cold { background: color-mix(in srgb, var(--hub-coral) 13%, transparent); color: var(--hub-coral-dark); }
+.ph-tree-branch .reaction .pill.maybe { background: color-mix(in srgb, var(--hub-accent) 13%, transparent); color: var(--hub-accent-dark); }
+.ph-tree-branch q {
+  font-family: var(--hub-f-display);
+  font-style: italic;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.2;
+  color: var(--hub-text);
+  quotes: none;
+  display: block;
+  margin-bottom: 6px;
+}
+.ph-tree-branch q::before { content: "«\00a0"; }
+.ph-tree-branch q::after { content: "\00a0»"; }
+.ph-tree-branch .reply {
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: var(--hub-text);
+  padding: 10px 0 0;
+  border-top: 1px dashed var(--hub-line-2);
+  margin-top: 6px;
+  white-space: pre-wrap;
+}
+.ph-tree-branch .reply::before {
+  content: "→ tu réponds";
+  display: block;
+  font-family: var(--hub-f-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--hub-teal-dark);
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+.ph-tree-branch .actions {
+  display: flex; gap: 6px;
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--hub-line);
+}
+
+/* ============================================================
+   MODULE — POST-APPEL (timeline)
+   ============================================================ */
+.ph-timeline {
+  position: relative;
+  padding-left: 28px;
+  margin-bottom: 10px;
+}
+.ph-timeline::before {
+  content: "";
+  position: absolute;
+  left: 9px; top: 6px; bottom: 6px;
+  width: 1.5px;
+  background: linear-gradient(180deg, var(--hub-accent), var(--hub-line-2));
+}
+.ph-t-step { margin-bottom: 14px; position: relative; }
+.ph-t-step::before {
+  content: "";
+  position: absolute;
+  left: -24px; top: 7px;
+  width: 13px; height: 13px;
+  border-radius: 50%;
+  background: var(--hub-bg);
+  border: 2px solid var(--hub-accent);
+}
+.ph-t-step.now::before {
+  background: var(--hub-accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--hub-accent) 20%, transparent);
+}
+.ph-t-step.future::before {
+  background: var(--hub-bg);
+  border-color: var(--hub-line-2);
+}
+.ph-t-step .when {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--hub-accent-dark);
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.ph-t-step.future .when { color: var(--hub-muted); }
+.ph-t-step h4 {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 16px;
+  margin: 0 0 4px;
+  letter-spacing: -0.01em;
+}
+.ph-t-step .msg {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--hub-text);
+  margin-top: 6px;
+  white-space: pre-wrap;
+}
+
+/* ============================================================
+   MODULE — CLOSING
+   ============================================================ */
+.ph-signal-card {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--hub-teal) 7%, transparent), transparent 50%), var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 14px;
+  padding: 13px 14px;
+  margin-bottom: 10px;
+}
+.ph-signal-card h5 {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--hub-teal-dark);
+  margin: 0 0 8px;
+  display: flex; align-items: center; gap: 6px;
+}
+.ph-signal-card h5::before {
+  content: "";
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--hub-teal);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hub-teal) 20%, transparent);
+}
+.ph-signal-list { display: flex; flex-direction: column; gap: 6px; }
+.ph-signal-list .row {
+  display: flex; gap: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  align-items: flex-start;
+}
+.ph-signal-list .row::before {
+  content: "✓";
+  color: var(--hub-teal-dark);
+  font-weight: 700;
+  font-size: 13px;
+  margin-top: 1px;
+}
+.ph-close-script {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 14px;
+  padding: 13px 16px;
+  margin-bottom: 10px;
+}
+.ph-close-script h4 {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 16px;
+  margin: 0 0 4px;
+  letter-spacing: -0.01em;
+}
+.ph-close-script .ctx {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  margin-bottom: 8px;
+}
+.ph-close-script p { margin: 0; font-size: 13.5px; line-height: 1.5; white-space: pre-wrap; }
+
+/* ============================================================
+   MODULE — CAS SPÉCIAUX
+   ============================================================ */
+.ph-case-tabs {
+  display: flex; gap: 6px; padding: 4px; margin-bottom: 12px;
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 11px;
+}
+.ph-case-tabs button {
+  flex: 1;
+  padding: 8px 6px;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: var(--hub-f-body);
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--hub-muted);
+  transition: background .15s, color .15s;
+}
+.ph-case-tabs button.on { background: var(--hub-text); color: var(--hub-bg); }
+
+/* ============================================================
+   MODULE — STORYTELLING
+   ============================================================ */
+.ph-story-struct {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  margin-bottom: 14px;
+}
+.ph-story-struct .seg {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 10px;
+  padding: 10px;
+  text-align: center;
+}
+.ph-story-struct .seg .step {
+  font-family: var(--hub-f-mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  font-weight: 600;
+}
+.ph-story-struct .seg h6 {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 14px;
+  margin: 6px 0 4px;
+  letter-spacing: -0.01em;
+}
+.ph-story-struct .seg p { margin: 0; font-size: 11.5px; color: var(--hub-muted); line-height: 1.35; }
+.ph-story-struct .seg.gold {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--hub-accent) 15%, transparent), transparent), var(--hub-surface);
+  border-color: color-mix(in srgb, var(--hub-accent) 30%, transparent);
+}
+.ph-story-example {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin-bottom: 10px;
+}
+.ph-story-example .by {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  margin-bottom: 6px;
+}
+.ph-story-example p { margin: 0 0 8px; font-size: 13.5px; line-height: 1.5; white-space: pre-wrap; }
+.ph-story-example p:last-child { margin-bottom: 0; }
+
+/* ============================================================
+   MODULE — ROUTINE
+   ============================================================ */
+.ph-routine-summary {
+  background: var(--ls-charcoal, #0B0D11);
+  color: #fff;
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin-bottom: 12px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  align-items: center;
+}
+.ph-routine-summary .big {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 42px;
+  line-height: 0.9;
+  color: var(--hub-accent);
+  letter-spacing: -0.04em;
+}
+.ph-routine-summary .big small {
+  font-family: var(--hub-f-body);
+  font-weight: 500;
+  font-size: 14px;
+  color: rgba(255,255,255,.6);
+  display: block;
+  letter-spacing: 0;
+  margin-top: 4px;
+}
+.ph-routine-summary p { margin: 0; font-size: 13.5px; line-height: 1.4; color: rgba(255,255,255,.86); }
+
+.ph-checklist {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 14px;
+  padding: 6px 14px;
+  margin-bottom: 10px;
+}
+.ph-check-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 11px 0;
+  border-top: 1px solid var(--hub-line);
+  cursor: pointer;
+}
+.ph-check-item:first-child { border-top: none; }
+.ph-check-item .box {
+  flex: 0 0 auto;
+  width: 20px; height: 20px;
+  border-radius: 6px;
+  border: 1.5px solid var(--hub-line-2);
+  background: var(--hub-surface);
+  display: flex; align-items: center; justify-content: center;
+  margin-top: 1px;
+  transition: background .15s, border-color .15s;
+}
+.ph-check-item.done .box {
+  background: var(--hub-accent);
+  border-color: var(--hub-accent);
+}
+.ph-check-item.done .box::after {
+  content: "✓";
+  color: #fff;
+  font-weight: 700;
+  font-size: 12px;
+}
+.ph-check-item .txt { font-size: 13.5px; line-height: 1.4; color: var(--hub-text); flex: 1; }
+.ph-check-item.done .txt {
+  color: var(--hub-muted);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+.ph-check-item .mins {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  color: var(--hub-muted);
+  letter-spacing: 0.1em;
+  align-self: center;
+}
+
+/* ============================================================
+   TOAST
+   ============================================================ */
+.ph-toast {
+  position: fixed;
+  left: 50%; bottom: 96px;
+  transform: translateX(-50%);
+  background: var(--ls-charcoal, #0B0D11);
+  color: #fff;
+  padding: 9px 14px;
+  border-radius: 99px;
+  font-size: 12.5px;
+  font-weight: 500;
+  display: flex; align-items: center; gap: 8px;
+  box-shadow: 0 8px 20px rgba(11,13,17,.3);
+  z-index: 60;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s ease, transform .2s ease;
+}
+.ph-toast.show { opacity: 1; pointer-events: auto; }
+.ph-toast .ic {
+  color: var(--hub-accent-light);
+  font-family: var(--hub-f-mono);
+  font-size: 11px;
+}
+
+/* ============================================================
+   BOTTOM SHEET
+   ============================================================ */
+.ph-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(11,13,17,0);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .25s ease;
+  z-index: 70;
+}
+.ph-sheet-backdrop.open {
+  background: rgba(11,13,17,.45);
+  opacity: 1;
+  pointer-events: auto;
+}
+.ph-sheet {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  background: var(--hub-bg);
+  border-radius: 24px 24px 0 0;
+  transform: translateY(110%);
+  transition: transform .3s cubic-bezier(.2,.85,.3,1);
+  z-index: 75;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--hub-line);
+}
+.ph-sheet.open { transform: translateY(0); }
+.ph-sheet .grab {
+  width: 40px;
+  height: 5px;
+  background: var(--hub-line-2);
+  border-radius: 3px;
+  margin: 10px auto 6px;
+}
+.ph-sheet .sheet-head { padding: 6px 22px 14px; border-bottom: 1px solid var(--hub-line); }
+.ph-sheet .sheet-head .kicker {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--hub-accent-dark);
+  margin-bottom: 4px;
+}
+.ph-sheet .sheet-head h3 {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 22px;
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+.ph-sheet .sheet-body {
+  padding: 14px 18px 24px;
+  overflow-y: auto;
+}
+
+/* Sheet centred on desktop */
+@media (min-width: 880px) {
+  .ph-sheet {
+    left: 50%;
+    right: auto;
+    transform: translate(-50%, 110%);
+    width: 480px;
+    border-radius: 24px;
+    bottom: 5vh;
+    max-height: 80vh;
+  }
+  .ph-sheet.open { transform: translate(-50%, 0); }
+}
+
+.ph-opts { display: grid; gap: 8px; }
+.ph-opts.cols-2 { grid-template-columns: 1fr 1fr; }
+@media (max-width: 360px) { .ph-opts.cols-2 { grid-template-columns: 1fr; } }
+.ph-opt {
+  display: flex; align-items: center; gap: 12px;
+  padding: 11px 12px;
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  transition: border-color .15s, background .15s;
+}
+.ph-opt:hover { border-color: var(--hub-line-2); }
+.ph-opt.on {
+  border-color: var(--hub-accent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--hub-accent) 8%, transparent), transparent 60%), var(--hub-surface);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--hub-accent) 18%, transparent);
+}
+.ph-opt .flag, .ph-opt .glyph {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px;
+  border-radius: 9px;
+  font-size: 18px;
+  flex: 0 0 auto;
+  background: var(--hub-surface2);
+  border: 1px solid var(--hub-line);
+}
+.ph-opt .flag {
+  font-family: 'Twemoji Country Flags', 'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif;
+}
+.ph-opt .info { display: flex; flex-direction: column; line-height: 1.2; min-width: 0; flex: 1; }
+.ph-opt .info b {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.ph-opt .info small {
+  font-family: var(--hub-f-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  margin-top: 2px;
+}
+.ph-opt .check {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid var(--hub-line-2);
+  flex: 0 0 auto;
+  position: relative;
+}
+.ph-opt.on .check {
+  background: var(--hub-accent);
+  border-color: var(--hub-accent);
+}
+.ph-opt.on .check::after {
+  content: "";
+  position: absolute;
+  left: 5px; top: 2px;
+  width: 4px; height: 8px;
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+/* Stat sheet (funnel) */
+.ph-stat-sheet .big {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.ph-stat-sheet .big .stat {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 12px;
+  padding: 12px;
+}
+.ph-stat-sheet .big .stat .v {
+  font-family: var(--hub-f-display);
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+.ph-stat-sheet .big .stat .k {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+  margin-top: 6px;
+}
+.ph-stat-sheet .funnel {
+  background: var(--hub-surface);
+  border: 1px solid var(--hub-line);
+  border-radius: 12px;
+  padding: 12px 14px;
+}
+.ph-stat-sheet .fn-row {
+  display: grid;
+  grid-template-columns: 90px 1fr 40px;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  padding: 6px 0;
+}
+.ph-stat-sheet .fn-row .lab {
+  font-family: var(--hub-f-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--hub-muted);
+}
+.ph-stat-sheet .fn-bar {
+  height: 8px;
+  border-radius: 99px;
+  background: var(--hub-surface2);
+}
+.ph-stat-sheet .fn-fill {
+  height: 100%;
+  border-radius: 99px;
+  background: linear-gradient(90deg, var(--hub-accent), var(--hub-accent-light));
+  transition: width .6s ease;
+}
+.ph-stat-sheet .fn-row .v {
+  font-weight: 700;
+  text-align: right;
+}
+
+/* ============================================================
+   DESKTOP (≥ 880px) — index étalé, plus de respiration
+   ============================================================ */
+@media (min-width: 880px) {
+  .prospection-hub { max-width: 760px; margin: 0 auto; }
+  .ph-hdr { padding: 10px 22px 14px; }
+  .ph-section-head { padding: 0 28px 14px; }
+  .ph-section-head h2 { font-size: 34px; }
+  .ph-section-head p.lede { font-size: 14.5px; max-width: 54ch; }
+  .ph-section-meta { padding: 14px 28px 6px; }
+  .ph-body-inner { padding: 0 28px; }
+  .ph-pickers { gap: 12px; }
+  .ph-index { margin-top: 12px; overflow: visible; }
+  .ph-index .step { padding: 8px 10px; font-size: 11.5px; }
+  .ph-index .step .name { display: inline; } /* All 10 modules visible */
+  .ph-botnav { padding: 12px 22px 18px; }
+}
+
+/* ============================================================
+   Reduced motion
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  .prospection-hub *,
+  .prospection-hub *::before,
+  .prospection-hub *::after {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/src/components/prospection/prospection-hub.css
+++ b/src/components/prospection/prospection-hub.css
@@ -18,10 +18,22 @@
   --hub-line-2: color-mix(in srgb, var(--ls-text) 14%, transparent);
   --hub-muted: var(--ls-text-muted, color-mix(in srgb, var(--ls-text) 56%, transparent));
   --hub-muted-2: color-mix(in srgb, var(--ls-text) 40%, transparent);
-  /* Accent : gold en light, teal en dark (Thomas validé) */
-  --hub-accent: var(--ls-gold);
-  --hub-accent-light: var(--ls-gold-light, #E5C97D);
-  --hub-accent-dark: color-mix(in srgb, var(--ls-gold) 70%, var(--ls-text));
+
+  /* ─── Accent : LIGHT = violet/turquoise (validé Thomas)
+                  DARK  = teal (cohérent app coach)
+     Le secondaire teal vit en parallèle de l'accent primary pour les
+     états positifs (sent, done, warm, success). En dark, accent=teal
+     et secondary=teal-light (variation lumineuse). En light, accent=
+     violet et secondary=teal. */
+  --hub-accent: #7C3AED;
+  --hub-accent-light: #A77BF7;
+  --hub-accent-dark: #5B21B6;
+  --hub-accent-secondary: var(--ls-teal);
+  --hub-accent-secondary-dark: #0F766E;
+  --hub-accent-gradient: linear-gradient(135deg, #7C3AED 0%, #2DD4BF 100%);
+  --hub-accent-gradient-soft: linear-gradient(135deg, color-mix(in srgb, #7C3AED 18%, transparent), color-mix(in srgb, #2DD4BF 18%, transparent));
+  --hub-accent-gradient-glow: linear-gradient(180deg, color-mix(in srgb, #7C3AED 12%, transparent), transparent 55%);
+
   --hub-coral: #FB7185;
   --hub-coral-dark: #BE3242;
   --hub-teal: var(--ls-teal);
@@ -42,12 +54,19 @@
   -webkit-font-smoothing: antialiased;
 }
 
-/* En dark (theme app default = pas de .theme-light), accent bascule teal */
+/* En dark (theme app default = pas de .theme-light), accent bascule teal pur
+   pour cohérence avec le reste de l'app coach. Le gradient devient
+   teal-to-light-teal pour rester monochrome dark-friendly. */
 :root:not(.theme-light) .prospection-hub,
 .dark .prospection-hub {
   --hub-accent: var(--ls-teal);
-  --hub-accent-light: color-mix(in srgb, var(--ls-teal) 70%, white);
-  --hub-accent-dark: color-mix(in srgb, var(--ls-teal) 60%, var(--ls-text));
+  --hub-accent-light: color-mix(in srgb, var(--ls-teal) 60%, white);
+  --hub-accent-dark: color-mix(in srgb, var(--ls-teal) 70%, var(--ls-text));
+  --hub-accent-secondary: color-mix(in srgb, var(--ls-teal) 80%, white);
+  --hub-accent-secondary-dark: #0F766E;
+  --hub-accent-gradient: linear-gradient(135deg, var(--ls-teal) 0%, color-mix(in srgb, var(--ls-teal) 60%, white) 100%);
+  --hub-accent-gradient-soft: linear-gradient(135deg, color-mix(in srgb, var(--ls-teal) 22%, transparent), color-mix(in srgb, var(--ls-teal) 8%, transparent));
+  --hub-accent-gradient-glow: linear-gradient(180deg, color-mix(in srgb, var(--ls-teal) 14%, transparent), transparent 55%);
   --hub-line: color-mix(in srgb, white 8%, transparent);
   --hub-line-2: color-mix(in srgb, white 16%, transparent);
 }
@@ -82,8 +101,10 @@
 }
 .ph-gem {
   width: 18px; height: 18px; border-radius: 5px;
-  background: linear-gradient(135deg, var(--ls-gold) 0%, var(--ls-gold-light, #E5C97D) 60%, #fff7d6 100%);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ls-gold) 50%, transparent) inset;
+  background: var(--hub-accent-gradient);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--hub-accent) 40%, transparent) inset,
+    0 4px 12px -2px color-mix(in srgb, var(--hub-accent) 40%, transparent);
   position: relative;
 }
 .ph-gem::after {
@@ -117,8 +138,10 @@
 .ph-stat-chip:hover { border-color: var(--hub-line-2); }
 .ph-stat-chip .dot-live {
   width: 6px; height: 6px; border-radius: 50%;
-  background: var(--hub-teal);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hub-teal) 18%, transparent);
+  background: var(--hub-accent-secondary);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--hub-accent-secondary) 22%, transparent),
+    0 0 8px color-mix(in srgb, var(--hub-accent-secondary) 60%, transparent);
 }
 .ph-stat-chip b { font-weight: 600; color: var(--hub-text); transition: color .2s; }
 .ph-stat-chip b.bumped { color: var(--hub-accent-dark); }
@@ -147,8 +170,10 @@
 .ph-picker:hover { border-color: var(--hub-line-2); }
 .ph-picker:active { transform: scale(.985); }
 .ph-picker.opening {
-  border-color: var(--hub-accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hub-accent) 15%, transparent);
+  border-color: transparent;
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--hub-accent) 50%, transparent),
+    0 8px 24px -10px color-mix(in srgb, var(--hub-accent) 40%, transparent);
 }
 .ph-picker .lbl {
   font-family: var(--hub-f-mono);
@@ -232,8 +257,17 @@
 .ph-index .step.active {
   background: var(--hub-text);
   color: var(--hub-bg);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--hub-accent) 30%, transparent),
+    0 4px 16px -6px color-mix(in srgb, var(--hub-accent) 35%, transparent);
 }
-.ph-index .step.active .n { color: var(--hub-accent-light); }
+.ph-index .step.active .n {
+  color: var(--hub-accent-light);
+  background: var(--hub-accent-gradient);
+  -webkit-background-clip: text;
+          background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
 .ph-index .step.active .name { display: inline; color: var(--hub-bg); }
 .ph-index .step.done { color: var(--hub-text); }
 .ph-index .step.done .n { color: var(--hub-accent-dark); }
@@ -374,9 +408,10 @@
   transition: background .2s, width .25s;
 }
 .ph-dots .d.on {
-  background: var(--hub-accent);
+  background: var(--hub-accent-gradient);
   width: 18px;
   border-radius: 3px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--hub-accent) 16%, transparent);
 }
 .ph-dots .d.done { background: var(--hub-accent-dark); }
 
@@ -394,10 +429,19 @@
 }
 .ph-truth::before {
   content: "";
-  position: absolute; right: -30px; top: -30px;
-  width: 120px; height: 120px;
-  background: radial-gradient(circle, color-mix(in srgb, var(--hub-accent) 40%, transparent), transparent 70%);
+  position: absolute; right: -40px; top: -40px;
+  width: 180px; height: 180px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--hub-accent) 45%, transparent), color-mix(in srgb, var(--hub-accent-secondary) 18%, transparent) 50%, transparent 75%);
   pointer-events: none;
+  filter: blur(6px);
+}
+.ph-truth::after {
+  content: "";
+  position: absolute; left: -20px; bottom: -30px;
+  width: 100px; height: 100px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--hub-accent-secondary) 30%, transparent), transparent 65%);
+  pointer-events: none;
+  filter: blur(8px);
 }
 .ph-truth .num {
   font-family: var(--hub-f-display);
@@ -436,8 +480,10 @@
 }
 
 .ph-truth-lite {
-  background: linear-gradient(180deg, var(--hub-surface), var(--hub-surface2));
-  border: 1px solid var(--hub-line);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--hub-accent) 8%, transparent), transparent 50%),
+    linear-gradient(180deg, var(--hub-surface), var(--hub-surface2));
+  border: 1px solid color-mix(in srgb, var(--hub-accent) 16%, var(--hub-line));
   border-radius: 14px;
   padding: 14px 16px;
   margin-bottom: 10px;
@@ -534,8 +580,11 @@
   transition: border-color .2s;
 }
 .ph-script.sent {
-  border-color: color-mix(in srgb, var(--hub-teal) 50%, transparent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hub-teal) 8%, transparent);
+  border-color: color-mix(in srgb, var(--hub-accent-secondary) 55%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--hub-accent-secondary) 9%, transparent), transparent 50%), var(--hub-surface);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--hub-accent-secondary) 10%, transparent),
+    0 8px 24px -8px color-mix(in srgb, var(--hub-accent-secondary) 28%, transparent);
 }
 .ph-script .head {
   display: flex; align-items: center; gap: 8px; margin-bottom: 10px;
@@ -1005,9 +1054,15 @@
   background: var(--hub-surface2);
   color: var(--hub-text);
 }
-.ph-tree-branch .reaction .pill.warm { background: color-mix(in srgb, var(--hub-teal) 13%, transparent); color: var(--hub-teal-dark); }
+.ph-tree-branch .reaction .pill.warm { background: color-mix(in srgb, var(--hub-accent-secondary) 16%, transparent); color: var(--hub-accent-secondary-dark); }
 .ph-tree-branch .reaction .pill.cold { background: color-mix(in srgb, var(--hub-coral) 13%, transparent); color: var(--hub-coral-dark); }
-.ph-tree-branch .reaction .pill.maybe { background: color-mix(in srgb, var(--hub-accent) 13%, transparent); color: var(--hub-accent-dark); }
+.ph-tree-branch .reaction .pill.maybe { background: color-mix(in srgb, var(--hub-accent) 14%, transparent); color: var(--hub-accent-dark); }
+/* Branch "warm" : gradient subtle + glow secondary (teal-violet) */
+.ph-tree-branch.warm-branch {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--hub-accent-secondary) 8%, transparent), transparent 55%), var(--hub-surface);
+  border-color: color-mix(in srgb, var(--hub-accent-secondary) 35%, var(--hub-line));
+  box-shadow: 0 6px 20px -10px color-mix(in srgb, var(--hub-accent-secondary) 30%, transparent);
+}
 .ph-tree-branch q {
   font-family: var(--hub-f-display);
   font-style: italic;
@@ -1114,11 +1169,14 @@
    MODULE — CLOSING
    ============================================================ */
 .ph-signal-card {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--hub-teal) 7%, transparent), transparent 50%), var(--hub-surface);
-  border: 1px solid var(--hub-line);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--hub-accent-secondary) 14%, transparent), transparent 55%),
+    var(--hub-surface);
+  border: 1px solid color-mix(in srgb, var(--hub-accent-secondary) 22%, var(--hub-line));
   border-radius: 14px;
   padding: 13px 14px;
   margin-bottom: 10px;
+  box-shadow: 0 10px 30px -16px color-mix(in srgb, var(--hub-accent-secondary) 32%, transparent);
 }
 .ph-signal-card h5 {
   font-family: var(--hub-f-mono);
@@ -1311,9 +1369,13 @@
   margin-top: 1px;
   transition: background .15s, border-color .15s;
 }
+.ph-check-item.done {
+  background: linear-gradient(90deg, color-mix(in srgb, var(--hub-accent-secondary) 8%, transparent), transparent 70%);
+}
 .ph-check-item.done .box {
-  background: var(--hub-accent);
-  border-color: var(--hub-accent);
+  background: var(--hub-accent-gradient);
+  border-color: transparent;
+  box-shadow: 0 4px 12px -4px color-mix(in srgb, var(--hub-accent) 50%, transparent);
 }
 .ph-check-item.done .box::after {
   content: "✓";
@@ -1336,30 +1398,33 @@
 }
 
 /* ============================================================
-   TOAST
+   TOAST — fixed bas-droite, hors bottom-nav, visible mobile + desktop full
    ============================================================ */
 .ph-toast {
   position: fixed;
-  left: 50%; bottom: 96px;
-  transform: translateX(-50%);
+  right: 24px; bottom: 24px;
   background: var(--ls-charcoal, #0B0D11);
   color: #fff;
-  padding: 9px 14px;
+  padding: 10px 16px;
   border-radius: 99px;
-  font-size: 12.5px;
+  font-size: 13px;
   font-weight: 500;
   display: flex; align-items: center; gap: 8px;
-  box-shadow: 0 8px 20px rgba(11,13,17,.3);
-  z-index: 60;
+  box-shadow:
+    0 12px 32px rgba(11,13,17,.4),
+    0 0 0 1px color-mix(in srgb, var(--hub-accent) 35%, transparent) inset;
+  z-index: 90;
   opacity: 0;
   pointer-events: none;
+  transform: translateY(8px);
   transition: opacity .2s ease, transform .2s ease;
 }
-.ph-toast.show { opacity: 1; pointer-events: auto; }
+.ph-toast.show { opacity: 1; pointer-events: auto; transform: translateY(0); }
 .ph-toast .ic {
   color: var(--hub-accent-light);
   font-family: var(--hub-f-mono);
-  font-size: 11px;
+  font-size: 12px;
+  font-weight: 700;
 }
 
 /* ============================================================
@@ -1454,9 +1519,16 @@
 }
 .ph-opt:hover { border-color: var(--hub-line-2); }
 .ph-opt.on {
-  border-color: var(--hub-accent);
-  background: linear-gradient(180deg, color-mix(in srgb, var(--hub-accent) 8%, transparent), transparent 60%), var(--hub-surface);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--hub-accent) 18%, transparent);
+  border-color: transparent;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--hub-accent) 14%, transparent), color-mix(in srgb, var(--hub-accent-secondary) 6%, transparent) 60%),
+    var(--hub-surface);
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--hub-accent) 30%, transparent),
+    0 10px 28px -10px color-mix(in srgb, var(--hub-accent) 35%, transparent);
+}
+.ph-opt.on .check {
+  background: var(--hub-accent-gradient);
 }
 .ph-opt .flag, .ph-opt .glyph {
   display: inline-flex; align-items: center; justify-content: center;
@@ -1563,7 +1635,8 @@
 .ph-stat-sheet .fn-fill {
   height: 100%;
   border-radius: 99px;
-  background: linear-gradient(90deg, var(--hub-accent), var(--hub-accent-light));
+  background: var(--hub-accent-gradient);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--hub-accent) 40%, transparent);
   transition: width .6s ease;
 }
 .ph-stat-sheet .fn-row .v {
@@ -1572,27 +1645,33 @@
 }
 
 /* ============================================================
-   DESKTOP (≥ 880px) — index étalé, plus de respiration
+   DESKTOP (≥ 880px) — full largeur app coach, plus de respiration
    ============================================================
-   Spec design v3 polish : sur desktop, l'index étale juste l'actif
-   avec son nom + autres en numéro+emoji seulement (comme mobile).
-   Ne PAS forcer .name { display:inline } pour tous, sinon overflow
-   visuel et calibrage cassé (cf. retour Thomas captures dark/light).
+   Validé Thomas : "full largeur sans rien casser". Pas de max-width
+   centré : on prend toute la place dispo dans le shell de l'app.
+   L'actif de l'index étale son nom, les autres restent en
+   icône+numéro pour ne pas overflow horizontalement.
 */
 @media (min-width: 880px) {
-  .prospection-hub { max-width: 920px; margin: 0 auto; }
-  .ph-hdr { padding: 10px 24px 14px; }
-  .ph-section-head { padding: 0 28px 14px; }
-  .ph-section-head h2 { font-size: 34px; }
-  .ph-section-head p.lede { font-size: 14.5px; max-width: 54ch; }
-  .ph-section-meta { padding: 14px 28px 6px; }
-  .ph-body-inner { padding: 0 28px; }
-  .ph-pickers { gap: 12px; }
-  .ph-index { margin-top: 12px; overflow-x: auto; }
-  .ph-index .step { padding: 8px 11px; font-size: 11.5px; }
-  /* L'actif a déjà display:inline via la règle .step.active .name;
-     les non-actifs restent en icône+numéro pour rester lisibles. */
-  .ph-botnav { padding: 12px 22px 18px; }
+  .prospection-hub { width: 100%; max-width: none; margin: 0; }
+  .ph-hdr { padding: 14px 32px 16px; }
+  .ph-section-head { padding: 0 32px 16px; }
+  .ph-section-head h2 { font-size: 36px; }
+  .ph-section-head p.lede { font-size: 14.5px; max-width: 62ch; }
+  .ph-section-meta { padding: 16px 32px 6px; }
+  .ph-body-inner { padding: 0 32px; max-width: 1100px; }
+  .ph-pickers { gap: 12px; max-width: 720px; }
+  .ph-index { margin-top: 14px; overflow-x: auto; max-width: 1100px; }
+  .ph-index .step { padding: 8px 12px; font-size: 11.5px; }
+  .ph-botnav { padding: 14px 32px 20px; }
+}
+
+@media (min-width: 1280px) {
+  /* Très large : on rend les zones de lecture confortables
+     (max 1100px sur le content) pour la lisibilité, le reste
+     respire en blanc/cream propre. */
+  .ph-section-head h2 { font-size: 40px; }
+  .ph-section-head p.lede { font-size: 15px; max-width: 64ch; }
 }
 
 /* ============================================================

--- a/src/components/prospection/prospection-hub.css
+++ b/src/components/prospection/prospection-hub.css
@@ -427,21 +427,14 @@
   position: relative;
   overflow: hidden;
 }
+/* Glow subtil sur le truth principal — pattern de la capture 3 signal-card :
+   un radial discret en coin, pas un blur massif qui pète l'esthétique. */
 .ph-truth::before {
   content: "";
-  position: absolute; right: -40px; top: -40px;
-  width: 180px; height: 180px;
-  background: radial-gradient(circle, color-mix(in srgb, var(--hub-accent) 45%, transparent), color-mix(in srgb, var(--hub-accent-secondary) 18%, transparent) 50%, transparent 75%);
+  position: absolute; right: -30px; top: -30px;
+  width: 120px; height: 120px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--hub-accent) 28%, transparent), transparent 70%);
   pointer-events: none;
-  filter: blur(6px);
-}
-.ph-truth::after {
-  content: "";
-  position: absolute; left: -20px; bottom: -30px;
-  width: 100px; height: 100px;
-  background: radial-gradient(circle, color-mix(in srgb, var(--hub-accent-secondary) 30%, transparent), transparent 65%);
-  pointer-events: none;
-  filter: blur(8px);
 }
 .ph-truth .num {
   font-family: var(--hub-f-display);
@@ -1653,25 +1646,29 @@
    icône+numéro pour ne pas overflow horizontalement.
 */
 @media (min-width: 880px) {
+  /* Full largeur app coach (pattern Co-pilote). Pas de max-width interne.
+     Padding cohérent avec le shell d'app. */
   .prospection-hub { width: 100%; max-width: none; margin: 0; }
   .ph-hdr { padding: 14px 32px 16px; }
   .ph-section-head { padding: 0 32px 16px; }
   .ph-section-head h2 { font-size: 36px; }
-  .ph-section-head p.lede { font-size: 14.5px; max-width: 62ch; }
+  .ph-section-head p.lede { font-size: 14.5px; max-width: 70ch; }
   .ph-section-meta { padding: 16px 32px 6px; }
-  .ph-body-inner { padding: 0 32px; max-width: 1100px; }
-  .ph-pickers { gap: 12px; max-width: 720px; }
-  .ph-index { margin-top: 14px; overflow-x: auto; max-width: 1100px; }
+  .ph-body-inner { padding: 0 32px; }
+  .ph-pickers { gap: 12px; }
+  .ph-index { margin-top: 14px; overflow-x: auto; }
   .ph-index .step { padding: 8px 12px; font-size: 11.5px; }
   .ph-botnav { padding: 14px 32px 20px; }
 }
 
 @media (min-width: 1280px) {
-  /* Très large : on rend les zones de lecture confortables
-     (max 1100px sur le content) pour la lisibilité, le reste
-     respire en blanc/cream propre. */
+  .ph-hdr { padding: 16px 40px 18px; }
+  .ph-section-head { padding: 0 40px 16px; }
   .ph-section-head h2 { font-size: 40px; }
-  .ph-section-head p.lede { font-size: 15px; max-width: 64ch; }
+  .ph-section-head p.lede { font-size: 15px; max-width: 78ch; }
+  .ph-section-meta { padding: 16px 40px 6px; }
+  .ph-body-inner { padding: 0 40px; }
+  .ph-botnav { padding: 16px 40px 22px; }
 }
 
 /* ============================================================

--- a/src/hooks/useProspectionData.ts
+++ b/src/hooks/useProspectionData.ts
@@ -233,7 +233,8 @@ export type ProspectionPlatform =
   | "whatsapp"
   | "telegram"
   | "linkedin"
-  | "sms";
+  | "sms"
+  | "tiktok";
 
 export type ProspectionScriptKind =
   | "first_contact"
@@ -403,6 +404,7 @@ export const PLATFORM_LABELS: Record<ProspectionPlatform, string> = {
   telegram: "Telegram",
   linkedin: "LinkedIn",
   sms: "SMS",
+  tiktok: "TikTok",
 };
 
 export const PLATFORM_ICONS: Record<ProspectionPlatform, string> = {
@@ -412,6 +414,7 @@ export const PLATFORM_ICONS: Record<ProspectionPlatform, string> = {
   telegram: "✈️",
   linkedin: "💼",
   sms: "📱",
+  tiktok: "🎵",
 };
 
 export const PLATFORM_GRADIENTS: Record<ProspectionPlatform, string> = {
@@ -421,6 +424,7 @@ export const PLATFORM_GRADIENTS: Record<ProspectionPlatform, string> = {
   telegram: "#0088CC",
   linkedin: "#0A66C2",
   sms: "#6B7280",
+  tiktok: "linear-gradient(135deg, #25F4EE, #000, #FE2C55)",
 };
 
 // ============================================================================

--- a/src/pages/ProspectionPage.tsx
+++ b/src/pages/ProspectionPage.tsx
@@ -137,13 +137,18 @@ export function ProspectionPage() {
   }
 
   if (mode === "hub") {
-    // V4 design polish : le hub a son propre header intégré (brand + stat-chip
-    // 7j cliquable). On ne re-render PAS le <Header /> du tunnel V3 ni le
-    // <StatsBanner /> externe, sinon doublon parasite (hero "Le monde, en
-    // messages prêts" qui casse le dark mode + prend 40 % de l'écran).
+    // V4 design polish : le hub a son propre header intégré + assume sa propre
+    // largeur (full largeur app coach, comme Co-pilote). On NE PASSE PAS par
+    // <PageShell> ici car celui-ci wrappe en maxWidth:760px (tunnel V3) et
+    // étrangle le hub. Wrapper full largeur direct.
     void stats; // stats internes au hub (compteur sent/RDV) — pas de chip externe
     return (
-      <PageShell>
+      <div style={{
+        minHeight: "100dvh",
+        background: "var(--ls-bg)",
+        color: "var(--ls-text)",
+        fontFamily: "'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif",
+      }}>
         <ProspectionHub
           markets={data.markets}
           profiles={data.profiles}
@@ -168,7 +173,7 @@ export function ProspectionPage() {
             setProfileSlug(null);
           }}
         />
-      </PageShell>
+      </div>
     );
   }
 

--- a/src/pages/ProspectionPage.tsx
+++ b/src/pages/ProspectionPage.tsx
@@ -137,10 +137,13 @@ export function ProspectionPage() {
   }
 
   if (mode === "hub") {
+    // V4 design polish : le hub a son propre header intégré (brand + stat-chip
+    // 7j cliquable). On ne re-render PAS le <Header /> du tunnel V3 ni le
+    // <StatsBanner /> externe, sinon doublon parasite (hero "Le monde, en
+    // messages prêts" qui casse le dark mode + prend 40 % de l'écran).
+    void stats; // stats internes au hub (compteur sent/RDV) — pas de chip externe
     return (
       <PageShell>
-        <Header />
-        {stats && <StatsBanner stats={stats} />}
         <ProspectionHub
           markets={data.markets}
           profiles={data.profiles}

--- a/supabase/migrations/20261119180000_prospection_v4_naming_cleanup.sql
+++ b/supabase/migrations/20261119180000_prospection_v4_naming_cleanup.sql
@@ -1,0 +1,29 @@
+-- =============================================================================
+-- Chantier #3 V4 — Cleanup naming "M1 / M2 / M3" (2026-05-19)
+--
+-- Le hub V4 utilise un naming user-friendly ("Premier message" / "Sa réponse").
+-- Cette migration purge les occurrences de "M1" / "M2 / M3" qui restent dans
+-- le copy seedé (principalement dans la routine et certains tips).
+-- =============================================================================
+
+begin;
+
+-- prospection_routines : "5 messages M1" → "5 premiers messages"
+--                        "M2 / M3" → "tes conversations en cours"
+update public.prospection_routines
+   set title = replace(title, 'messages M1', 'premiers messages'),
+       detail = replace(replace(detail, 'M2 / M3', 'tes conversations en cours'), 'messages M1', 'premiers messages')
+ where (title like '%M1%' or detail like '%M1%' or detail like '%M2%');
+
+-- prospection_scripts : tip "M1" → "premier message"
+update public.prospection_scripts
+   set tip = replace(tip, 'M1', 'premier message')
+ where tip like '%M1%';
+
+-- prospection_followups : warning "J+5" reste mais nettoie si "M1" mentionné
+update public.prospection_followups
+   set body = replace(body, 'M1', 'premier message'),
+       body_fr = case when body_fr is not null then replace(body_fr, 'M1', 'premier message') else null end
+ where body like '%M1%' or (body_fr is not null and body_fr like '%M1%');
+
+commit;

--- a/supabase/migrations/20261119190000_prospection_v4_locale_fix.sql
+++ b/supabase/migrations/20261119190000_prospection_v4_locale_fix.sql
@@ -1,0 +1,77 @@
+-- =============================================================================
+-- Chantier #3 V4 — Locale fix (2026-05-19)
+--
+-- Le coach FR doit voir tout le contenu d'INFO (mindset, drapeaux, sources,
+-- métriques, routines, storytelling) en français — peu importe le marché
+-- sélectionné. Seuls les SCRIPTS À ENVOYER (M1, réponses, objections,
+-- post-appel, closing, cas spéciaux) restent en langue native du marché.
+--
+-- Mon seed initial (étape 3) avait écrit les tables "info" en langue native
+-- pour les 5 marchés non-FR. Ce script corrige en clonant le contenu FR
+-- vers les 5 autres marchés sur les tables info uniquement.
+--
+-- Hashtags : restent en natif (recherche réseaux sociaux).
+-- Scripts : restent en natif + body_fr déjà présent (toggle UI).
+--
+-- Stratégie : DELETE non-FR + INSERT depuis FR avec UPDATE market_code.
+-- =============================================================================
+
+begin;
+
+-- ─── 1. Mindset blocks ─────────────────────────────────────────────────────
+delete from public.prospection_mindset_blocks where market_code <> 'fr';
+
+insert into public.prospection_mindset_blocks (market_code, kind, title, body, position)
+select mc.code, mb.kind, mb.title, mb.body, mb.position
+  from public.prospection_mindset_blocks mb
+ cross join (values ('en'), ('es'), ('pt'), ('tr'), ('hi')) as mc(code)
+ where mb.market_code = 'fr';
+
+-- ─── 2. Profile flags ──────────────────────────────────────────────────────
+delete from public.prospection_profile_flags where market_code <> 'fr';
+
+insert into public.prospection_profile_flags (market_code, profile_slug, flag_type, text, position)
+select mc.code, pf.profile_slug, pf.flag_type, pf.text, pf.position
+  from public.prospection_profile_flags pf
+ cross join (values ('en'), ('es'), ('pt'), ('tr'), ('hi')) as mc(code)
+ where pf.market_code = 'fr';
+
+-- ─── 3. Sources alternatives ───────────────────────────────────────────────
+delete from public.prospection_sources where market_code <> 'fr';
+
+insert into public.prospection_sources (market_code, profile_slug, kind, label, detail, position)
+select mc.code, src.profile_slug, src.kind, src.label, src.detail, src.position
+  from public.prospection_sources src
+ cross join (values ('en'), ('es'), ('pt'), ('tr'), ('hi')) as mc(code)
+ where src.market_code = 'fr';
+
+-- ─── 4. Metrics ────────────────────────────────────────────────────────────
+delete from public.prospection_metrics where market_code <> 'fr';
+
+insert into public.prospection_metrics (market_code, kind, label, value_min, value_max, value_unit, hint, position)
+select mc.code, m.kind, m.label, m.value_min, m.value_max, m.value_unit, m.hint, m.position
+  from public.prospection_metrics m
+ cross join (values ('en'), ('es'), ('pt'), ('tr'), ('hi')) as mc(code)
+ where m.market_code = 'fr';
+
+-- ─── 5. Routines ───────────────────────────────────────────────────────────
+delete from public.prospection_routines where market_code <> 'fr';
+
+insert into public.prospection_routines (market_code, kind, title, detail, duration_minutes, position)
+select mc.code, r.kind, r.title, r.detail, r.duration_minutes, r.position
+  from public.prospection_routines r
+ cross join (values ('en'), ('es'), ('pt'), ('tr'), ('hi')) as mc(code)
+ where r.market_code = 'fr';
+
+-- ─── 6. Storytelling ───────────────────────────────────────────────────────
+-- Note : storytelling existe déjà en FR sur tous les marchés via mon seed
+-- initial, mais on s'assure en re-clonant proprement.
+delete from public.prospection_storytelling where market_code <> 'fr';
+
+insert into public.prospection_storytelling (market_code, profile_slug, kind, title, body, position)
+select mc.code, s.profile_slug, s.kind, s.title, s.body, s.position
+  from public.prospection_storytelling s
+ cross join (values ('en'), ('es'), ('pt'), ('tr'), ('hi')) as mc(code)
+ where s.market_code = 'fr';
+
+commit;

--- a/supabase/migrations/20261119200000_prospection_v4_fr_scripts_complete.sql
+++ b/supabase/migrations/20261119200000_prospection_v4_fr_scripts_complete.sql
@@ -1,0 +1,108 @@
+-- =============================================================================
+-- Chantier #3 V4 — Scripts FR complets (2026-05-19)
+--
+-- Le seed FR initial a couvert :
+--   - weight-women : insta, fb, whatsapp (3 scripts)
+--   - weight-men   : insta, fb, whatsapp, sms (4 scripts)
+--   - sport        : insta uniquement
+--   - business     : insta + linkedin
+--
+-- Manque pour avoir une couverture pro complète :
+--   - sport     : fb, whatsapp, sms, tiktok (4 scripts)
+--   - business  : fb, whatsapp, sms, tiktok (4 scripts)
+--   - weight-women : sms, tiktok (2 scripts)
+--   - weight-men   : tiktok (1 script)
+--   = 11 nouveaux scripts FR
+--
+-- Plus : ajout de TikTok comme plateforme valide (CHECK constraint).
+-- =============================================================================
+
+begin;
+
+-- ─── 1. Étendre CHECK platform pour inclure TikTok ─────────────────────────
+alter table public.prospection_scripts
+  drop constraint if exists prospection_scripts_platform_check;
+alter table public.prospection_scripts
+  add constraint prospection_scripts_platform_check
+  check (platform in ('insta', 'fb', 'whatsapp', 'telegram', 'linkedin', 'sms', 'tiktok'));
+
+-- ─── 2. Scripts FR pour sport (fb, whatsapp, sms, tiktok) ──────────────────
+do $$ begin if (select count(*) from public.prospection_scripts
+                where market_code='fr' and profile_slug='sport' and platform in ('fb','whatsapp','sms','tiktok')) = 0 then
+  insert into public.prospection_scripts
+    (market_code, profile_slug, platform, body, tip, position, kind, label, language_label) values
+    ('fr','sport','fb',
+     E'Bonjour [prénom],\n\nVu ton post dans [nom du groupe] sur [détail course / sortie / séance]. Je suis coach nutrition à [ville], j''accompagne des sportifs amateurs sur la récup et la performance — surtout ceux qui combinent boulot et entraînements intenses.\n\nTu prépares un truc en particulier en ce moment ? Course, défi, ou plus du fond ?',
+     'FB Messenger sport = groupes course/triathlon/CrossFit. Ton posé, mention course concrète.',
+     1, 'first_contact', 'Facebook · groupe course/triathlon', '🇫🇷 Français'),
+
+    ('fr','sport','whatsapp',
+     E'Salut [prénom],\n\nC''est [ton prénom], on s''est croisés via [contexte — club / course / coach commun]. Tu m''avais parlé de [détail — ton objectif / point bloquant]. Tu en es où ?',
+     'WhatsApp sport = lead chaud déjà rencontré IRL. Réf au contexte de rencontre.',
+     1, 'first_contact', 'WhatsApp · contact tiède', '🇫🇷 Français'),
+
+    ('fr','sport','sms',
+     E'Salut [prénom], c''est [ton prénom]. On avait parlé de [contexte sportif]. Si tu es toujours sur ton objectif [course / perf / récup], dis-moi, on cale 15 min cette semaine. Sinon bonne continuation dans l''entraînement.',
+     'SMS sport = court, viril, sans emoji. Pas de bla bla.',
+     1, 'first_contact', 'SMS · court & posé', '🇫🇷 Français'),
+
+    ('fr','sport','tiktok',
+     E'Hey [prénom] 🔥\n\nTa vidéo sur [détail séance / record / progression] est dingue. Je suis nutritionniste sportive, j''ai aidé pas mal de coureurs/cyclistes à débloquer leur palier — sans régime extrême.\n\nT''as une seconde pour me dire sur quoi tu bosses en ce moment ?',
+     'TikTok = hook fort + emoji + question rapide. Cible jeunes sportifs amateurs.',
+     1, 'first_contact', 'TikTok · DM post-vidéo', '🇫🇷 Français');
+end if; end$$;
+
+-- ─── 3. Scripts FR pour business (fb, whatsapp, sms, tiktok) ───────────────
+do $$ begin if (select count(*) from public.prospection_scripts
+                where market_code='fr' and profile_slug='business' and platform in ('fb','whatsapp','sms','tiktok')) = 0 then
+  insert into public.prospection_scripts
+    (market_code, profile_slug, platform, body, tip, position, kind, label, language_label) values
+    ('fr','business','fb',
+     E'Bonjour [prénom],\n\nVu ton post dans [nom du groupe] sur [détail — projet / side-hustle / reconversion]. Je développe une activité wellness en parallèle de [ton activité], et je vois des points communs avec ton parcours.\n\nTu cherches un truc précis en ce moment (revenu complémentaire, indépendance), ou tu testes des idées ?',
+     'FB business = groupes "side hustle" / "entrepreneur [ville]". Ton pair, pas vendeur.',
+     1, 'first_contact', 'Facebook · groupe entrepreneurs', '🇫🇷 Français'),
+
+    ('fr','business','whatsapp',
+     E'Salut [prénom],\n\nC''est [ton prénom], on s''était croisés sur [contexte]. Tu m''avais parlé de [détail — envie de développer autre chose / projet en réflexion]. Tu en es où ?',
+     'WhatsApp business = lead chaud post-networking. Réf au contexte concret.',
+     1, 'first_contact', 'WhatsApp · contact tiède', '🇫🇷 Français'),
+
+    ('fr','business','sms',
+     E'Salut [prénom], c''est [ton prénom]. On avait parlé de [contexte — réunion / café / event]. Si tu es toujours ouvert à explorer une activité complémentaire, dis-moi, on cale 20 min cette semaine.',
+     'SMS business = direct, mention du contexte. Pas de pitch dans le SMS.',
+     1, 'first_contact', 'SMS · court & posé', '🇫🇷 Français'),
+
+    ('fr','business','tiktok',
+     E'Hey [prénom] 💼\n\nTon contenu sur [détail — entrepreneuriat / mindset / liberté financière] est inspirant. Je développe une activité wellness en parallèle de ma vie pro, je connecte avec d''autres entrepreneurs.\n\nT''es ouvert à un échange rapide pour voir si ça peut matcher ?',
+     'TikTok business = hook ambition + emoji business + question ouverte. Cible 28-45 ans.',
+     1, 'first_contact', 'TikTok · DM post-vidéo', '🇫🇷 Français');
+end if; end$$;
+
+-- ─── 4. Scripts FR weight-women (sms + tiktok) ─────────────────────────────
+do $$ begin if (select count(*) from public.prospection_scripts
+                where market_code='fr' and profile_slug='weight-women' and platform in ('sms','tiktok')) = 0 then
+  insert into public.prospection_scripts
+    (market_code, profile_slug, platform, body, tip, position, kind, label, language_label) values
+    ('fr','weight-women','sms',
+     E'Salut [prénom], c''est [ton prénom]. On avait parlé de [contexte]. Si tu es toujours sur l''idée de [perdre du poids / retrouver de l''énergie], dis-moi, on peut en discuter cette semaine. Sans pression.',
+     'SMS = court, ton naturel, mention contexte. Effet "vraie personne" pas marketing.',
+     1, 'first_contact', 'SMS · court & posé', '🇫🇷 Français'),
+
+    ('fr','weight-women','tiktok',
+     E'Hello [prénom] ✨\n\nTa vidéo sur [détail — quotidien maman / parcours / quotidien] m''a touchée. Je suis coach nutrition, j''accompagne des femmes qui veulent retrouver leur énergie et perdre du poids sans régime extrême.\n\nT''as 2 min pour me dire où tu en es ?',
+     'TikTok = ton chaleureux + emoji léger + ouverture douce. Cible femmes 28-45.',
+     1, 'first_contact', 'TikTok · DM post-vidéo', '🇫🇷 Français');
+end if; end$$;
+
+-- ─── 5. Scripts FR weight-men (tiktok) ─────────────────────────────────────
+do $$ begin if (select count(*) from public.prospection_scripts
+                where market_code='fr' and profile_slug='weight-men' and platform='tiktok') = 0 then
+  insert into public.prospection_scripts
+    (market_code, profile_slug, platform, body, tip, position, kind, label, language_label) values
+    ('fr','weight-men','tiktok',
+     E'Hey [prénom] 💪\n\nTa vidéo sur [détail — transformation / training / vie pro] est carrée. Je suis coach nutrition, j''accompagne des mecs sur la perte de gras et l''énergie quand on combine boulot prenant et sport.\n\nT''es sur quel objectif en ce moment — perte de gras, prise de masse propre, ou juste retrouver de l''énergie ?',
+     'TikTok homme = punchy + emoji muscle + question concrète. Vocabulaire perf.',
+     1, 'first_contact', 'TikTok · DM post-vidéo', '🇫🇷 Français');
+end if; end$$;
+
+commit;


### PR DESCRIPTION
## Summary

Refonte design polish complète du hub `/prospection` aligné sur le design v3 Claude Design + 2 sprints de fix sur retours captures Thomas (Vercel dev).

**4 commits** depuis le dernier merge prod :

- `de48f5a` — Refonte hub V4 pixel-near sur design Claude v3 polish (sticky header 3 rows, twin pickers, index rail numéroté, section heading éditorial, bottom-sheets iOS marché/profil/funnel, toast Copié, toggle EN↔FR, raccourcis clavier, compteur 7j incrémenté, glow gradient accent)
- `bfcdd9d` — Fix hero V3 parasite + calibrage index (drop `<Header />` + `<StatsBanner />` en mode hub)
- `5f8d0c6` — Sprint all-in-one : locale fix (FR pour tables info), 11 scripts FR manquants, TikTok 5e plateforme, drop KIND·PROPOSE, "Reco" au lieu de "Recommandation", bouton tunnel discret, toast bottom-right, stats Supabase réelles, accent light=violet/turquoise + dark=teal, glow gradient partout
- `aa2c5b3` — Vraie pleine largeur (bypass PageShell maxWidth:760) + glow truth calmé (retour pattern subtil signal-card)

## Migrations Supabase (déjà appliquées sur DB partagée dev/prod)

- `20261119180000` — Cleanup naming M1/M2/M3 dans copy seed
- `20261119190000` — Locale fix : copie FR sur EN/ES/PT/TR/HI pour mindset/flags/sources/metrics/routines/storytelling (coach FR lit en FR, scripts envoyés restent en natif)
- `20261119200000` — +11 scripts FR : sport+business × FB/WhatsApp/SMS/TikTok, weight-women SMS/TikTok, weight-men TikTok. CHECK platform étendu avec `tiktok`.

## Logique langues finale (validée Thomas)

| Contenu | Affichage |
|---|---|
| Mindset / flags / sources / metrics / routines / storytelling | **FR** pour tous marchés |
| Hashtags | **NATIF** (recherche réseaux) |
| Scripts M1, M2/M3, objections, post-appel, closing, cas spéciaux | NATIF + toggle EN↔FR |

## Test plan

- [x] `npm run build` strict TS + Vite OK (chunk ProspectionPage 62 KB)
- [x] Migrations Supabase appliquées sur remote (db partagée dev/prod)
- [ ] Vercel prod build automatique sur merge
- [ ] Recette visuelle prod (Mélanie + équipe coach) : `/prospection` en mode hub light + dark, all 10 modules, sheets marché/profil, copy+toast, toggle FR, raccourcis clavier
- [ ] Annonce `Kit prospection complet 🌍` push notification chez tous les distri

## Backlog post-prod

- Étendre scripts M1 international (FB/SMS/TikTok × 5 marchés EN/ES/PT/TR/HI)
- Traduction app native quand l'i18n globale arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)