### PR TITLE
feat(prospection): V5 — seed CLEAN end-to-end + câblage toggle Natif↔FR

### DIFF
--- a/audit_messages.md
+++ b/audit_messages.md
@@ -1,0 +1,1348 @@
+# AUDIT MESSAGES PROSPECTION — La Base 360
+*Généré 2026-05-20 — source : migrations Supabase ordre chronologique*
+
+## INVENTAIRE
+
+- Nombre de marchés : 6
+- Profils par marché : 4 (weight-women, weight-men, sport, business)
+- Plateformes possibles : 7 (insta, fb, whatsapp, telegram, linkedin, sms, tiktok)
+- Combinaisons attendues (marché × profil × plateforme) : 168
+- Combinaisons réellement seedées (au moins 1 script) : 64
+- Messages réellement seedés (toutes positions confondues) : 67
+- Taux de couverture (combos uniques) : 38 %
+
+| Marché | Profils couverts | Plateformes seedées | Messages |
+|---|---|---|---|
+| France (fr) | weight-women, weight-men, sport, business | insta, fb, whatsapp, sms, linkedin, tiktok | 16 |
+| International (en) | weight-women, weight-men, sport, business | insta, fb, whatsapp, sms, linkedin | 12 |
+| LatAm + Espagne (es) | weight-women, weight-men, sport, business | insta, fb, whatsapp, sms | 11 |
+| Brésil + Portugal (pt) | weight-women, weight-men, sport, business | insta, fb, whatsapp, sms | 10 |
+| Turquie + DE (tr) | weight-women, weight-men, sport, business | insta, fb, whatsapp, sms | 10 |
+| Inde (hi) | weight-women, weight-men, sport, business | insta, fb, whatsapp, sms | 8 |
+
+---
+
+# MARCHÉ : France
+
+## PROFIL : Perte de poids Femmes (weight-women)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Salut [prénom] ! 👋
+Je suis tombée sur ton profil et tes posts m'ont vraiment parlé. Je vois qu'on partage le côté [healthy / sport / mom-life].
+
+Petite question pour mieux comprendre — tu cherches plutôt à perdre du poids, à gagner en énergie, ou les deux ? 🌿
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+Personnalise [détail vu sur son profil]. Pas de lien dans le 1er message (filtre spam).
+
+---
+
+**Position : 2 — Kind : j3_followup — Label : "Instagram DM · Relance J+3" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Hey [prénom] 🙂
+Je voulais pas te perdre dans le flux — tu te poses peut-être la question sans savoir par où commencer ?
+
+Si tu veux, je peux te partager comment je travaille avec mes coachés. Aucune pression, juste pour échanger.
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+Ne pas en remettre une couche après J+3 si toujours rien.
+
+---
+
+### PLATEFORME : Facebook Messenger (fb)
+
+**Position : 1 — Kind : first_contact — Label : "Facebook Messenger · Premier contact" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Bonjour [prénom],
+J'ai vu ton commentaire / post dans le groupe [nom groupe], et ça m'a vraiment touchée.
+
+Je suis coach nutrition à [ville], j'accompagne des personnes sur la perte de poids durable. Tu cherches quoi en ce moment précisément ?
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+FB Messenger = ton plus posé que Instagram. Groupes wellness = mine d'or.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Coucou [prénom] ! 😊
+C'est [ton prénom], on s'est croisées via [contexte]. Tu m'avais parlé de ton envie de [perdre du poids / te sentir mieux].
+
+J'ai une approche qui marche bien — tu veux qu'on en discute 15 min ?
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+WhatsApp = pour ceux qui t'ont déjà donné leur numéro. Plus chaud, plus direct.
+
+---
+
+### PLATEFORME : SMS (sms)
+
+**Position : 1 — Kind : first_contact — Label : "SMS · Court & posé" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Salut [prénom], c'est [ton prénom]. Je voulais pas te perdre dans les DM Insta donc je passe par SMS. Je suis coach bien-être, on avait échangé sur [contexte]. Si t'as toujours envie qu'on en discute, dis-moi. Sinon pas de souci, belle journée.
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+SMS FR : court, sans emoji, ton posé. Effet "vraie personne" pas marketing.
+
+---
+
+## PROFIL : Perte de poids Hommes (weight-men)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Salut [prénom],
+
+J'ai vu ton post sur [détail vu sur son profil]. Je bosse avec des hommes sur la nutrition et la remise en forme — surtout sur la perte de gras, l'énergie et la récup quand on combine boulot intense et sport.
+
+Curieux de savoir : tu es plus sur un objectif perte de gras, prise de masse propre, ou juste retrouver de l'énergie au quotidien ?
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+Vocabulaire perf/énergie/récup. ZÉRO "bien-être" ou "douceur" → ça les éjecte direct.
+
+---
+
+### PLATEFORME : Facebook Messenger (fb)
+
+**Position : 1 — Kind : first_contact — Label : "Facebook Messenger · Premier contact" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Bonjour [prénom],
+
+Vu ton post dans [nom du groupe] sur [détail]. Je suis coach nutrition à [ville], je bosse pas mal avec des hommes 30-50 ans sur la remise en forme — surtout ceux qui ont un boulot prenant et qui veulent pas que le corps lâche.
+
+Tu en es où toi ? Tu cherches un truc précis ou tu testes des trucs au feeling ?
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+FB Messenger = ton plus posé qu'Insta. Groupes "remise en forme homme" = mine d'or.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Salut [prénom],
+
+C'est [ton prénom], on s'est croisés via [contexte]. Tu m'avais parlé de [détail — perte de poids / énergie / sport]. Tu en es où ?
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+WhatsApp = lead chaud déjà rencontré. Direct mais pas agressif.
+
+---
+
+### PLATEFORME : SMS (sms)
+
+**Position : 1 — Kind : first_contact — Label : "SMS · Court & posé" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Salut [prénom], c'est [ton prénom]. On avait parlé de [contexte]. Si tu es toujours sur l'idée de [objectif], dis-moi, on peut en discuter cette semaine.
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+SMS = court, sans emoji, ton viril posé. Effet "vraie personne".
+
+---
+
+### PLATEFORME : TikTok (tiktok)
+
+**Position : 1 — Kind : first_contact — Label : "TikTok · DM post-vidéo" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Hey [prénom] 💪
+
+Ta vidéo sur [détail — transformation / training / vie pro] est carrée. Je suis coach nutrition, j'accompagne des mecs sur la perte de gras et l'énergie quand on combine boulot prenant et sport.
+
+T'es sur quel objectif en ce moment — perte de gras, prise de masse propre, ou juste retrouver de l'énergie ?
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+TikTok homme = punchy + emoji muscle + question concrète. Vocabulaire perf.
+
+---
+
+## PROFIL : Sportif (sport)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Hello [prénom] 💪
+Ton profil m'a fait sourire (le post sur [détail spécifique], top !). Je travaille avec des sportifs sur la nutrition adaptée — récup, performance, prise de masse.
+
+T'es plutôt sur quelle approche en ce moment côté nutrition ?
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+Pour les sportifs, parler PERF avant tout. Pas de poids/régime.
+
+---
+
+**Position : 2 — Kind : j3_followup — Label : "Instagram DM · Relance J+3" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Hey [prénom] 🙂
+Du coup ta nutrition c'est plutôt feeling ou tu suis un plan structuré ? Curieuse de savoir ce qui marche pour toi.
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+Relance avec question ouverte, pas de pitch.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Salut [prénom] ! 💪 Je suis [ton prénom], on s'est connectés via [contexte]. J'ai vu que tu t'investis à fond dans ton sport et je voulais te dire : j'accompagne pas mal de sportifs amateurs sur la nutrition et la récup, c'est souvent là que les perfs se débloquent. Si t'as envie qu'on en parle un jour, fais-moi signe 🙌
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+WhatsApp FR sport : préciser le contexte de connexion avant de proposer.
+
+---
+
+## PROFIL : Business (business)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Salut [prénom],
+J'ai vu que tu t'intéresses à [entrepreneuriat / lifestyle libre / finance perso]. Je développe une activité dans le wellness en parallèle de ma vie pro, ça monte vite.
+
+Curieux de voir ce que ça implique ? Aucun engagement, juste pour échanger 15 min en visio.
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+Pour le business, dire "à côté de ma vie pro" rassure (pas un MLM 100% à plein temps).
+
+---
+
+### PLATEFORME : LinkedIn (linkedin)
+
+**Position : 1 — Kind : pitch — Label : "LinkedIn · Pitch business" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Bonjour [prénom],
+Votre parcours dans [son secteur] m'intéresse. Je développe une activité complémentaire dans le wellness avec une équipe internationale, et je cherche des profils ambitieux pour bâtir en France.
+
+Une discussion 20 min en visio cette semaine vous tente ?
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+LinkedIn = ton corporate. Vouvoiement, structure claire.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇫🇷 Français**
+
+**Langue locale (FR) :**
+Salut [prénom] ! 😊 Je suis [ton prénom], on avait échangé sur [contexte]. Je voulais reprendre contact comme il faut. Je développe un projet sérieux dans le bien-être avec une vraie dimension entrepreneuriale et je cherche à échanger avec des profils sérieux. Si t'es ouvert, on cale 15 min en visio quand tu veux — sans engagement.
+
+**Version FR :**
+(idem — message déjà en français)
+
+**Note technique affichée :**
+WhatsApp FR business : poser le sérieux du projet, rassurer sur le "sans engagement".
+
+---
+
+# MARCHÉ : International (en)
+
+## PROFIL : Perte de poids Femmes (weight-women)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hey [name] 👋
+Came across your profile and loved your vibe — looks like we share the same passion for [fitness / healthy living / mom-life].
+
+Quick question to get the feel for what you're up to — are you more focused on losing weight, boosting energy, or both? 🌿
+
+**Version FR :**
+Hey [prénom] 👋 Je suis tombé sur ton profil et j'ai trouvé ton énergie vraiment cool. Je suis coach bien-être, j'accompagne des personnes qui veulent reprendre la main sur leur forme sans régime extrême. Si un jour ça te parle, je peux te partager comment je bosse — zéro pression. Bonne journée à toi ✨
+
+**Note technique affichée :**
+EN works for US, UK, intl Insta profiles. Keep it casual.
+
+---
+
+**Position : 2 — Kind : j3_followup — Label : "Instagram DM · Relance J+3" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hey [name] 🙂
+Didn't want you to get lost in your DMs — maybe you're asking yourself the same questions but not sure where to start?
+
+Happy to share how I work with my clients. No pressure, just an open chat.
+
+**Version FR :**
+Hey [prénom] 🙂 Je voulais pas que tu te perdes dans mes DM. Petit suivi de mon message précédent — je sais que la vie va vite. Si jamais tu veux qu'on échange sur ta forme ou tes objectifs bien-être, je suis dispo. Sinon pas de souci, je te souhaite une belle journée 🌿
+
+**Note technique affichée :**
+No salesy tone, pure conversation.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : referral — Label : "WhatsApp · Après recommandation" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hey [name]! 😊
+[Mutual contact] told me about you — said you wanted to start something on the [weight loss / health] side.
+
+I work with people on personalized nutrition. Got 15 mins for a quick chat?
+
+**Version FR :**
+Hey [prénom] ! 😊 [Contact en commun] m'a parlé de toi en disant que tu cherchais à te remettre en forme. Je suis coach bien-être, j'accompagne des personnes sur la nutrition et l'énergie au quotidien. Si tu veux qu'on en discute autour d'un café (ou en visio), dis-moi ✨
+
+**Note technique affichée :**
+EN WhatsApp = pour les leads tièdes via recommandation. Mentionner le contact mutuel.
+
+---
+
+### PLATEFORME : SMS (sms)
+
+**Position : 1 — Kind : first_contact — Label : "SMS · Court & posé" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hi [name], this is [your name]. I didn't want to lose you in Insta DMs so I'm sending a quick text. I'm a wellness coach, we connected on [context]. If you're still up for a chat, let me know. Otherwise no worries, have a great day.
+
+**Version FR :**
+Salut [prénom], c'est [ton prénom]. Je voulais pas te perdre dans les DM Insta donc je passe par SMS. Je suis coach bien-être, on avait échangé sur [contexte]. Si t'as toujours envie qu'on discute, dis-moi. Sinon pas de souci, belle journée.
+
+**Note technique affichée :**
+SMS EN : court, sans emoji, ton posé. Effet "vraie personne".
+
+---
+
+## PROFIL : Perte de poids Hommes (weight-men)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · First contact" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hey [name],
+
+Saw your post about [detail from profile]. I work with guys on nutrition and getting back in shape — mostly fat loss, energy and recovery when juggling intense work and training.
+
+Quick question — are you more on the fat loss side, lean bulk, or just trying to get your energy back day-to-day?
+
+**Version FR :**
+Salut [prénom], j'ai vu ton post sur [détail]. Je bosse avec des hommes sur la nutrition et la remise en forme — surtout perte de gras, énergie, récup quand on combine boulot intense et sport. Tu es plutôt perte de gras, prise de masse propre, ou retrouver de l'énergie ?
+
+**Note technique affichée :**
+Vocabulaire perf/énergie/récup. Évite "wellness" et "feel good" qui éjectent les mecs.
+
+---
+
+### PLATEFORME : Facebook Messenger (fb)
+
+**Position : 1 — Kind : first_contact — Label : "Facebook Messenger · First contact" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hi [name],
+
+Saw your post in [group name] about [detail]. I'm a nutrition coach in [city], I work with 30-50 men on getting back in shape — particularly those balancing a demanding job and not wanting their body to crash.
+
+Where are you at? Looking for something specific or just experimenting?
+
+**Version FR :**
+Bonjour [prénom], j'ai vu ton post dans [groupe]. Je suis coach nutrition à [ville], je bosse avec des hommes 30-50 ans sur la remise en forme — surtout ceux qui combinent un boulot prenant et ne veulent pas que le corps lâche. Tu en es où ?
+
+**Note technique affichée :**
+FB Messenger = ton plus posé qu'Insta. Groupes "men's fitness" = mine d'or.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Direct contact" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hey [name], it's [your name], we crossed paths via [context]. You mentioned [detail — fat loss / energy / training]. Where are you at with it?
+
+**Version FR :**
+Salut [prénom], c'est [ton prénom], on s'est croisés via [contexte]. Tu m'avais parlé de [détail — perte de gras / énergie / sport]. Tu en es où ?
+
+**Note technique affichée :**
+WhatsApp = lead chaud déjà rencontré. Direct mais pas agressif.
+
+---
+
+### PLATEFORME : SMS (sms)
+
+**Position : 1 — Kind : first_contact — Label : "SMS · Short & grounded" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hey [name], it's [your name]. We talked about [context]. If you're still on the idea of [goal], let me know — happy to chat this week.
+
+**Version FR :**
+Salut [prénom], c'est [ton prénom]. On avait parlé de [contexte]. Si tu es toujours sur [objectif], dis-moi, on peut discuter cette semaine.
+
+**Note technique affichée :**
+SMS = court, sans emoji, ton viril posé. Effet "vraie personne".
+
+---
+
+## PROFIL : Sportif (sport)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hey [name] 💪
+Your profile cracked me up (loved the post about [specific detail]!). I work with athletes on nutrition — recovery, performance, gains.
+
+What's your current approach on the nutrition side?
+
+**Version FR :**
+Hey [prénom] 💪 Ton profil m'a fait sourire, on voit que t'es à fond dans ton sport. Je bosse avec pas mal d'athlètes amateurs sur la nutrition et la récup — souvent c'est ce qui débloque les perfs. Si un jour t'as envie d'échanger là-dessus, fais-moi signe 🙌
+
+**Note technique affichée :**
+Talk performance, never weight loss.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hey [name]! 💪 I'm [your name], we connected through [context]. Saw you're really putting in the work training-wise. I coach quite a few amateur athletes on nutrition and recovery — that's usually where performance unlocks. If you're up for a chat one day, no pressure, let me know 🙌
+
+**Version FR :**
+Hey [prénom] ! 💪 Je suis [ton prénom], on s'est connectés via [contexte]. J'ai vu que tu t'entraînes vraiment dur. J'accompagne pas mal de sportifs amateurs sur la nutrition et la récup — c'est souvent là que les perfs se débloquent. Si tu veux qu'on en parle, sans pression, fais-moi signe 🙌
+
+**Note technique affichée :**
+WhatsApp EN sport : context first, puis valeur nutrition/récup.
+
+---
+
+## PROFIL : Business (business)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hey [name],
+Saw you're into [entrepreneurship / freedom lifestyle / personal dev]. I'm scaling a wellness side-business and it's been wild — fun, lifestyle, real income.
+
+Curious to see how it works? Zero pressure, just an open chat.
+
+**Version FR :**
+Hey [prénom], j'ai vu que t'étais dans [entrepreneuriat / ton secteur]. J'accompagne des personnes qui veulent développer une activité bien-être en complément, avec une vraie liberté de temps. Pas du tout le délire MLM agressif — c'est posé, on en parle si ça t'intéresse. Bonne journée ✨
+
+**Note technique affichée :**
+EN business pitch must be short and confident.
+
+---
+
+### PLATEFORME : LinkedIn (linkedin)
+
+**Position : 1 — Kind : pitch — Label : "LinkedIn · Pitch business" — Lang : 🇬🇧 English**
+
+**Langue locale (EN) :**
+Hi [name],
+Your background in [their field] caught my eye. I'm scaling a complementary wellness business with an international team, looking for ambitious profiles.
+
+Open to a 20-min Zoom call this week?
+
+**Version FR :**
+Bonjour [prénom], ton parcours dans [leur domaine] m'a intéressé. Je développe un projet bien-être avec une approche entrepreneuriale et je cherche des profils sérieux pour échanger. Si tu es ouvert à un appel découverte (15 min, sans engagement), dis-moi. Au plaisir.
+
+**Note technique affichée :**
+LinkedIn EN = ton corporate. Structure courte et claire.
+
+---
+
+# MARCHÉ : LatAm + Espagne (es)
+
+## PROFIL : Perte de poids Femmes (weight-women)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+¡Hola [nombre]! 👋
+Me topé con tu perfil y me llamó la atención tu vibe. Trabajo con personas en su transformación — bajar de peso, ganar energía.
+
+¿Estás más enfocada en perder peso, sentirte con más energía, o las dos cosas? 🌿
+
+**Version FR :**
+Salut [prénom] ! 👋 Je suis tombée sur ton profil et j'ai trouvé ton énergie super inspirante. Je suis coach bien-être et j'accompagne des personnes qui veulent retrouver la forme sans régime extrême. Si un jour ça t'intéresse d'en parler, fais-moi signe — sans pression ✨
+
+**Note technique affichée :**
+Mexique, Colombie, Argentine, Espagne. Style proche du français.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+¡Hola [nombre]! 😊
+Soy [tu nombre], nos conocimos por [contexto]. Me hablaste de tus ganas de [bajar de peso / sentirte mejor].
+
+Tengo un método que funciona — ¿quieres que platiquemos 15 min?
+
+**Version FR :**
+Salut [prénom] ! 😊 Je suis [ton prénom], on s'est connectés sur [contexte]. Je voulais juste te dire bonjour comme il faut. Je bosse dans le coaching bien-être — si jamais tu veux qu'on échange sur tes objectifs forme, je suis là. Bonne journée 🌿
+
+**Note technique affichée :**
+WhatsApp est ULTRA dominant en LatAm. Privilégie ce canal.
+
+---
+
+## PROFIL : Perte de poids Hommes (weight-men)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Primer contacto" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+¡Hola [nombre]!
+
+Vi tu post sobre [detalle del perfil]. Trabajo con hombres en nutrición y volver a la forma — sobre todo pérdida de grasa, energía y recuperación cuando combinas chamba intensa y deporte.
+
+Pregunta rápida: ¿estás más en pérdida de grasa, ganancia de masa limpia, o solo recuperar energía día a día?
+
+**Version FR :**
+Vu ton post sur [détail]. Coaching nutrition hommes : perte de gras, énergie, récup quand boulot + sport. Tu es plutôt perte de gras, prise de masse propre, ou retrouver de l'énergie ?
+
+**Note technique affichée :**
+ES Mexique/LatAm. "Chamba" = boulot, ton natural. Evita "bienestar".
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contacto directo" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+¡Hola [nombre]! Soy [tu nombre], nos conectamos por [contexto]. Me hablaste de [pérdida de grasa / energía / deporte]. ¿Cómo vas con eso?
+
+**Version FR :**
+Salut, on s'est connectés via [contexte]. Tu m'avais parlé de [détail]. Tu en es où ?
+
+**Note technique affichée :**
+WhatsApp dominante LatAm. Tono directo, sin emojis exagerados.
+
+---
+
+### PLATEFORME : Facebook Messenger (fb)
+
+**Position : 1 — Kind : first_contact — Label : "Facebook Messenger · Primer contacto" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+Hola [nombre], vi tu post en [nombre grupo] sobre [detalle]. Soy coach nutrición en [ciudad], trabajo con hombres 30-50 en volver a la forma — sobre todo los que combinan chamba demandante y no quieren que el cuerpo aguante mal.
+
+¿Dónde estás tú? ¿Buscas algo preciso o probando cosas al azar?
+
+**Version FR :**
+Coach nutrition à [ville], je bosse avec des hommes 30-50 sur la remise en forme — surtout boulot prenant + corps qui ne lâche pas. Tu en es où ?
+
+**Note technique affichée :**
+FB Messenger LatAm. Más posado, grupos "ponerse en forma" mina de oro.
+
+---
+
+### PLATEFORME : SMS (sms)
+
+**Position : 1 — Kind : first_contact — Label : "SMS · Corto y posado" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+Hola [nombre], soy [tu nombre]. Habíamos hablado de [contexto]. Si sigues con la idea de [objetivo], dime, podemos platicar esta semana.
+
+**Version FR :**
+Salut [prénom], c'est [ton prénom]. On avait parlé de [contexte]. Si tu es toujours sur [objectif], dis-moi.
+
+**Note technique affichée :**
+SMS LatAm. "Platicar" = parler de façon décontractée, mot clé culturel.
+
+---
+
+## PROFIL : Sportif (sport)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+¡Hola [nombre]! 💪
+Tu perfil me hizo sonreír (¡el post sobre [detalle específico] genial!). Trabajo con deportistas en nutrición — recuperación, rendimiento, masa muscular.
+
+¿Cómo manejas tu nutrición ahora?
+
+**Version FR :**
+Salut [prénom] ! 💪 Ton profil m'a fait sourire, on voit que t'es à fond dans ton sport. J'accompagne pas mal de sportifs sur la nutrition et la récup — c'est souvent là que ça se joue niveau perfs. Si tu veux qu'on en parle un jour, fais-moi signe 🙌
+
+**Note technique affichée :**
+LatAm sportifs = WhatsApp et Insta. Ton chaleureux.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+¡Hola [nombre]! 💪 Soy [tu nombre], nos conectamos por [contexto]. Vi que entrenas fuerte y quería contarte: acompaño a deportistas amateurs en nutrición y recuperación, suele ser ahí donde se desbloquean los progresos. Si te apetece que charlemos un día, sin compromiso, dime 🙌
+
+**Version FR :**
+Salut [prénom] ! 💪 Je suis [ton prénom], on s'est connectés sur [contexte]. J'ai vu que tu t'entraînes dur et je voulais te dire : j'accompagne des sportifs amateurs sur la nutrition et la récup, c'est souvent là que ça débloque. Si tu veux qu'on en parle, fais-moi signe 🙌
+
+**Note technique affichée :**
+WhatsApp ES sport : référencer un contexte commun avant de proposer.
+
+---
+
+### PLATEFORME : Facebook Messenger (fb)
+
+**Position : 1 — Kind : first_contact — Label : "Facebook Messenger · Premier contact" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+¡Hola [nombre]! 💪 Vi tu perfil y tu energía deportiva me llamó la atención. Soy coach de bienestar, trabajo bastante con deportistas amateurs sobre nutrición y recuperación. Si un día te apetece intercambiar, sin presión, aquí estoy ✨
+
+**Version FR :**
+Salut [prénom] ! 💪 J'ai vu ton profil et ton énergie sportive m'a marqué. Je suis coach bien-être, je bosse pas mal avec des sportifs amateurs sur la nutrition et la récup. Si un jour t'as envie d'échanger, sans pression, je suis là ✨
+
+**Note technique affichée :**
+FB ES sport : ton chaleureux, contact pro plus posé qu'Insta.
+
+---
+
+## PROFIL : Business (business)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+Hola [nombre],
+Vi que te interesa el [emprendimiento / libertad financiera / desarrollo personal]. Estoy desarrollando un negocio en wellness con equipo internacional, está creciendo fuerte.
+
+¿Te late ver de qué se trata? Sin compromiso, solo una plática de 15 min.
+
+**Version FR :**
+Bonjour [prénom], j'ai vu que tu t'intéressais à [entrepreneuriat / ton secteur]. Je développe un projet bien-être avec une vraie dimension business et je cherche à échanger avec des profils sérieux. Pas de pitch agressif — juste un appel posé si ça te parle. Belle journée ✨
+
+**Note technique affichée :**
+En LatAm, "plática" = conversation décontractée.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : referral — Label : "WhatsApp · Après recommandation" — Lang : 🇲🇽 Español**
+
+**Langue locale (ES) :**
+¡Hola [nombre]! 😊
+Soy [tu nombre], nos conectamos por [contexto]. Te conté que estoy construyendo algo en wellness.
+
+¿Tienes 15 min para que te explique? Sin presión.
+
+**Version FR :**
+Salut [prénom] ! 😊 Je suis [ton prénom], on s'est connectés sur [contexte]. Je voulais qu'on prenne le temps de se reparler comme il faut. Je développe un projet bien-être avec une dimension entrepreneuriale — si t'es curieux, on cale un appel quand tu veux.
+
+**Note technique affichée :**
+Mexique business = WhatsApp obligatoire après 1er contact.
+
+---
+
+# MARCHÉ : Brésil + Portugal (pt)
+
+## PROFIL : Perte de poids Femmes (weight-women)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇧🇷 Português (BR)**
+
+**Langue locale (PT) :**
+Oi [nome]! 👋
+Sou [seu nome], vi seu perfil e gostei muito da sua vibe. Trabalho com pessoas na transformação — emagrecimento, energia.
+
+Você tá mais focada em perder peso, ganhar energia, ou os dois? 🌿
+
+**Version FR :**
+Salut [prénom] ! 👋 Je suis [ton prénom], j'ai vu ton profil et j'ai trouvé ton énergie cool. Je suis coach bien-être, j'accompagne des personnes qui veulent reprendre la main sur leur forme sans tomber dans les régimes restrictifs. Si ça te parle un jour, fais-moi signe ✨
+
+**Note technique affichée :**
+Brésil = top 5 mondial Herbalife. Ton chaleureux obligatoire.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇧🇷 Português (BR)**
+
+**Langue locale (PT) :**
+Oi [nome]! 😊
+Sou [seu nome], a gente se conheceu pelo [contexto]. Você me falou que queria [emagrecer / se sentir melhor].
+
+Tenho um método que funciona muito bem — quer bater um papo de 15 min?
+
+**Version FR :**
+Salut [prénom] ! 😊 Je suis [ton prénom], on s'est connus sur [contexte]. Je voulais te dire bonjour comme il faut. Je bosse dans le coaching bien-être — si t'as envie d'échanger sur tes objectifs forme, je suis là, zéro pression. Bonne journée 🌿
+
+**Note technique affichée :**
+Brésil = WhatsApp obligatoire, langage très chaleureux et personnel.
+
+---
+
+## PROFIL : Perte de poids Hommes (weight-men)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Primeiro contato" — Lang : 🇧🇷 Português (BR)**
+
+**Langue locale (PT) :**
+Oi [nome]!
+
+Vi seu post sobre [detalhe do perfil]. Trabalho com homens em nutrição e voltar à forma — principalmente cutting, energia e recovery quando você junta trampo intenso e treino.
+
+Pergunta rápida: você tá mais focado em cutting, ganho limpo de massa, ou só recuperar energia no dia a dia?
+
+**Version FR :**
+Vu ton post. Coaching nutrition hommes : cutting, énergie, récup. Tu es plutôt cut, bulk propre, ou retrouver de l'énergie ?
+
+**Note technique affichée :**
+BR ton direct mas chaleureux. "Trampo" = boulot, mot oral.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contato direto" — Lang : 🇧🇷 Português (BR)**
+
+**Langue locale (PT) :**
+Oi [nome]! Sou [seu nome], a gente se conheceu no [contexto]. Você me falou de [cutting / energia / treino]. Como tá indo?
+
+**Version FR :**
+Salut, on s'est connus via [contexte]. Tu m'avais parlé de [détail]. Tu en es où ?
+
+**Note technique affichée :**
+BR WhatsApp OBLIGATOIRE après Insta. "A gente" pas "nós".
+
+---
+
+### PLATEFORME : Facebook Messenger (fb)
+
+**Position : 1 — Kind : first_contact — Label : "Facebook Messenger · Primeiro contato" — Lang : 🇧🇷 Português (BR)**
+
+**Langue locale (PT) :**
+Oi [nome], vi seu post no [grupo] sobre [detalhe]. Sou coach nutrição em [cidade], trabalho com homens 30-50 voltando à forma — principalmente quem junta trampo pesado e não quer o corpo ceder.
+
+Você tá onde? Procurando algo específico ou testando?
+
+**Version FR :**
+Coach nutrition à [ville], hommes 30-50 sur la remise en forme. Tu en es où ?
+
+**Note technique affichée :**
+BR FB Messenger plus posé. Groupes "voltar à forma" mine d'or.
+
+---
+
+### PLATEFORME : SMS (sms)
+
+**Position : 1 — Kind : first_contact — Label : "SMS · Curto & posado" — Lang : 🇧🇷 Português (BR)**
+
+**Langue locale (PT) :**
+Oi [nome], é [seu nome]. A gente tinha falado de [contexto]. Se você ainda tá com a ideia de [objetivo], me fala, podemos bater papo essa semana.
+
+**Version FR :**
+Salut, c'est [ton prénom]. On avait parlé de [contexte]. Si tu es toujours sur [objectif], dis-moi.
+
+**Note technique affichée :**
+BR SMS court. "Bater papo" = converser casualement.
+
+---
+
+## PROFIL : Sportif (sport)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇧🇷 Português (BR)**
+
+**Langue locale (PT) :**
+Oi [nome]! 💪
+Adorei seu conteúdo de treino! Trabalho com atletas em nutrição — recuperação, performance, ganho de massa.
+
+Como você cuida da nutrição atualmente?
+
+**Version FR :**
+Salut [prénom] ! 💪 J'ai adoré ton contenu training, on voit que t'es vraiment investi. J'accompagne pas mal de sportifs sur la nutrition et la récup — c'est souvent ce qui fait passer un cap niveau perfs. Si t'as envie qu'on en parle, fais-moi signe 🙌
+
+**Note technique affichée :**
+Brésil sport = très visuel. Mentionner contenu spécifique.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇧🇷 Português (BR)**
+
+**Langue locale (PT) :**
+Oi [nome]! 💪 Sou [seu nome], a gente se conheceu em [contexto]. Vi que você treina firme e quis te dizer: acompanho atletas amadores em nutrição e recuperação, é geralmente ali que o progresso destrava. Se quiser conversar um dia, sem compromisso, me avisa 🙌
+
+**Version FR :**
+Salut [prénom] ! 💪 Je suis [ton prénom], on s'est connus sur [contexte]. J'ai vu que tu t'entraînes dur et je voulais te dire : j'accompagne des athlètes amateurs sur la nutrition et la récup, c'est souvent là que ça débloque. Si tu veux qu'on en parle un jour, fais-moi signe 🙌
+
+**Note technique affichée :**
+WhatsApp PT sport : poser le contexte commun avant tout.
+
+---
+
+## PROFIL : Business (business)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇧🇷 Português (BR)**
+
+**Langue locale (PT) :**
+Oi [nome],
+Vi que você curte [empreendedorismo / liberdade financeira / desenvolvimento pessoal]. Tô construindo um negócio em wellness com equipe internacional, tá crescendo rápido.
+
+Curte ver como funciona? Sem compromisso, só um papo de 15 min.
+
+**Version FR :**
+Salut [prénom], j'ai vu que t'étais dans [entrepreneuriat / ton secteur]. Je développe un projet bien-être avec une vraie dimension business et je cherche des profils sérieux pour échanger. Si ça te parle, on cale un appel posé. Belle journée ✨
+
+**Note technique affichée :**
+Brésil = "papo" = conversation décontractée. Ne pas être trop formel.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : referral — Label : "WhatsApp · Après recommandation" — Lang : 🇧🇷 Português (BR)**
+
+**Langue locale (PT) :**
+Oi [nome]! 😊
+Sou [seu nome], a gente conversou no [contexto]. Você ficou curioso sobre o negócio.
+
+Tem 15 min essa semana pra eu te explicar? Sem compromisso.
+
+**Version FR :**
+Salut [prénom] ! 😊 Je suis [ton prénom], on s'est connus via [contexte]. Je voulais reprendre contact comme il faut. Je développe un projet bien-être avec une dimension entrepreneuriale — si t'es curieux, on prend 15 min en visio quand tu veux.
+
+**Note technique affichée :**
+Brésil ultra-personnel. Toujours "a gente" plutôt que "nós".
+
+---
+
+# MARCHÉ : Turquie + DE (tr)
+
+## PROFIL : Perte de poids Femmes (weight-women)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇹🇷 Türkçe**
+
+**Langue locale (TR) :**
+Selam [isim] 👋
+Profilini gördüm, enerjini sevdim! Beslenme danışmanıyım — kilo verme, enerji, vücut form.
+
+Senin önceliğin daha çok kilo vermek mi, enerjik hissetmek mi, yoksa ikisi de mi? 🌿
+
+**Version FR :**
+Salut [prénom] 👋 J'ai vu ton profil et j'ai trouvé ton énergie cool. Je suis coach bien-être, j'accompagne des personnes qui veulent retrouver la forme sans régime extrême. Si ça te parle un jour, fais-moi signe — zéro pression ✨
+
+**Note technique affichée :**
+Turquie marché chaud Herbalife. Aussi diaspora turque en Allemagne (5M).
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇹🇷 Türkçe**
+
+**Langue locale (TR) :**
+Selam [isim]! 😊
+Ben [adın], [bağlam] üzerinden tanışmıştık. Sen bana [kilo verme / enerji] istediğini söylemiştin.
+
+15 dakika konuşalım mı? Test edilmiş bir metodum var.
+
+**Version FR :**
+Salut [prénom] ! 😊 Je suis [ton prénom], on s'est connectés sur [contexte]. Je voulais te dire bonjour comme il faut. Je bosse dans le coaching bien-être — si t'as envie d'en discuter, je suis dispo. Bonne journée 🌿
+
+**Note technique affichée :**
+Turquie : WhatsApp dominant. Style direct mais chaleureux.
+
+---
+
+## PROFIL : Perte de poids Hommes (weight-men)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · İlk iletişim" — Lang : 🇹🇷 Türkçe**
+
+**Langue locale (TR) :**
+Selam [isim],
+
+[Profilde detay] hakkındaki paylaşımını gördüm. Erkeklerle beslenme ve forma girme üzerine çalışıyorum — özellikle yoğun iş ve spor birleştiğinde yağ yakımı, enerji ve toparlanma.
+
+Kısa soru: daha çok yağ yakımı, temiz kas kazanımı, yoksa günlük enerjini geri kazanma hedefi mi?
+
+**Version FR :**
+Vu ton post. Coaching nutrition hommes : cut, énergie, récup. Tu es plutôt cut, bulk propre, ou retrouver de l'énergie ?
+
+**Note technique affichée :**
+TR ton direct mais respectueux. "Wellness" terimini koru ama "yumuşak" tonu evite.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Doğrudan iletişim" — Lang : 🇹🇷 Türkçe**
+
+**Langue locale (TR) :**
+Selam [isim]! Ben [adın], [bağlam] üzerinden tanışmıştık. Bana [yağ yakımı / enerji / spor] hakkında konuşmuştun. Nasıl gidiyor?
+
+**Version FR :**
+Salut, on s'est connectés via [contexte]. Tu m'avais parlé de [détail]. Tu en es où ?
+
+**Note technique affichée :**
+TR WhatsApp dominant après contact initial. Ton direct.
+
+---
+
+### PLATEFORME : Facebook Messenger (fb)
+
+**Position : 1 — Kind : first_contact — Label : "Facebook Messenger · İlk iletişim" — Lang : 🇹🇷 Türkçe**
+
+**Langue locale (TR) :**
+Merhaba [isim], [grup adı] grubundaki [detay] paylaşımını gördüm. [Şehir]'de beslenme koçuyum, 30-50 yaş erkeklerle forma girme üzerine çalışıyorum — özellikle yoğun bir iş tempolu ve vücudunun pes etmesini istemeyenlerle.
+
+Sen nerede duruyorsun? Belirli bir şey mi arıyorsun yoksa rastgele mi deniyorsun?
+
+**Version FR :**
+Coach nutrition, 30-50 hommes, remise en forme. Tu en es où ?
+
+**Note technique affichée :**
+TR FB Messenger plus posé. "Forma girme erkek" grupları mine d'or.
+
+---
+
+### PLATEFORME : SMS (sms)
+
+**Position : 1 — Kind : first_contact — Label : "SMS · Kısa ve sakin" — Lang : 🇹🇷 Türkçe**
+
+**Langue locale (TR) :**
+Selam [isim], ben [adın]. [Bağlam] üzerinde konuşmuştuk. [Hedef] fikrinde hâlâ varsan, söyle, bu hafta konuşabiliriz.
+
+**Version FR :**
+Salut, c'est [ton prénom]. On avait parlé de [contexte]. Si tu es toujours sur [objectif], dis-moi.
+
+**Note technique affichée :**
+TR SMS kısa, emoji yok. "Gerçek bir kişi" hissi.
+
+---
+
+## PROFIL : Sportif (sport)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇹🇷 Türkçe**
+
+**Langue locale (TR) :**
+Selam [isim] 💪
+Profilin harika ([detay] paylaşımına bayıldım!). Sporcularla çalışıyorum — toparlanma, performans, kas kazanımı.
+
+Şu an beslenme tarafında nasıl bir yaklaşımın var?
+
+**Version FR :**
+Salut [prénom] 💪 Ton profil est top, on voit que t'es à fond dans ton sport. J'accompagne pas mal de sportifs sur la nutrition et la récup — c'est souvent là que ça se joue. Si tu veux qu'on en parle, fais-moi signe 🙌
+
+**Note technique affichée :**
+Pour Allemagne diaspora turque, idem (turc langue maison).
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇹🇷 Türkçe**
+
+**Langue locale (TR) :**
+Selam [isim]! 💪 Ben [adın], [bağlam] üzerinden tanışmıştık. Profilinde antrenmanlarına çok yatırım yaptığını gördüm. Amatör sporculara beslenme ve toparlanma konusunda eşlik ediyorum — performans genelde orada açılıyor. Konuşmak istersen, baskı yok, haber ver 🙌
+
+**Version FR :**
+Salut [prénom] ! 💪 Je suis [ton prénom], on s'est connus via [contexte]. J'ai vu que tu t'investis à fond dans ton entraînement. J'accompagne des sportifs amateurs sur la nutrition et la récup — les perfs se débloquent souvent là. Si tu veux qu'on échange, fais-moi signe 🙌
+
+**Note technique affichée :**
+WhatsApp TR sport : poser le contexte avant la proposition.
+
+---
+
+## PROFIL : Business (business)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇹🇷 Türkçe**
+
+**Langue locale (TR) :**
+Selam [isim],
+Profilini gördüm, [girişimcilik / kişisel gelişim / finansal özgürlük] ile ilgilendiğini fark ettim. Uluslararası bir ekiple wellness sektöründe iş büyütüyorum.
+
+Zoom'da 20 dakika sohbet eder misin? Hiçbir baskı yok.
+
+**Version FR :**
+Salut [prénom], j'ai vu ton profil et ton parcours m'intéresse. Je développe un projet bien-être avec une vraie dimension entrepreneuriale et je cherche des profils sérieux pour échanger. Si ça te parle, on cale un appel. Belle journée ✨
+
+**Note technique affichée :**
+Turquie business : LinkedIn moins utilisé, préférer Insta DM ou WhatsApp.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇹🇷 Türkçe**
+
+**Langue locale (TR) :**
+Selam [isim]! 😊 Ben [adın], [bağlam] üzerinden tanışmıştık. Tekrar düzgün bir şekilde merhaba demek istedim. Wellness alanında ciddi bir girişim projesi yürütüyorum ve ciddi profillerle konuşmak istiyorum. İlgini çekerse, baskısız bir şekilde 15 dakikalık bir görüşme ayarlayabiliriz.
+
+**Version FR :**
+Salut [prénom] ! 😊 Je suis [ton prénom], on s'est connus via [contexte]. Je voulais reprendre contact comme il faut. Je développe un projet sérieux dans le bien-être avec une dimension entrepreneuriale et je cherche à échanger avec des profils sérieux. Si ça t'intéresse, on cale 15 min sans pression.
+
+**Note technique affichée :**
+WhatsApp TR business : ton respectueux, le "ciddi" (sérieux) rassure.
+
+---
+
+# MARCHÉ : Inde (hi)
+
+## PROFIL : Perte de poids Femmes (weight-women)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇮🇳 Hinglish / English**
+
+**Langue locale (HI) :**
+Hi [name] 👋
+Main [your name] hu, aapka profile dekha aur achha laga. Main nutrition consultant hu — weight loss, energy boost mein madad karti hu.
+
+Aapka focus weight loss pe hai, energy pe hai, ya dono pe? 🌿
+
+**Version FR :**
+Salut [prénom] 👋 Je suis [ton prénom], j'ai vu ton profil. Je suis coach bien-être, j'accompagne des personnes qui veulent retrouver la forme sans régime extrême. Si ça te parle un jour, fais-moi signe — sans pression ✨
+
+**Note technique affichée :**
+Inde : la classe moyenne aisée écrit en Hinglish (Hindi en Latin) sur Insta/WhatsApp. Évite Devanagari sauf si profil le justifie.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Contact direct" — Lang : 🇮🇳 Hinglish / English**
+
+**Langue locale (HI) :**
+Hi [name]! 😊
+Main [your name], hum [context] mein mile the. Aapne mujhe bataya tha ki aap [weight loss / better energy] chahti hain.
+
+Mera ek tested method hai — 15 min ki call karenge?
+
+**Version FR :**
+Salut [prénom] ! 😊 Je suis [ton prénom], on s'est connectés sur [contexte]. Je voulais te dire bonjour comme il faut. Je bosse dans le coaching bien-être — si t'as envie d'échanger sur tes objectifs, je suis là. Bonne journée 🌿
+
+**Note technique affichée :**
+WhatsApp est LE canal numéro 1 en Inde (700M+ users).
+
+---
+
+## PROFIL : Perte de poids Hommes (weight-men)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · First contact" — Lang : 🇮🇳 Hinglish**
+
+**Langue locale (HI) :**
+Hi [name],
+
+Maine [profile detail] pe tera post dekha. Main men ke saath nutrition aur back-in-shape ke upar kaam karta hu — mostly fat loss, energy aur recovery jab work intense ho aur training bhi.
+
+Quick question — tu zyada fat loss pe hai, lean bulk pe, ya sirf daily energy wapas paana chahta hai?
+
+**Version FR :**
+Vu ton post. Coaching nutrition hommes : cut, énergie, récup. Tu es plutôt cut, bulk propre, ou retrouver de l'énergie ?
+
+**Note technique affichée :**
+Hinglish naturel pour Inde DM. Anglais technique + hindi conversationnel mélangé.
+
+---
+
+### PLATEFORME : WhatsApp (whatsapp)
+
+**Position : 1 — Kind : first_contact — Label : "WhatsApp · Direct contact" — Lang : 🇮🇳 Hinglish**
+
+**Langue locale (HI) :**
+Hi [name]! Main [your name], hum [context] pe connect hue the. Tune mujhe [fat loss / energy / training] ke baare mein bola tha. Kaisa chal raha hai?
+
+**Version FR :**
+Salut, on s'est connectés via [contexte]. Tu m'avais parlé de [détail]. Tu en es où ?
+
+**Note technique affichée :**
+WhatsApp #1 channel Inde (700M users). Hinglish chaleureux.
+
+---
+
+### PLATEFORME : Facebook Messenger (fb)
+
+**Position : 1 — Kind : first_contact — Label : "Facebook Messenger · First contact" — Lang : 🇮🇳 Hinglish**
+
+**Langue locale (HI) :**
+Hi [name], [group name] mein tera post dekha [detail] ke baare mein. Main nutrition coach hu [city] mein, 30-50 men ke saath back-in-shape pe kaam karta hu — especially jo demanding job + training combine karte hai aur nahi chahte body crash ho.
+
+Tu kahaan hai? Specific kuch dhundh raha hai ya experiment kar raha hai?
+
+**Version FR :**
+Coach nutrition, 30-50 hommes, remise en forme. Tu en es où ?
+
+**Note technique affichée :**
+FB Messenger Inde, ton plus posé. Groupes "men's fitness India" mine d'or.
+
+---
+
+### PLATEFORME : SMS (sms)
+
+**Position : 1 — Kind : first_contact — Label : "SMS · Short & grounded" — Lang : 🇮🇳 Hinglish**
+
+**Langue locale (HI) :**
+Hi [name], main [your name]. Hum [context] ke baare mein baat kiye the. Agar tu abhi bhi [goal] pe hai, bata, is hafte baat kar sakte hai.
+
+**Version FR :**
+Salut, c'est [ton prénom]. On avait parlé de [contexte]. Si tu es toujours sur [objectif], dis-moi.
+
+**Note technique affichée :**
+SMS Hinglish court, "real person" feel.
+
+---
+
+## PROFIL : Sportif (sport)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇮🇳 Hinglish / English**
+
+**Langue locale (HI) :**
+Hey [name] 💪
+Loved your training content! I help athletes with nutrition — recovery, performance, gains. Specially crafted for desi athletes.
+
+What's your current approach on the food/supplements side?
+
+**Version FR :**
+Hey [prénom] 💪 J'ai adoré ton contenu training. J'accompagne pas mal de sportifs sur la nutrition et la récup — c'est souvent ce qui débloque les perfs. Si t'as envie qu'on en parle, fais-moi signe 🙌
+
+**Note technique affichée :**
+Athlètes indiens lisent EN. Mentionner "desi" rassure sur la culture.
+
+---
+
+## PROFIL : Business (business)
+
+### PLATEFORME : Instagram (insta)
+
+**Position : 1 — Kind : first_contact — Label : "Instagram DM · Premier contact" — Lang : 🇮🇳 Hinglish / English**
+
+**Langue locale (HI) :**
+Hi [name],
+Saw your profile and your work in [their field] looks great. I'm building a wellness business with an international team — solid income, flexible hours.
+
+Open to a 15-min Zoom call to see how it works? No commitment.
+
+**Version FR :**
+Salut [prénom], j'ai vu ton profil et ton travail m'intéresse. Je développe un projet bien-être avec une dimension entrepreneuriale et je cherche des profils sérieux pour échanger. Si ça te parle, on cale un appel posé. Belle journée ✨
+
+**Note technique affichée :**
+Inde business : anglais corporate. WhatsApp Business très utilisé.
+
+---
+
+# CASES VIDES
+
+Liste exhaustive des combinaisons marché × profil × plateforme sans aucun script seedé (104 cases).
+
+## France (fr)
+
+- France × Perte de poids Femmes × Telegram → ABSENT
+- France × Perte de poids Femmes × LinkedIn → ABSENT
+- France × Perte de poids Femmes × TikTok → ABSENT
+- France × Perte de poids Hommes × Telegram → ABSENT
+- France × Perte de poids Hommes × LinkedIn → ABSENT
+- France × Sportif × Facebook Messenger → ABSENT
+- France × Sportif × Telegram → ABSENT
+- France × Sportif × LinkedIn → ABSENT
+- France × Sportif × SMS → ABSENT
+- France × Sportif × TikTok → ABSENT
+- France × Business × Facebook Messenger → ABSENT
+- France × Business × Telegram → ABSENT
+- France × Business × SMS → ABSENT
+- France × Business × TikTok → ABSENT
+
+## International (en)
+
+- International × Perte de poids Femmes × Facebook Messenger → ABSENT
+- International × Perte de poids Femmes × Telegram → ABSENT
+- International × Perte de poids Femmes × LinkedIn → ABSENT
+- International × Perte de poids Femmes × TikTok → ABSENT
+- International × Perte de poids Hommes × Telegram → ABSENT
+- International × Perte de poids Hommes × LinkedIn → ABSENT
+- International × Perte de poids Hommes × TikTok → ABSENT
+- International × Sportif × Facebook Messenger → ABSENT
+- International × Sportif × Telegram → ABSENT
+- International × Sportif × LinkedIn → ABSENT
+- International × Sportif × SMS → ABSENT
+- International × Sportif × TikTok → ABSENT
+- International × Business × Facebook Messenger → ABSENT
+- International × Business × WhatsApp → ABSENT
+- International × Business × Telegram → ABSENT
+- International × Business × SMS → ABSENT
+- International × Business × TikTok → ABSENT
+
+## LatAm + Espagne (es)
+
+- LatAm × Perte de poids Femmes × Facebook Messenger → ABSENT
+- LatAm × Perte de poids Femmes × Telegram → ABSENT
+- LatAm × Perte de poids Femmes × LinkedIn → ABSENT
+- LatAm × Perte de poids Femmes × SMS → ABSENT
+- LatAm × Perte de poids Femmes × TikTok → ABSENT
+- LatAm × Perte de poids Hommes × Telegram → ABSENT
+- LatAm × Perte de poids Hommes × LinkedIn → ABSENT
+- LatAm × Perte de poids Hommes × TikTok → ABSENT
+- LatAm × Sportif × Telegram → ABSENT
+- LatAm × Sportif × LinkedIn → ABSENT
+- LatAm × Sportif × SMS → ABSENT
+- LatAm × Sportif × TikTok → ABSENT
+- LatAm × Business × Facebook Messenger → ABSENT
+- LatAm × Business × Telegram → ABSENT
+- LatAm × Business × LinkedIn → ABSENT
+- LatAm × Business × SMS → ABSENT
+- LatAm × Business × TikTok → ABSENT
+
+## Brésil + Portugal (pt)
+
+- Brésil × Perte de poids Femmes × Facebook Messenger → ABSENT
+- Brésil × Perte de poids Femmes × Telegram → ABSENT
+- Brésil × Perte de poids Femmes × LinkedIn → ABSENT
+- Brésil × Perte de poids Femmes × SMS → ABSENT
+- Brésil × Perte de poids Femmes × TikTok → ABSENT
+- Brésil × Perte de poids Hommes × Telegram → ABSENT
+- Brésil × Perte de poids Hommes × LinkedIn → ABSENT
+- Brésil × Perte de poids Hommes × TikTok → ABSENT
+- Brésil × Sportif × Facebook Messenger → ABSENT
+- Brésil × Sportif × Telegram → ABSENT
+- Brésil × Sportif × LinkedIn → ABSENT
+- Brésil × Sportif × SMS → ABSENT
+- Brésil × Sportif × TikTok → ABSENT
+- Brésil × Business × Facebook Messenger → ABSENT
+- Brésil × Business × Telegram → ABSENT
+- Brésil × Business × LinkedIn → ABSENT
+- Brésil × Business × SMS → ABSENT
+- Brésil × Business × TikTok → ABSENT
+
+## Turquie + DE (tr)
+
+- Turquie × Perte de poids Femmes × Facebook Messenger → ABSENT
+- Turquie × Perte de poids Femmes × Telegram → ABSENT
+- Turquie × Perte de poids Femmes × LinkedIn → ABSENT
+- Turquie × Perte de poids Femmes × SMS → ABSENT
+- Turquie × Perte de poids Femmes × TikTok → ABSENT
+- Turquie × Perte de poids Hommes × Telegram → ABSENT
+- Turquie × Perte de poids Hommes × LinkedIn → ABSENT
+- Turquie × Perte de poids Hommes × TikTok → ABSENT
+- Turquie × Sportif × Facebook Messenger → ABSENT
+- Turquie × Sportif × Telegram → ABSENT
+- Turquie × Sportif × LinkedIn → ABSENT
+- Turquie × Sportif × SMS → ABSENT
+- Turquie × Sportif × TikTok → ABSENT
+- Turquie × Business × Facebook Messenger → ABSENT
+- Turquie × Business × Telegram → ABSENT
+- Turquie × Business × LinkedIn → ABSENT
+- Turquie × Business × SMS → ABSENT
+- Turquie × Business × TikTok → ABSENT
+
+## Inde (hi)
+
+- Inde × Perte de poids Femmes × Facebook Messenger → ABSENT
+- Inde × Perte de poids Femmes × Telegram → ABSENT
+- Inde × Perte de poids Femmes × LinkedIn → ABSENT
+- Inde × Perte de poids Femmes × SMS → ABSENT
+- Inde × Perte de poids Femmes × TikTok → ABSENT
+- Inde × Perte de poids Hommes × Telegram → ABSENT
+- Inde × Perte de poids Hommes × LinkedIn → ABSENT
+- Inde × Perte de poids Hommes × TikTok → ABSENT
+- Inde × Sportif × Facebook Messenger → ABSENT
+- Inde × Sportif × WhatsApp → ABSENT
+- Inde × Sportif × Telegram → ABSENT
+- Inde × Sportif × LinkedIn → ABSENT
+- Inde × Sportif × SMS → ABSENT
+- Inde × Sportif × TikTok → ABSENT
+- Inde × Business × Facebook Messenger → ABSENT
+- Inde × Business × WhatsApp → ABSENT
+- Inde × Business × Telegram → ABSENT
+- Inde × Business × LinkedIn → ABSENT
+- Inde × Business × SMS → ABSENT
+- Inde × Business × TikTok → ABSENT

--- a/src/components/prospection/ProspectionHub.tsx
+++ b/src/components/prospection/ProspectionHub.tsx
@@ -824,26 +824,40 @@ function ReplyModule({
     <>
       {nodes.map((n) => {
         const meta = branchLabel[n.branch] ?? { pill: n.branch, emoji: "·", cls: "maybe" };
-        const body = marketCode !== "fr" && n.body_fr ? n.body_fr : n.body;
-        const isWarm = meta.cls === "warm";
         return (
-          <article key={n.id} className={`ph-tree-branch${isWarm ? " warm-branch" : ""}`}>
-            <div className="reaction">
-              <span>{meta.emoji} Il / elle réagit</span>
-              <span className={`pill ${meta.cls}`}>{meta.pill}</span>
-              <span style={{ marginLeft: "auto", fontFamily: "var(--hub-f-mono)", fontSize: 9.5, color: "var(--hub-muted)" }}>{n.level}</span>
-            </div>
-            <q>{n.tip ?? "—"}</q>
-            <div className="reply">{renderScriptBody(body)}</div>
-            <div className="actions">
-              <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
-                <span className="ic">⌘C</span>Copier
-              </button>
-            </div>
-          </article>
+          <ReplyBranchCard key={n.id} node={n} meta={meta} marketCode={marketCode} onCopy={onCopy} />
         );
       })}
     </>
+  );
+}
+
+function ReplyBranchCard({
+  node, meta, marketCode, onCopy,
+}: {
+  node: ProspectionReplyNode;
+  meta: { pill: string; emoji: string; cls: string };
+  marketCode: string;
+  onCopy: (t: string) => void;
+}) {
+  const { body, toggle } = useBodyToggle(node.body, node.body_fr, marketCode);
+  const isWarm = meta.cls === "warm";
+  return (
+    <article className={`ph-tree-branch${isWarm ? " warm-branch" : ""}`}>
+      <div className="reaction">
+        <span>{meta.emoji} Il / elle réagit</span>
+        <span className={`pill ${meta.cls}`}>{meta.pill}</span>
+        <span style={{ marginLeft: "auto", fontFamily: "var(--hub-f-mono)", fontSize: 9.5, color: "var(--hub-muted)" }}>{node.level}</span>
+        {toggle}
+      </div>
+      <q>{node.tip ?? "—"}</q>
+      <div className="reply">{renderScriptBody(body)}</div>
+      <div className="actions">
+        <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
+          <span className="ic">⌘C</span>Copier
+        </button>
+      </div>
+    </article>
   );
 }
 
@@ -853,46 +867,55 @@ function ObjectionsModule({
   if (items.length === 0) return <Empty>Aucune objection pour ce marché.</Empty>;
   return (
     <>
-      {items.map((o, i) => {
-        const goodBody = marketCode !== "fr" && o.good_response_fr ? o.good_response_fr : o.good_response;
-        return (
-          <div key={o.id} className="ph-obj">
-            <div className="quote">
-              <div className="n">{String(i + 1).padStart(2, "0")}<small>{o.slug}</small></div>
-              <q>{o.title}</q>
-            </div>
-            <div className="ph-obj-row bad">
-              <span className="badge">✕</span>
-              <div>
-                <div className="lbl">À ne pas dire</div>
-                <p>{o.bad_response}</p>
-              </div>
-            </div>
-            <div className="ph-obj-row good">
-              <span className="badge">✓</span>
-              <div>
-                <div className="lbl">Ce qui ouvre</div>
-                <p>{renderScriptBody(goodBody)}</p>
-              </div>
-            </div>
-            {o.warning && (
-              <div className="ph-obj-row bad" style={{ marginTop: 6 }}>
-                <span className="badge">!</span>
-                <div>
-                  <div className="lbl" style={{ color: "var(--hub-accent-dark)" }}>Attention</div>
-                  <p style={{ color: "var(--hub-text)", textDecoration: "none" }}>{o.warning}</p>
-                </div>
-              </div>
-            )}
-            <div className="ph-obj-actions">
-              <button className="ph-btn copy" type="button" onClick={() => onCopy(goodBody)}>
-                <span className="ic">⌘C</span>Copier la réponse
-              </button>
-            </div>
-          </div>
-        );
-      })}
+      {items.map((o, i) => (
+        <ObjectionCard key={o.id} objection={o} idx={i} marketCode={marketCode} onCopy={onCopy} />
+      ))}
     </>
+  );
+}
+
+function ObjectionCard({
+  objection: o, idx: i, marketCode, onCopy,
+}: { objection: ProspectionObjection; idx: number; marketCode: string; onCopy: (t: string) => void }) {
+  const { body: goodBody, toggle } = useBodyToggle(o.good_response, o.good_response_fr, marketCode);
+  return (
+    <div className="ph-obj">
+      <div className="quote">
+        <div className="n">{String(i + 1).padStart(2, "0")}<small>{o.slug}</small></div>
+        <q>{o.title}</q>
+      </div>
+      <div className="ph-obj-row bad">
+        <span className="badge">✕</span>
+        <div>
+          <div className="lbl">À ne pas dire</div>
+          <p>{o.bad_response}</p>
+        </div>
+      </div>
+      <div className="ph-obj-row good">
+        <span className="badge">✓</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+            <div className="lbl">Ce qui ouvre</div>
+            {toggle}
+          </div>
+          <p>{renderScriptBody(goodBody)}</p>
+        </div>
+      </div>
+      {o.warning && (
+        <div className="ph-obj-row bad" style={{ marginTop: 6 }}>
+          <span className="badge">!</span>
+          <div>
+            <div className="lbl" style={{ color: "var(--hub-accent-dark)" }}>Attention</div>
+            <p style={{ color: "var(--hub-text)", textDecoration: "none" }}>{o.warning}</p>
+          </div>
+        </div>
+      )}
+      <div className="ph-obj-actions">
+        <button className="ph-btn copy" type="button" onClick={() => onCopy(goodBody)}>
+          <span className="ic">⌘C</span>Copier la réponse
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -903,25 +926,34 @@ function PostCallModule({
   if (postCall.length === 0) return <Empty>Pas de séquence post-appel pour ce marché.</Empty>;
   return (
     <div className="ph-timeline">
-      {postCall.map((f, idx) => {
-        const state = idx === 0 ? "now" : "future";
-        const body = marketCode !== "fr" && f.body_fr ? f.body_fr : f.body;
-        return (
-          <div key={f.id} className={`ph-t-step ${state}`}>
-            <div className="when">{f.title}</div>
-            <h4>Touche {idx + 1}</h4>
-            <div className="msg">{renderScriptBody(body)}</div>
-            <div style={{ marginTop: 8, display: "flex", gap: 6 }}>
-              <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
-                <span className="ic">⌘C</span>Copier
-              </button>
-              {f.warning && (
-                <span style={{ fontFamily: "var(--hub-f-mono)", fontSize: 10, color: "var(--hub-accent-dark)", alignSelf: "center" }}>⚠ {f.warning}</span>
-              )}
-            </div>
-          </div>
-        );
-      })}
+      {postCall.map((f, idx) => (
+        <FollowupStep key={f.id} followup={f} idx={idx} marketCode={marketCode} onCopy={onCopy} />
+      ))}
+    </div>
+  );
+}
+
+function FollowupStep({
+  followup: f, idx, marketCode, onCopy,
+}: { followup: ProspectionFollowup; idx: number; marketCode: string; onCopy: (t: string) => void }) {
+  const { body, toggle } = useBodyToggle(f.body, f.body_fr, marketCode);
+  const state = idx === 0 ? "now" : "future";
+  return (
+    <div className={`ph-t-step ${state}`}>
+      <div className="when" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span>{f.title}</span>
+        {toggle}
+      </div>
+      <h4>Touche {idx + 1}</h4>
+      <div className="msg">{renderScriptBody(body)}</div>
+      <div style={{ marginTop: 8, display: "flex", gap: 6 }}>
+        <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
+          <span className="ic">⌘C</span>Copier
+        </button>
+        {f.warning && (
+          <span style={{ fontFamily: "var(--hub-f-mono)", fontSize: 10, color: "var(--hub-accent-dark)", alignSelf: "center" }}>⚠ {f.warning}</span>
+        )}
+      </div>
     </div>
   );
 }
@@ -954,22 +986,44 @@ function ClosingModule({
           </div>
         </div>
       )}
-      {scripts.map((s) => {
-        const body = marketCode !== "fr" && s.body_fr ? s.body_fr : s.body;
-        return (
-          <article key={s.id} className="ph-close-script">
-            <h4>{s.title ?? scriptTitle[s.kind] ?? s.kind}</h4>
-            {scriptCtx[s.kind] && <div className="ctx">{scriptCtx[s.kind]}</div>}
-            <p>{renderScriptBody(body)}</p>
-            <div style={{ marginTop: 10, display: "flex", gap: 6 }}>
-              <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
-                <span className="ic">⌘C</span>Copier
-              </button>
-            </div>
-          </article>
-        );
-      })}
+      {scripts.map((s) => (
+        <CloseScriptCard
+          key={s.id}
+          script={s}
+          marketCode={marketCode}
+          title={s.title ?? scriptTitle[s.kind] ?? s.kind}
+          ctx={scriptCtx[s.kind]}
+          onCopy={onCopy}
+        />
+      ))}
     </>
+  );
+}
+
+function CloseScriptCard({
+  script: s, marketCode, title, ctx, onCopy,
+}: {
+  script: ProspectionClosingBlock;
+  marketCode: string;
+  title: string;
+  ctx?: string;
+  onCopy: (t: string) => void;
+}) {
+  const { body, toggle } = useBodyToggle(s.body, s.body_fr, marketCode);
+  return (
+    <article className="ph-close-script">
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 8 }}>
+        <h4>{title}</h4>
+        {toggle}
+      </div>
+      {ctx && <div className="ctx">{ctx}</div>}
+      <p>{renderScriptBody(body)}</p>
+      <div style={{ marginTop: 10, display: "flex", gap: 6 }}>
+        <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
+          <span className="ic">⌘C</span>Copier
+        </button>
+      </div>
+    </article>
   );
 }
 
@@ -1002,17 +1056,34 @@ function SpecialCasesModule({
         ))}
       </div>
       {active && (
-        <article className="ph-close-script">
-          <h4>{active.title}</h4>
-          <p>{renderScriptBody(marketCode !== "fr" && active.body_fr ? active.body_fr : active.body)}</p>
-          <div style={{ marginTop: 10, display: "flex", gap: 6 }}>
-            <button className="ph-btn copy" type="button" onClick={() => onCopy(active.body)}>
-              <span className="ic">⌘C</span>Copier
-            </button>
-          </div>
-        </article>
+        <SpecialCaseCard
+          key={active.id}
+          item={active}
+          marketCode={marketCode}
+          onCopy={onCopy}
+        />
       )}
     </>
+  );
+}
+
+function SpecialCaseCard({
+  item, marketCode, onCopy,
+}: { item: ProspectionSpecialCase; marketCode: string; onCopy: (t: string) => void }) {
+  const { body, toggle } = useBodyToggle(item.body, item.body_fr, marketCode);
+  return (
+    <article className="ph-close-script">
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 8 }}>
+        <h4>{item.title}</h4>
+        {toggle}
+      </div>
+      <p>{renderScriptBody(body)}</p>
+      <div style={{ marginTop: 10, display: "flex", gap: 6 }}>
+        <button className="ph-btn copy" type="button" onClick={() => onCopy(body)}>
+          <span className="ic">⌘C</span>Copier
+        </button>
+      </div>
+    </article>
   );
 }
 
@@ -1178,6 +1249,42 @@ function FnRow({ lab, v, pct }: { lab: string; v: number; pct: number }) {
 // ────────────────────────────────────────────────────────────
 // Helpers
 // ────────────────────────────────────────────────────────────
+
+/**
+ * Hook : toggle Natif ↔ FR pour les modules qui exposent un body à
+ * copier-coller (scripts envoyés au prospect).
+ *
+ * - Sur marché FR : pas de toggle, juste le body natif (= FR).
+ * - Sur marché non-FR sans body_fr : pas de toggle, juste le natif.
+ * - Sur marché non-FR avec body_fr : toggle segmented inline.
+ *   Par défaut on affiche le NATIF (c'est ce que le coach copie pour
+ *   envoyer au prospect). FR = vérification de compréhension.
+ *
+ * Retourne le body courant + le node JSX du toggle (à insérer où on veut).
+ */
+function useBodyToggle(native: string, fr: string | null, marketCode: string): {
+  body: string;
+  toggle: ReactNode;
+} {
+  const [lang, setLang] = useState<"native" | "fr">("native");
+  const hasToggle = marketCode !== "fr" && !!fr && fr.trim().length > 0;
+  const body = hasToggle && lang === "fr" ? (fr as string) : native;
+  if (!hasToggle) return { body, toggle: null };
+  return {
+    body,
+    toggle: (
+      <div className="ph-lang-switch" style={{ marginLeft: "auto", flexShrink: 0 }}>
+        <button type="button" className={lang === "native" ? "on" : ""} onClick={() => setLang("native")}>
+          {marketCode.toUpperCase()}
+        </button>
+        <button type="button" className={lang === "fr" ? "on" : ""} onClick={() => setLang("fr")}>
+          FR
+        </button>
+      </div>
+    ),
+  };
+}
+
 function Caret() {
   return (
     <svg className="caret" viewBox="0 0 12 12" fill="none">

--- a/supabase/migrations/20261119210000_prospection_v5_scripts_clean.sql
+++ b/supabase/migrations/20261119210000_prospection_v5_scripts_clean.sql
@@ -1,0 +1,881 @@
+-- =============================================================================
+-- Chantier #3 V5 — Seed scripts CLEAN (2026-05-20)
+--
+-- Remplace TOUS les scripts existants par le seed définitif Thomas
+-- (« 3 corrections cœur » : zéro pitch en M1, zéro "sans pression",
+-- zéro demande de Zoom en M1, finir sur question ouverte qualifiante).
+--
+-- Audit avait montré 67 scripts défectueux (pitch en M1, formules MLM)
+-- + bug du guard count()=0 qui skippait 10 scripts FR sur la précédente
+-- migration. Reset complet ici.
+--
+-- Spec finale :
+--   - 6 marchés × 4 profils × 5 plateformes M1 = 120
+--   - + business × linkedin × 6 marchés = 6
+--   - = 126 scripts position=1 (kind=first_contact)
+--   - + relances J+3 (position=2, kind=j3_followup) :
+--     · weight-women + weight-men = relance "poids" identique
+--     · sport, business = relances dédiées
+--     · stockée avec platform='insta' (utilisable Insta/FB/WhatsApp)
+--     · 4 profils × 6 marchés = 24 scripts position=2
+--   - = TOTAL 150 scripts.
+--
+-- Telegram exclu volontairement. LinkedIn uniquement sur business.
+-- ES + PT marqués needs_native_review (à valider par natif avant prod).
+-- =============================================================================
+
+begin;
+
+-- ─── 1. Schema : colonne needs_native_review + extension contrainte CHECK ──
+alter table public.prospection_scripts
+  add column if not exists needs_native_review boolean not null default false;
+
+comment on column public.prospection_scripts.needs_native_review is
+  'Chantier #3 V5 — true si le script doit être relu par un natif avant exposition prod. ES + PT ont besoin de validation par natif (registre mexicain / 100 % brésilien).';
+
+-- ─── 2. Wipe existant + contrainte unique (market × profile × platform × position) ─
+delete from public.prospection_scripts;
+
+alter table public.prospection_scripts
+  drop constraint if exists prospection_scripts_unique_combo;
+alter table public.prospection_scripts
+  add constraint prospection_scripts_unique_combo
+  unique (market_code, profile_slug, platform, position);
+
+-- ─── 3. Helpers : function de upsert plus lisible ─────────────────────────
+-- (utilisée pour les INSERT ON CONFLICT DO UPDATE)
+-- Pour rester idempotent et permettre re-run sans erreur.
+
+-- ============================================================================
+-- INSERTS M1 (position=1, kind=first_contact)
+-- ============================================================================
+
+-- ─── 🇫🇷 FRANCE ───────────────────────────────────────────────────────────
+insert into public.prospection_scripts
+  (market_code, profile_slug, platform, position, kind, label, language_label, body, body_fr, tip, needs_native_review) values
+
+-- FR weight-women
+('fr','weight-women','insta',1,'first_contact','Instagram DM · Premier contact','🇫🇷 Français',
+ E'Salut [prénom] 👋 Je suis tombée sur ton profil et [détail vu sur son profil] m''a parlé. On a des points communs côté healthy. Tu es plutôt sur un objectif perte de poids, énergie au quotidien, ou les deux en ce moment ?',
+ null,
+ E'Personnalise [détail vu sur son profil]. Pas de lien dans le 1er message (filtre spam).', false),
+
+('fr','weight-women','fb',1,'first_contact','Facebook Messenger · Premier contact','🇫🇷 Français',
+ E'Bonjour [prénom], j''ai vu ton message dans le groupe [nom groupe], ça m''a parlé — je suis passée par là aussi. Tu en es où dans ta démarche en ce moment ?',
+ null,
+ E'FB Messenger = ton plus posé que Instagram. Groupes wellness = mine d''or.', false),
+
+('fr','weight-women','whatsapp',1,'first_contact','WhatsApp · Contact direct','🇫🇷 Français',
+ E'Coucou [prénom] 😊 C''est [ton prénom], on s''est croisées via [contexte]. Tu m''avais parlé de ton envie de te sentir mieux — tu en es où là-dessus aujourd''hui ?',
+ null,
+ E'WhatsApp = pour ceux qui t''ont déjà donné leur numéro. Plus chaud, plus direct.', false),
+
+('fr','weight-women','sms',1,'first_contact','SMS · Court & posé','🇫🇷 Français',
+ E'Salut [prénom], c''est [ton prénom]. Je passe par SMS pour ne pas te perdre dans les DM. On avait échangé sur [contexte] — tu en es où sur ton objectif forme en ce moment ?',
+ null,
+ E'SMS FR : court, sans emoji, ton posé. Effet "vraie personne" pas marketing.', false),
+
+('fr','weight-women','tiktok',1,'first_contact','TikTok · DM post-vidéo','🇫🇷 Français',
+ E'Salut [prénom] ! Ta vidéo sur [détail] m''a parlé. Tu es dans une démarche de remise en forme en ce moment, ou c''est plus pour le fun ?',
+ null,
+ E'TikTok = ton léger, référence directe à la vidéo vue.', false),
+
+-- FR weight-men
+('fr','weight-men','insta',1,'first_contact','Instagram DM · Premier contact','🇫🇷 Français',
+ E'Salut [prénom], j''ai vu ton post sur [détail vu sur son profil]. Curieux de savoir — tu es plutôt sur un objectif perte de gras, prise de masse propre, ou retrouver de l''énergie au quotidien ?',
+ null,
+ E'Vocabulaire perf/énergie/récup. ZÉRO "bien-être" ou "douceur" → ça les éjecte direct.', false),
+
+('fr','weight-men','fb',1,'first_contact','Facebook Messenger · Premier contact','🇫🇷 Français',
+ E'Bonjour [prénom], vu ton post dans [nom du groupe] sur [détail]. Tu cherches un truc précis en ce moment, ou tu testes des trucs au feeling ?',
+ null,
+ E'FB Messenger = ton plus posé qu''Insta. Groupes "remise en forme homme" = mine d''or.', false),
+
+('fr','weight-men','whatsapp',1,'first_contact','WhatsApp · Contact direct','🇫🇷 Français',
+ E'Salut [prénom], c''est [ton prénom], on s''est croisés via [contexte]. Tu m''avais parlé de [détail — perte de poids / énergie / sport]. Tu en es où ?',
+ null,
+ E'WhatsApp = lead chaud déjà rencontré. Direct mais pas agressif.', false),
+
+('fr','weight-men','sms',1,'first_contact','SMS · Court & posé','🇫🇷 Français',
+ E'Salut [prénom], c''est [ton prénom]. On avait parlé de [contexte]. Tu en es où sur ton objectif forme en ce moment ?',
+ null,
+ E'SMS = court, sans emoji, ton viril posé. Effet "vraie personne".', false),
+
+('fr','weight-men','tiktok',1,'first_contact','TikTok · DM post-vidéo','🇫🇷 Français',
+ E'Salut [prénom], ta vidéo sur [détail] est carrée. T''es sur quel objectif en ce moment — perte de gras, prise de masse propre, ou retrouver de l''énergie ?',
+ null,
+ E'TikTok homme = punchy + question concrète. Vocabulaire perf.', false),
+
+-- FR sport
+('fr','sport','insta',1,'first_contact','Instagram DM · Premier contact','🇫🇷 Français',
+ E'Salut [prénom] 💪 Ton post sur [détail spécifique] a attiré mon œil, surtout [point précis]. Tu gères comment ton alim autour de tes sorties en ce moment ?',
+ null,
+ E'Pour les sportifs, parler PERF avant tout. Pas de poids/régime.', false),
+
+('fr','sport','fb',1,'first_contact','Facebook Messenger · Premier contact','🇫🇷 Français',
+ E'Bonjour [prénom], vu ton partage dans [nom du groupe] sur [détail]. Tu prépares un truc en particulier en ce moment — course, défi, ou plutôt du fond ?',
+ null,
+ E'FB sport = groupes course/triathlon/running. Ton entre passionnés.', false),
+
+('fr','sport','whatsapp',1,'first_contact','WhatsApp · Contact direct','🇫🇷 Français',
+ E'Salut [prénom], c''est [ton prénom], on s''était croisés via [contexte]. Tu m''avais parlé de [détail — objectif / course]. Tu en es où ?',
+ null,
+ E'WhatsApp FR sport : préciser le contexte de connexion avant tout.', false),
+
+('fr','sport','sms',1,'first_contact','SMS · Court & posé','🇫🇷 Français',
+ E'Salut [prénom], c''est [ton prénom]. On avait parlé de ton objectif sportif. Tu es toujours dessus en ce moment ?',
+ null,
+ E'SMS sport = court, factuel, entre gens qui se respectent.', false),
+
+('fr','sport','tiktok',1,'first_contact','TikTok · DM post-vidéo','🇫🇷 Français',
+ E'Salut [prénom], vu ta vidéo sur [détail], beau boulot. Tu as une stratégie nutrition autour de tes séances, ou tu y vas au feeling ?',
+ null,
+ E'TikTok sport = reconnaissance technique + question feeling/structure.', false),
+
+-- FR business
+('fr','business','insta',1,'first_contact','Instagram DM · Premier contact','🇫🇷 Français',
+ E'Salut [prénom], ton [détail] a attiré mon œil, surtout [point précis]. Tu fais ça depuis combien de temps ? Je suis toujours curieux du parcours des gens qui construisent leur propre truc.',
+ null,
+ E'Business = JAMAIS pitcher en M1. Curiosité sincère sur le parcours.', false),
+
+('fr','business','fb',1,'first_contact','Facebook Messenger · Premier contact','🇫🇷 Français',
+ E'Bonjour [prénom], vu ton post dans [nom du groupe] sur [détail], ça m''a parlé — je suis dans une démarche similaire. Tu travailles sur quoi en ce moment ?',
+ null,
+ E'FB business = groupes entrepreneurs/repreneurs. Terrain commun d''abord.', false),
+
+('fr','business','whatsapp',1,'first_contact','WhatsApp · Contact direct','🇫🇷 Français',
+ E'Salut [prénom], c''est [ton prénom], on s''était croisés via [contexte]. Pour être franc, je te recontacte parce que je construis quelque chose en ce moment et ton profil m''a fait penser à toi. Tu es ouvert à découvrir de nouveaux projets, ou tu es 100% focus sur ton activité actuelle ?',
+ null,
+ E'WhatsApp business : transparence (pas de pitch caché), filtre par une vraie question.', false),
+
+('fr','business','sms',1,'first_contact','SMS · Court & posé','🇫🇷 Français',
+ E'Salut [prénom], c''est [ton prénom]. Je te contacte pour une raison précise — ton profil m''a fait penser à un projet sur lequel je bosse. C''est un sujet qui pourrait t''intéresser, ou pas du tout ?',
+ null,
+ E'SMS business = direct, donne tout de suite la porte de sortie.', false),
+
+('fr','business','tiktok',1,'first_contact','TikTok · DM post-vidéo','🇫🇷 Français',
+ E'Salut [prénom], vu ta vidéo sur [détail], ça m''a parlé. Tu travailles sur quoi en ce moment à côté de ça ?',
+ null,
+ E'TikTok business = curiosité, surtout pas de pitch projet.', false),
+
+('fr','business','linkedin',1,'first_contact','LinkedIn · Premier contact','🇫🇷 Français',
+ E'Bonjour [prénom], votre parcours dans [leur secteur] a retenu mon attention, en particulier [point précis]. J''échange en ce moment avec des profils qui construisent quelque chose par eux-mêmes. Qu''est-ce qui vous occupe le plus professionnellement en ce moment ?',
+ null,
+ E'LinkedIn = ton corporate, vouvoiement, structure claire. PAS de pitch ni de Zoom en 1er message.', false);
+
+-- ─── 🇬🇧 INTERNATIONAL (English) ──────────────────────────────────────────
+insert into public.prospection_scripts
+  (market_code, profile_slug, platform, position, kind, label, language_label, body, body_fr, tip, needs_native_review) values
+
+-- EN weight-women
+('en','weight-women','insta',1,'first_contact','Instagram DM · First contact','🇬🇧 English',
+ E'Hey [name] 👋 Came across your profile and [detail] really stood out. Right now are you more focused on losing weight, getting your energy back, or both?',
+ E'Salut [name] 👋 Je suis tombée sur ton profil et [detail] ressort vraiment. Là tu es plutôt perte de poids, retrouver l''énergie, ou les deux ?',
+ E'EN works for US, UK, intl Insta profiles. Keep it casual.', false),
+
+('en','weight-women','fb',1,'first_contact','Facebook Messenger · First contact','🇬🇧 English',
+ E'Hi [name], saw your post in [group name] about [detail] — it really resonated, I''ve been through that too. Where are you at with it right now?',
+ E'Salut [name], vu ton post dans [groupe] sur [detail] — ça m''a parlé, je suis passée par là. Tu en es où ?',
+ E'FB Messenger plus posé qu''Insta. Wellness groups = goldmine.', false),
+
+('en','weight-women','whatsapp',1,'first_contact','WhatsApp · Direct contact','🇬🇧 English',
+ E'Hi [name] 😊 It''s [your name], we connected through [context]. You''d mentioned wanting to feel better — how''s that going for you now?',
+ E'Salut [name] 😊 C''est [your name], on s''était connectées via [contexte]. Tu m''avais parlé de te sentir mieux — ça avance ?',
+ E'EN WhatsApp = leads tièdes via reco ou contact donné.', false),
+
+('en','weight-women','sms',1,'first_contact','SMS · Short & grounded','🇬🇧 English',
+ E'Hi [name], it''s [your name]. Texting so we don''t lose each other in the DMs. We''d talked about [context] — where are you at with your fitness goal right now?',
+ E'Salut [name], c''est [your name]. Je texte pour ne pas se perdre dans les DM. On avait parlé de [contexte] — tu en es où sur ton objectif forme ?',
+ E'SMS EN : court, sans emoji, ton posé. Effet "vraie personne".', false),
+
+('en','weight-women','tiktok',1,'first_contact','TikTok · Post-video DM','🇬🇧 English',
+ E'Hi [name]! Your video on [detail] really spoke to me. Are you on a fitness journey right now, or more just for fun?',
+ E'Salut [name] ! Ta vidéo sur [detail] m''a parlé. Tu es dans une démarche fitness, ou plus pour le fun ?',
+ E'TikTok = ton léger.', false),
+
+-- EN weight-men
+('en','weight-men','insta',1,'first_contact','Instagram DM · First contact','🇬🇧 English',
+ E'Hey [name], saw your post on [detail]. Quick question — are you more into fat loss, clean muscle gain, or just getting your daily energy back?',
+ E'Salut [name], vu ton post sur [detail]. Petite question — tu es plutôt fat loss, prise de muscle propre, ou retrouver ton énergie ?',
+ E'Vocabulaire perf/énergie/récup. Évite "wellness" et "feel good" qui éjectent les mecs.', false),
+
+('en','weight-men','fb',1,'first_contact','Facebook Messenger · First contact','🇬🇧 English',
+ E'Hi [name], saw your post in [group name] about [detail]. Are you working toward something specific right now, or just experimenting?',
+ E'Salut [name], vu ton post dans [groupe] sur [detail]. Tu vises un objectif précis, ou tu expérimentes ?',
+ E'FB Messenger = ton plus posé. Groupes "men''s fitness" mine d''or.', false),
+
+('en','weight-men','whatsapp',1,'first_contact','WhatsApp · Direct contact','🇬🇧 English',
+ E'Hi [name], it''s [your name], we met through [context]. You''d mentioned [detail]. Where are you at with it now?',
+ E'Salut [name], c''est [your name], on s''est rencontrés via [contexte]. Tu m''avais parlé de [detail]. Tu en es où ?',
+ E'WhatsApp = lead chaud déjà rencontré. Direct mais pas agressif.', false),
+
+('en','weight-men','sms',1,'first_contact','SMS · Short & grounded','🇬🇧 English',
+ E'Hi [name], it''s [your name]. We''d talked about [context]. Where are you at with your fitness goal now?',
+ E'Salut [name], c''est [your name]. On avait parlé de [contexte]. Tu en es où ?',
+ E'SMS = court, sans emoji, ton viril posé.', false),
+
+('en','weight-men','tiktok',1,'first_contact','TikTok · Post-video DM','🇬🇧 English',
+ E'Hi [name], saw your video on [detail], solid work. What''s the goal right now — fat loss, energy, something else?',
+ E'Salut [name], vu ta vidéo sur [detail], du bon boulot. L''objectif c''est quoi — fat loss, énergie, autre ?',
+ E'TikTok homme = punchy + question concrète.', false),
+
+-- EN sport
+('en','sport','insta',1,'first_contact','Instagram DM · First contact','🇬🇧 English',
+ E'Hey [name] 💪 Your post on [detail] caught my eye, especially [point précis]. How do you manage your nutrition around your training right now?',
+ E'Salut [name] 💪 Ton post sur [detail] a attiré mon œil, surtout [point précis]. Tu gères comment ta nutrition autour de l''entraînement ?',
+ E'Talk performance, never weight loss.', false),
+
+('en','sport','fb',1,'first_contact','Facebook Messenger · First contact','🇬🇧 English',
+ E'Hi [name], saw your post in [group name] about [detail]. Are you prepping for something specific — a race, a goal, or general fitness?',
+ E'Salut [name], vu ton post dans [groupe] sur [detail]. Tu prépares un truc précis — course, objectif, forme générale ?',
+ E'FB sport = groupes running/triathlon.', false),
+
+('en','sport','whatsapp',1,'first_contact','WhatsApp · Direct contact','🇬🇧 English',
+ E'Hi [name], it''s [your name], we met through [context]. You''d mentioned [detail]. Where are you at now?',
+ E'Salut [name], c''est [your name], on s''est rencontrés via [contexte]. Tu m''avais parlé de [detail]. Tu en es où ?',
+ E'WhatsApp EN sport : context first.', false),
+
+('en','sport','sms',1,'first_contact','SMS · Short & grounded','🇬🇧 English',
+ E'Hi [name], it''s [your name]. We''d talked about your sport goal. Still on it right now?',
+ E'Salut [name], c''est [your name]. On avait parlé de ton objectif sportif. Toujours dessus ?',
+ E'SMS court, factuel.', false),
+
+('en','sport','tiktok',1,'first_contact','TikTok · Post-video DM','🇬🇧 English',
+ E'Hi [name], saw your video on [detail], impressive. Do you have a nutrition strategy around your training, or do you just go by feel?',
+ E'Salut [name], vu ta vidéo sur [detail], impressionnant. Tu as une stratégie nutrition, ou tu y vas au feeling ?',
+ E'TikTok sport = reconnaissance technique.', false),
+
+-- EN business
+('en','business','insta',1,'first_contact','Instagram DM · First contact','🇬🇧 English',
+ E'Hey [name], your [detail] caught my eye, especially [point précis]. How long have you been doing this? I''m always curious about the path of people building something of their own.',
+ E'Salut [name], ton [detail] a attiré mon œil, surtout [point précis]. Tu fais ça depuis combien de temps ? Le parcours des gens qui construisent leur propre truc m''intéresse toujours.',
+ E'Business = jamais de pitch en M1. Curiosité sincère.', false),
+
+('en','business','fb',1,'first_contact','Facebook Messenger · First contact','🇬🇧 English',
+ E'Hi [name], saw your post in [group name] about [detail] — really related, I''m on a similar path. What are you working on right now?',
+ E'Salut [name], vu ton post dans [groupe] sur [detail] — je me suis reconnu, voie similaire. Tu bosses sur quoi ?',
+ E'FB business = terrain commun.', false),
+
+('en','business','whatsapp',1,'first_contact','WhatsApp · Direct contact','🇬🇧 English',
+ E'Hi [name], it''s [your name], we connected through [context]. I''ll be upfront — I''m building something right now and your profile made me think of you. Are you open to exploring new projects, or fully focused on your current thing?',
+ E'Salut [name], c''est [your name], on s''était connectés via [contexte]. Je serai franc — je construis quelque chose et ton profil m''a fait penser à toi. Tu es ouvert à de nouveaux projets, ou 100% focus sur ton activité ?',
+ E'WhatsApp business : transparence + filtre.', false),
+
+('en','business','sms',1,'first_contact','SMS · Short & grounded','🇬🇧 English',
+ E'Hi [name], it''s [your name]. Reaching out for a specific reason — your profile reminded me of a project I''m working on. Could be of interest, or not your thing at all?',
+ E'Salut [name], c''est [your name]. Je te contacte pour une raison précise — ton profil m''a rappelé un projet sur lequel je bosse. Ça pourrait t''intéresser, ou pas du tout ton truc ?',
+ E'SMS business = direct, porte de sortie.', false),
+
+('en','business','tiktok',1,'first_contact','TikTok · Post-video DM','🇬🇧 English',
+ E'Hi [name], really liked your video on [detail]. Alongside that, what are you working on these days?',
+ E'Salut [name], ta vidéo sur [detail] m''a plu. À côté de ça, tu bosses sur quoi ?',
+ E'TikTok business = curiosité.', false),
+
+('en','business','linkedin',1,'first_contact','LinkedIn · First contact','🇬🇧 English',
+ E'Hi [name], your background in [their field] caught my eye, especially [point précis]. I enjoy connecting with people building something of their own. What are you most focused on professionally these days?',
+ E'Bonjour [name], votre parcours dans [secteur] a retenu mon attention, surtout [point précis]. J''aime échanger avec des gens qui construisent par eux-mêmes. Sur quoi vous concentrez-vous professionnellement ?',
+ E'LinkedIn EN = ton corporate. Structure courte. PAS de Zoom en M1.', false);
+
+-- ─── 🇲🇽 LATAM + ESPAGNE (Español, needs_native_review=true) ──────────────
+insert into public.prospection_scripts
+  (market_code, profile_slug, platform, position, kind, label, language_label, body, body_fr, tip, needs_native_review) values
+
+-- ES weight-women
+('es','weight-women','insta',1,'first_contact','Instagram DM · Primer contacto','🇲🇽 Español',
+ E'¡Hola [nombre]! 👋 Vi tu perfil y [detalle] me encantó. Ahora mismo, ¿estás más enfocada en bajar de peso, recuperar energía, o las dos cosas?',
+ E'Salut [nombre] 👋 J''ai vu ton profil et [détail] m''a plu. Là tu es plutôt perte de poids, énergie, ou les deux ?',
+ E'Mexique, Colombie, Argentine, Espagne. Style proche du français.', true),
+
+('es','weight-women','fb',1,'first_contact','Facebook Messenger · Primer contacto','🇲🇽 Español',
+ E'Hola [nombre], vi tu publicación en [nombre grupo] sobre [detalle], me llegó — yo también pasé por ahí. ¿Cómo vas con eso ahora?',
+ E'Salut [nombre], vu ton post dans [groupe] sur [détail], ça m''a touchée — je suis passée par là. Tu en es où ?',
+ E'FB Messenger LatAm más posado. Grupos "bajar de peso" mina de oro.', true),
+
+('es','weight-women','whatsapp',1,'first_contact','WhatsApp · Contacto directo','🇲🇽 Español',
+ E'¡Hola [nombre]! 😊 Soy [tu nombre], nos conocimos por [contexto]. Me habías comentado que querías sentirte mejor — ¿cómo vas con eso ahora?',
+ E'Salut [nombre] 😊 C''est [tu nombre], on s''était connectées via [contexte]. Tu m''avais dit vouloir te sentir mieux — ça avance ?',
+ E'WhatsApp ULTRA dominant en LatAm. Privilégie ce canal.', true),
+
+('es','weight-women','sms',1,'first_contact','SMS · Corto y posado','🇲🇽 Español',
+ E'Hola [nombre], soy [tu nombre]. Te escribo por SMS para no perdernos en los DM. Habíamos hablado de [contexto] — ¿cómo vas con tu meta de forma ahora?',
+ E'Salut [nombre], c''est [tu nombre]. J''écris par SMS pour ne pas se perdre dans les DM. On avait parlé de [contexte] — tu en es où ?',
+ E'SMS LatAm court.', true),
+
+('es','weight-women','tiktok',1,'first_contact','TikTok · DM post-video','🇲🇽 Español',
+ E'¡Hola [nombre]! Tu video sobre [detalle] me encantó. ¿Estás en un proceso de ponerte en forma ahora, o más por diversión?',
+ E'Salut [nombre] ! Ta vidéo sur [détail] m''a plu. Tu es dans une démarche de remise en forme, ou plus pour le fun ?',
+ E'TikTok = ton léger.', true),
+
+-- ES weight-men
+('es','weight-men','insta',1,'first_contact','Instagram DM · Primer contacto','🇲🇽 Español',
+ E'Hola [nombre], vi tu post sobre [detalle]. Una pregunta rápida — ¿estás más en perder grasa, ganar músculo limpio, o recuperar tu energía del día a día?',
+ E'Salut [nombre], vu ton post sur [détail]. Petite question — tu es plutôt perte de gras, muscle propre, ou retrouver ton énergie ?',
+ E'ES Mexique/LatAm. Ton naturel. Evita "bienestar" con hombres.', true),
+
+('es','weight-men','fb',1,'first_contact','Facebook Messenger · Primer contacto','🇲🇽 Español',
+ E'Hola [nombre], vi tu publicación en [nombre grupo] sobre [detalle]. ¿Estás trabajando hacia algo específico ahora, o experimentando?',
+ E'Salut [nombre], vu ton post dans [groupe] sur [détail]. Tu vises un objectif précis, ou tu expérimentes ?',
+ E'FB Messenger LatAm. Grupos "ponerse en forma" mina de oro.', true),
+
+('es','weight-men','whatsapp',1,'first_contact','WhatsApp · Contacto directo','🇲🇽 Español',
+ E'Hola [nombre], soy [tu nombre], nos conocimos por [contexto]. Me habías comentado sobre [detalle]. ¿Cómo vas con eso ahora?',
+ E'Salut [nombre], c''est [tu nombre], on s''est connus via [contexte]. Tu m''avais parlé de [détail]. Tu en es où ?',
+ E'WhatsApp dominante LatAm. Tono directo, sin emojis exagerados.', true),
+
+('es','weight-men','sms',1,'first_contact','SMS · Corto y posado','🇲🇽 Español',
+ E'Hola [nombre], soy [tu nombre]. Habíamos hablado de [contexto]. ¿Cómo vas con tu meta de forma ahora?',
+ E'Salut [nombre], c''est [tu nombre]. On avait parlé de [contexte]. Tu en es où ?',
+ E'SMS LatAm.', true),
+
+('es','weight-men','tiktok',1,'first_contact','TikTok · DM post-video','🇲🇽 Español',
+ E'Hola [nombre], vi tu video sobre [detalle], buen trabajo. ¿Cuál es la meta ahora — perder grasa, energía, otra cosa?',
+ E'Salut [nombre], vu ta vidéo sur [détail], beau boulot. L''objectif c''est quoi — perte de gras, énergie, autre ?',
+ E'TikTok homme = punchy.', true),
+
+-- ES sport
+('es','sport','insta',1,'first_contact','Instagram DM · Primer contacto','🇲🇽 Español',
+ E'¡Hola [nombre]! 💪 Tu publicación sobre [detalle] me llamó la atención, sobre todo [point précis]. ¿Cómo manejas tu nutrición alrededor de tus entrenamientos ahora?',
+ E'Salut [nombre] 💪 Ton post sur [détail] a attiré mon œil, surtout [point précis]. Tu gères comment ta nutrition autour de l''entraînement ?',
+ E'LatAm sportifs = WhatsApp et Insta. Ton chaleureux. Hablar de performance.', true),
+
+('es','sport','fb',1,'first_contact','Facebook Messenger · Primer contacto','🇲🇽 Español',
+ E'Hola [nombre], vi tu publicación en [nombre grupo] sobre [detalle]. ¿Te estás preparando para algo específico — una carrera, una meta, o condición general?',
+ E'Salut [nombre], vu ton post dans [groupe] sur [détail]. Tu prépares un truc précis — course, objectif, forme générale ?',
+ E'FB ES sport : ton chaleureux, plus posé qu''Insta.', true),
+
+('es','sport','whatsapp',1,'first_contact','WhatsApp · Contacto directo','🇲🇽 Español',
+ E'Hola [nombre], soy [tu nombre], nos conocimos por [contexto]. Me habías comentado sobre [detalle]. ¿Cómo vas ahora?',
+ E'Salut [nombre], c''est [tu nombre], on s''est connus via [contexte]. Tu m''avais parlé de [détail]. Tu en es où ?',
+ E'WhatsApp ES sport : referenciar contexto común antes de proponer.', true),
+
+('es','sport','sms',1,'first_contact','SMS · Corto y posado','🇲🇽 Español',
+ E'Hola [nombre], soy [tu nombre]. Habíamos hablado de tu meta deportiva. ¿Sigues con eso ahora?',
+ E'Salut [nombre], c''est [tu nombre]. On avait parlé de ton objectif sportif. Toujours dessus ?',
+ E'SMS court.', true),
+
+('es','sport','tiktok',1,'first_contact','TikTok · DM post-video','🇲🇽 Español',
+ E'Hola [nombre], vi tu video sobre [detalle], impresionante. ¿Tienes una estrategia de nutrición alrededor del entrenamiento, o vas por instinto?',
+ E'Salut [nombre], vu ta vidéo sur [détail], impressionnant. Tu as une stratégie nutrition, ou tu y vas à l''instinct ?',
+ E'TikTok sport = reconnaissance technique.', true),
+
+-- ES business
+('es','business','insta',1,'first_contact','Instagram DM · Primer contacto','🇲🇽 Español',
+ E'Hola [nombre], tu [detalle] me llamó la atención, sobre todo [point précis]. ¿Cuánto tiempo llevas en esto? Siempre me interesa el camino de quienes construyen algo propio.',
+ E'Salut [nombre], ton [détail] a attiré mon œil, surtout [point précis]. Tu fais ça depuis combien de temps ? Le parcours des gens qui construisent leur propre truc m''intéresse toujours.',
+ E'Business = jamais de pitch en M1. Curiosidad sincera.', true),
+
+('es','business','fb',1,'first_contact','Facebook Messenger · Primer contacto','🇲🇽 Español',
+ E'Hola [nombre], vi tu publicación en [nombre grupo] sobre [detalle], me identifiqué — voy por un camino similar. ¿En qué estás trabajando ahora?',
+ E'Salut [nombre], vu ton post dans [groupe] sur [détail], je me suis reconnu — voie similaire. Tu bosses sur quoi ?',
+ E'FB business = terrain commun.', true),
+
+('es','business','whatsapp',1,'first_contact','WhatsApp · Contacto directo','🇲🇽 Español',
+ E'Hola [nombre], soy [tu nombre], nos conectamos por [contexto]. Seré directo — estoy construyendo algo ahora y tu perfil me hizo pensar en ti. ¿Estás abierto a explorar nuevos proyectos, o totalmente enfocado en lo tuyo?',
+ E'Salut [nombre], c''est [tu nombre], on s''était connectés via [contexte]. Je serai direct — je construis quelque chose et ton profil m''a fait penser à toi. Ouvert à de nouveaux projets, ou 100% focus sur ton activité ?',
+ E'WhatsApp business : transparencia + filtro por pregunta.', true),
+
+('es','business','sms',1,'first_contact','SMS · Corto y posado','🇲🇽 Español',
+ E'Hola [nombre], soy [tu nombre]. Te escribo por una razón específica — tu perfil me recordó un proyecto en el que trabajo. ¿Podría interesarte, o no es lo tuyo?',
+ E'Salut [nombre], c''est [tu nombre]. J''écris pour une raison précise — ton profil m''a rappelé un projet sur lequel je bosse. Ça pourrait t''intéresser, ou pas ton truc ?',
+ E'SMS business = direct.', true),
+
+('es','business','tiktok',1,'first_contact','TikTok · DM post-video','🇲🇽 Español',
+ E'Hola [nombre], me gustó mucho tu video sobre [detalle]. Además de eso, ¿en qué estás trabajando ahora?',
+ E'Salut [nombre], ta vidéo sur [détail] m''a plu. À côté de ça, tu bosses sur quoi ?',
+ E'TikTok business = curiosité.', true),
+
+('es','business','linkedin',1,'first_contact','LinkedIn · Primer contacto','🇲🇽 Español',
+ E'Hola [nombre], su trayectoria en [su sector] me llamó la atención, especialmente [point précis]. Disfruto conectar con personas que construyen algo propio. ¿En qué está más enfocado profesionalmente en este momento?',
+ E'Bonjour [nombre], votre parcours dans [secteur] a retenu mon attention, surtout [point précis]. J''aime échanger avec des gens qui construisent par eux-mêmes. Sur quoi vous concentrez-vous professionnellement ?',
+ E'LinkedIn = ton corporate, "usted".', true);
+
+-- ─── 🇧🇷 BRÉSIL + PORTUGAL (Português, needs_native_review=true) ──────────
+insert into public.prospection_scripts
+  (market_code, profile_slug, platform, position, kind, label, language_label, body, body_fr, tip, needs_native_review) values
+
+-- PT weight-women
+('pt','weight-women','insta',1,'first_contact','Instagram DM · Primeiro contato','🇧🇷 Português (BR)',
+ E'Oi [nome]! 👋 Vi seu perfil e [detalhe] me chamou atenção. Agora você tá mais focada em emagrecer, recuperar energia, ou os dois?',
+ E'Salut [nome] 👋 Vu ton profil et [détail] m''a marquée. Là tu es plutôt perte de poids, énergie, ou les deux ?',
+ E'Brésil = top 5 mondial Herbalife. Ton chaleureux obligatoire.', true),
+
+('pt','weight-women','fb',1,'first_contact','Facebook Messenger · Primeiro contato','🇧🇷 Português (BR)',
+ E'Oi [nome], vi seu post no [nome grupo] sobre [detalhe], me tocou — também já passei por isso. Como você tá com isso agora?',
+ E'Salut [nome], vu ton post dans [groupe] sur [détail], ça m''a touchée — je suis passée par là. Tu en es où ?',
+ E'FB Messenger BR plus posé. Grupos "emagrecimento" mina de ouro.', true),
+
+('pt','weight-women','whatsapp',1,'first_contact','WhatsApp · Contato direto','🇧🇷 Português (BR)',
+ E'Oi [nome]! 😊 Sou a [seu nome], a gente se conectou pelo [contexto]. Você tinha comentado que queria se sentir melhor — como tá indo isso?',
+ E'Salut [nome] 😊 C''est [seu nome], on s''était connectées via [contexte]. Tu m''avais dit vouloir te sentir mieux — ça avance ?',
+ E'Brésil = WhatsApp obligatoire, langage très chaleureux et personnel.', true),
+
+('pt','weight-women','sms',1,'first_contact','SMS · Curto e posado','🇧🇷 Português (BR)',
+ E'Oi [nome], é a [seu nome]. Tô mandando SMS pra gente não se perder nas DM. A gente tinha falado sobre [contexto] — como você tá com sua meta de forma agora?',
+ E'Salut [nome], c''est [seu nome]. J''écris en SMS pour ne pas se perdre dans les DM. On avait parlé de [contexte] — tu en es où ?',
+ E'BR SMS court. "Bater papo" = converser casualement.', true),
+
+('pt','weight-women','tiktok',1,'first_contact','TikTok · DM pós-vídeo','🇧🇷 Português (BR)',
+ E'Oi [nome]! Seu vídeo sobre [detalhe] me chamou atenção. Você tá num processo de entrar em forma agora, ou mais por diversão?',
+ E'Salut [nome] ! Ta vidéo sur [détail] m''a marquée. Tu es dans une démarche de remise en forme, ou plus pour le fun ?',
+ E'TikTok = ton léger.', true),
+
+-- PT weight-men
+('pt','weight-men','insta',1,'first_contact','Instagram DM · Primeiro contato','🇧🇷 Português (BR)',
+ E'Oi [nome], vi seu post sobre [detalhe]. Pergunta rápida — você tá mais em perder gordura, ganhar músculo limpo, ou recuperar sua energia do dia a dia?',
+ E'Salut [nome], vu ton post sur [détail]. Petite question — tu es plutôt perte de gras, muscle propre, ou retrouver ton énergie ?',
+ E'BR ton direct mais chaleureux. "Trampo" = boulot, mot oral.', true),
+
+('pt','weight-men','fb',1,'first_contact','Facebook Messenger · Primeiro contato','🇧🇷 Português (BR)',
+ E'Oi [nome], vi seu post no [nome grupo] sobre [detalhe]. Você tá trabalhando em algo específico agora, ou experimentando?',
+ E'Salut [nome], vu ton post dans [groupe] sur [détail]. Tu vises un objectif précis, ou tu expérimentes ?',
+ E'BR FB Messenger plus posé. Grupos "voltar à forma" mina de ouro.', true),
+
+('pt','weight-men','whatsapp',1,'first_contact','WhatsApp · Contato direto','🇧🇷 Português (BR)',
+ E'Oi [nome], sou o [seu nome], a gente se conheceu pelo [contexto]. Você tinha comentado sobre [detalhe]. Como tá indo isso agora?',
+ E'Salut [nome], c''est [seu nome], on s''est connus via [contexte]. Tu m''avais parlé de [détail]. Tu en es où ?',
+ E'BR WhatsApp OBLIGATOIRE après Insta. "A gente" pas "nós".', true),
+
+('pt','weight-men','sms',1,'first_contact','SMS · Curto e posado','🇧🇷 Português (BR)',
+ E'Oi [nome], é o [seu nome]. A gente tinha falado sobre [contexto]. Como você tá com sua meta de forma agora?',
+ E'Salut [nome], c''est [seu nome]. On avait parlé de [contexte]. Tu en es où ?',
+ E'BR SMS court. "Bater papo" = converser.', true),
+
+('pt','weight-men','tiktok',1,'first_contact','TikTok · DM pós-vídeo','🇧🇷 Português (BR)',
+ E'Oi [nome], vi seu vídeo sobre [detalhe], mandou bem. Qual a meta agora — perder gordura, energia, outra coisa?',
+ E'Salut [nome], vu ta vidéo sur [détail], bien joué. L''objectif c''est quoi — perte de gras, énergie, autre ?',
+ E'TikTok homme = punchy.', true),
+
+-- PT sport
+('pt','sport','insta',1,'first_contact','Instagram DM · Primeiro contato','🇧🇷 Português (BR)',
+ E'Oi [nome]! 💪 Seu post sobre [detalhe] me chamou atenção, principalmente [point précis]. Como você gerencia sua nutrição em volta dos treinos agora?',
+ E'Salut [nome] 💪 Ton post sur [détail] a attiré mon œil, surtout [point précis]. Tu gères comment ta nutrition autour de l''entraînement ?',
+ E'Brésil sport = très visuel. Mentionner contenu spécifique.', true),
+
+('pt','sport','fb',1,'first_contact','Facebook Messenger · Primeiro contato','🇧🇷 Português (BR)',
+ E'Oi [nome], vi seu post no [nome grupo] sobre [detalhe]. Você tá se preparando pra algo específico — uma prova, uma meta, ou condição geral?',
+ E'Salut [nome], vu ton post dans [groupe] sur [détail]. Tu prépares un truc précis — course, objectif, forme générale ?',
+ E'FB sport BR = grupos corrida/triathlon.', true),
+
+('pt','sport','whatsapp',1,'first_contact','WhatsApp · Contato direto','🇧🇷 Português (BR)',
+ E'Oi [nome], sou o [seu nome], a gente se conheceu pelo [contexto]. Você tinha comentado sobre [detalhe]. Como tá agora?',
+ E'Salut [nome], c''est [seu nome], on s''est connus via [contexte]. Tu m''avais parlé de [détail]. Tu en es où ?',
+ E'WhatsApp PT sport : poser le contexte commun avant tout.', true),
+
+('pt','sport','sms',1,'first_contact','SMS · Curto e posado','🇧🇷 Português (BR)',
+ E'Oi [nome], é o [seu nome]. A gente tinha falado da sua meta esportiva. Ainda tá nela agora?',
+ E'Salut [nome], c''est [seu nome]. On avait parlé de ton objectif sportif. Toujours dessus ?',
+ E'BR SMS court.', true),
+
+('pt','sport','tiktok',1,'first_contact','TikTok · DM pós-vídeo','🇧🇷 Português (BR)',
+ E'Oi [nome], vi seu vídeo sobre [detalhe], impressionante. Você tem uma estratégia de nutrição em volta do treino, ou vai no feeling?',
+ E'Salut [nome], vu ta vidéo sur [détail], impressionnant. Tu as une stratégie nutrition, ou tu y vas au feeling ?',
+ E'TikTok sport = reconnaissance technique.', true),
+
+-- PT business
+('pt','business','insta',1,'first_contact','Instagram DM · Primeiro contato','🇧🇷 Português (BR)',
+ E'Oi [nome], seu [detalhe] me chamou atenção, principalmente [point précis]. Faz quanto tempo que você tá nisso? Sempre me interessa a trajetória de quem constrói algo próprio.',
+ E'Salut [nome], ton [détail] a attiré mon œil, surtout [point précis]. Tu fais ça depuis combien de temps ? Le parcours des gens qui construisent leur propre truc m''intéresse toujours.',
+ E'Business = jamais de pitch en M1. "Papo" = conversa descontraída.', true),
+
+('pt','business','fb',1,'first_contact','Facebook Messenger · Primeiro contato','🇧🇷 Português (BR)',
+ E'Oi [nome], vi seu post no [nome grupo] sobre [detalhe], me identifiquei — tô num caminho parecido. No que você tá trabalhando agora?',
+ E'Salut [nome], vu ton post dans [groupe] sur [détail], je me suis reconnu — voie similaire. Tu bosses sur quoi ?',
+ E'FB business = terrain commun.', true),
+
+('pt','business','whatsapp',1,'first_contact','WhatsApp · Contato direto','🇧🇷 Português (BR)',
+ E'Oi [nome], sou o [seu nome], a gente se conectou pelo [contexto]. Vou ser direto — tô construindo algo agora e seu perfil me fez pensar em você. Você tá aberto a explorar novos projetos, ou totalmente focado no seu negócio atual?',
+ E'Salut [nome], c''est [seu nome], on s''était connectés via [contexte]. Je serai direct — je construis quelque chose et ton profil m''a fait penser à toi. Ouvert à de nouveaux projets, ou 100% focus sur ton activité ?',
+ E'Brésil ultra-personnel. Toujours "a gente". Transparence + filtre.', true),
+
+('pt','business','sms',1,'first_contact','SMS · Curto e posado','🇧🇷 Português (BR)',
+ E'Oi [nome], é o [seu nome]. Tô escrevendo por um motivo específico — seu perfil me lembrou um projeto em que tô trabalhando. Pode te interessar, ou não é a sua praia?',
+ E'Salut [nome], c''est [seu nome]. J''écris pour une raison précise — ton profil m''a rappelé un projet sur lequel je bosse. Ça pourrait t''intéresser, ou pas ton truc ?',
+ E'SMS business = direct. "Não é a sua praia" = pas ton truc (idiome BR).', true),
+
+('pt','business','tiktok',1,'first_contact','TikTok · DM pós-vídeo','🇧🇷 Português (BR)',
+ E'Oi [nome], curti muito seu vídeo sobre [detalhe]. Além disso, no que você tá trabalhando agora?',
+ E'Salut [nome], ta vidéo sur [détail] m''a plu. À côté de ça, tu bosses sur quoi ?',
+ E'TikTok business = curiosité.', true),
+
+('pt','business','linkedin',1,'first_contact','LinkedIn · Primeiro contato','🇧🇷 Português (BR)',
+ E'Olá [nome], sua trajetória em [seu setor] me chamou atenção, principalmente [point précis]. Gosto de me conectar com pessoas que constroem algo próprio. No que você está mais focado profissionalmente nesse momento?',
+ E'Bonjour [nome], votre parcours dans [secteur] a retenu mon attention, surtout [point précis]. J''aime échanger avec des gens qui construisent par eux-mêmes. Sur quoi vous concentrez-vous professionnellement ?',
+ E'LinkedIn BR = ton corporate, "olá" plus formel que "oi".', true);
+
+-- ─── 🇹🇷 TURQUIE + DE (Türkçe) ────────────────────────────────────────────
+insert into public.prospection_scripts
+  (market_code, profile_slug, platform, position, kind, label, language_label, body, body_fr, tip, needs_native_review) values
+
+-- TR weight-women
+('tr','weight-women','insta',1,'first_contact','Instagram DM · İlk iletişim','🇹🇷 Türkçe',
+ E'Selam [isim] 👋 Profiline denk geldim, [detay] çok hoşuma gitti. Şu an daha çok kilo vermek mi, enerji kazanmak mı, yoksa ikisi birden mi senin için öncelik?',
+ E'Salut [name] 👋 Je suis tombée sur ton profil, [detay] m''a beaucoup plu. En ce moment c''est plutôt perdre du poids, gagner en énergie, ou les deux ta priorité ?',
+ E'Turquie marché chaud Herbalife. Aussi diaspora turque en Allemagne (5M).', false),
+
+('tr','weight-women','fb',1,'first_contact','Facebook Messenger · İlk iletişim','🇹🇷 Türkçe',
+ E'Merhaba [isim], [grup adı] grubundaki [detay] paylaşımını gördüm, bana da dokundu — ben de o yollardan geçtim. Şu an bu konuda neredesin?',
+ E'Bonjour [name], vu ton post dans [groupe] sur [detay], ça m''a touchée — je suis passée par là. Tu en es où sur ce sujet ?',
+ E'FB Messenger plus posé. Groupes "kilo verme / sağlıklı yaşam" mine d''or.', false),
+
+('tr','weight-women','whatsapp',1,'first_contact','WhatsApp · Doğrudan iletişim','🇹🇷 Türkçe',
+ E'Merhaba [isim] 😊 Ben [adın], [bağlam] üzerinden tanışmıştık. Daha iyi hissetme isteğinden bahsetmiştin — şu an o konuda neredesin?',
+ E'Coucou [name] 😊 C''est [your name], on s''était connues via [contexte]. Tu m''avais parlé de ton envie de te sentir mieux — tu en es où ?',
+ E'Turquie : WhatsApp dominant. Style direct mais chaleureux.', false),
+
+('tr','weight-women','sms',1,'first_contact','SMS · Kısa ve sakin','🇹🇷 Türkçe',
+ E'Selam [isim], ben [adın]. DM''de kaybolmamak için SMS''ten yazıyorum. [bağlam] üzerine konuşmuştuk — form hedefinde şu an neredesin?',
+ E'Salut [name], c''est [your name]. J''écris par SMS pour ne pas se perdre dans les DM. On avait parlé de [contexte] — tu en es où sur ton objectif forme ?',
+ E'TR SMS kısa, emoji yok. "Gerçek bir kişi" hissi.', false),
+
+('tr','weight-women','tiktok',1,'first_contact','TikTok · Video sonrası DM','🇹🇷 Türkçe',
+ E'Selam [isim]! [detay] videon hoşuma gitti. Şu an forma girme sürecinde misin, yoksa daha çok keyfine mi yapıyorsun?',
+ E'Salut [name] ! Ta vidéo sur [detay] m''a plu. Tu es dans une démarche de remise en forme, ou plus pour le plaisir ?',
+ E'TikTok TR = ton léger, référence à la vidéo.', false),
+
+-- TR weight-men
+('tr','weight-men','insta',1,'first_contact','Instagram DM · İlk iletişim','🇹🇷 Türkçe',
+ E'Selam [isim], [detay] paylaşımını gördüm. Merak ettim — şu an daha çok yağ yakmak mı, temiz kas kazanmak mı, yoksa günlük enerjini geri kazanmak mı istiyorsun?',
+ E'Salut [name], vu ton post sur [detay]. Curieux — tu veux plutôt brûler du gras, prendre du muscle propre, ou retrouver ton énergie ?',
+ E'TR ton direct mais respectueux. Évite le ton "yumuşak/doux".', false),
+
+('tr','weight-men','fb',1,'first_contact','Facebook Messenger · İlk iletişim','🇹🇷 Türkçe',
+ E'Merhaba [isim], [grup adı] grubundaki [detay] paylaşımını gördüm. Şu an belli bir hedefin mi var, yoksa deneme yanılma mı yapıyorsun?',
+ E'Bonjour [name], vu ton post dans [groupe] sur [detay]. Tu as un objectif précis, ou tu tâtonnes ?',
+ E'TR FB Messenger plus posé. "Forma girme erkek" grupları mine d''or.', false),
+
+('tr','weight-men','whatsapp',1,'first_contact','WhatsApp · Doğrudan iletişim','🇹🇷 Türkçe',
+ E'Selam [isim], ben [adın], [bağlam] üzerinden tanışmıştık. [detay] hakkında konuşmuştun. Şu an neredesin bu konuda?',
+ E'Salut [name], c''est [your name], on s''était connus via [contexte]. Tu m''avais parlé de [detay]. Tu en es où ?',
+ E'TR WhatsApp dominant après contact initial. Ton direct.', false),
+
+('tr','weight-men','sms',1,'first_contact','SMS · Kısa ve sakin','🇹🇷 Türkçe',
+ E'Selam [isim], ben [adın]. [bağlam] üzerine konuşmuştuk. Form hedefinde şu an neredesin?',
+ E'Salut [name], c''est [your name]. On avait parlé de [contexte]. Tu en es où sur ton objectif forme ?',
+ E'TR SMS court, sans emoji.', false),
+
+('tr','weight-men','tiktok',1,'first_contact','TikTok · Video sonrası DM','🇹🇷 Türkçe',
+ E'Selam [isim], [detay] videonu gördüm, güzel iş. Şu an hedefin ne — yağ yakmak mı, enerji mi, başka bir şey mi?',
+ E'Salut [name], vu ta vidéo sur [detay], beau boulot. Ton objectif c''est quoi — brûler du gras, l''énergie, autre chose ?',
+ E'TikTok homme = punchy, question concrète.', false),
+
+-- TR sport
+('tr','sport','insta',1,'first_contact','Instagram DM · İlk iletişim','🇹🇷 Türkçe',
+ E'Selam [isim] 💪 [detay] paylaşımın dikkatimi çekti, özellikle [point précis]. Antrenmanların çevresinde beslenmeni şu an nasıl yönetiyorsun?',
+ E'Salut [name] 💪 Ton post sur [detay] a attiré mon œil, surtout [point précis]. Tu gères comment ta nutrition autour de tes entraînements ?',
+ E'Sport = parler PERF, jamais kilo/régime. Diaspora DE idem.', false),
+
+('tr','sport','fb',1,'first_contact','Facebook Messenger · İlk iletişim','🇹🇷 Türkçe',
+ E'Merhaba [isim], [grup adı] grubundaki [detay] paylaşımını gördüm. Şu an özel bir şeye mi hazırlanıyorsun — yarış, hedef, yoksa genel kondisyon mu?',
+ E'Bonjour [name], vu ton post dans [groupe] sur [detay]. Tu prépares un truc en particulier — course, objectif, ou condition générale ?',
+ E'FB sport = groupes koşu/triatlon. Ton entre passionnés.', false),
+
+('tr','sport','whatsapp',1,'first_contact','WhatsApp · Doğrudan iletişim','🇹🇷 Türkçe',
+ E'Selam [isim], ben [adın], [bağlam] üzerinden tanışmıştık. [detay] hakkında konuşmuştun. Şu an neredesin?',
+ E'Salut [name], c''est [your name], on s''était connus via [contexte]. Tu m''avais parlé de [detay]. Tu en es où ?',
+ E'WhatsApp TR sport : poser le contexte avant tout.', false),
+
+('tr','sport','sms',1,'first_contact','SMS · Kısa ve sakin','🇹🇷 Türkçe',
+ E'Selam [isim], ben [adın]. Spor hedefin üzerine konuşmuştuk. Hâlâ onun üzerinde misin?',
+ E'Salut [name], c''est [your name]. On avait parlé de ton objectif sportif. Toujours dessus ?',
+ E'SMS court, factuel.', false),
+
+('tr','sport','tiktok',1,'first_contact','TikTok · Video sonrası DM','🇹🇷 Türkçe',
+ E'Selam [isim], [detay] videonu gördüm, helal olsun. Antrenmanlarının çevresinde bir beslenme stratejin var mı, yoksa içgüdüyle mi gidiyorsun?',
+ E'Salut [name], vu ta vidéo sur [detay], chapeau. Tu as une stratégie nutrition autour de l''entraînement, ou tu y vas à l''instinct ?',
+ E'"helal olsun" = respect fort entre passionnés. Reconnaissance technique.', false),
+
+-- TR business
+('tr','business','insta',1,'first_contact','Instagram DM · İlk iletişim','🇹🇷 Türkçe',
+ E'Selam [isim], [detay] dikkatimi çekti, özellikle [point précis]. Ne kadar süredir bu işin içindesin? Kendi yolunu çizen insanların hikayesi hep ilgimi çeker.',
+ E'Salut [name], [detay] a attiré mon œil, surtout [point précis]. Tu fais ça depuis combien de temps ? Le parcours des gens qui tracent leur propre voie m''intéresse toujours.',
+ E'Business = JAMAIS pitcher en M1. Le pitch direct est le marqueur MLM nº1, surtout sur ce marché.', false),
+
+('tr','business','fb',1,'first_contact','Facebook Messenger · İlk iletişim','🇹🇷 Türkçe',
+ E'Merhaba [isim], [grup adı] grubundaki [detay] paylaşımını gördüm, bana da yakın geldi — ben de benzer bir yoldayım. Şu an ne üzerine çalışıyorsun?',
+ E'Bonjour [name], vu ton post dans [groupe] sur [detay], ça m''a parlé — je suis sur une voie similaire. Tu travailles sur quoi en ce moment ?',
+ E'FB business = terrain commun d''abord, jamais l''offre.', false),
+
+('tr','business','whatsapp',1,'first_contact','WhatsApp · Doğrudan iletişim','🇹🇷 Türkçe',
+ E'Selam [isim], ben [adın], [bağlam] üzerinden tanışmıştık. Açık olayım: şu an bir şey kuruyorum ve profilin aklıma seni getirdi. Yeni projelere açık mısın, yoksa şu an tamamen kendi işine mi odaklısın?',
+ E'Salut [name], c''est [your name], on s''était connus via [contexte]. Je vais être franc : je construis quelque chose et ton profil m''a fait penser à toi. Tu es ouvert à de nouveaux projets, ou 100% focus sur ton activité ?',
+ E'WhatsApp business : transparence + filtre par question. Le "açık olayım" (je suis franc) désarme la méfiance MLM.', false),
+
+('tr','business','sms',1,'first_contact','SMS · Kısa ve sakin','🇹🇷 Türkçe',
+ E'Selam [isim], ben [adın]. Belirli bir nedenle yazıyorum — profilin, üzerinde çalıştığım bir projeyi hatırlattı. İlgini çekebilir mi, yoksa hiç mi senlik değil?',
+ E'Salut [name], c''est [your name]. J''écris pour une raison précise — ton profil m''a rappelé un projet sur lequel je bosse. Ça pourrait t''intéresser, ou pas du tout ?',
+ E'SMS business = direct, porte de sortie immédiate.', false),
+
+('tr','business','tiktok',1,'first_contact','TikTok · Video sonrası DM','🇹🇷 Türkçe',
+ E'Selam [isim], [detay] videon hoşuma gitti. Bunun yanında şu an ne üzerine çalışıyorsun?',
+ E'Salut [name], ta vidéo sur [detay] m''a plu. À côté de ça, tu travailles sur quoi en ce moment ?',
+ E'TikTok business = curiosité, pas de pitch.', false),
+
+('tr','business','linkedin',1,'first_contact','LinkedIn · İlk iletişim','🇹🇷 Türkçe',
+ E'Merhaba [isim], [leur secteur] alanındaki yolculuğunuz dikkatimi çekti, özellikle [point précis]. Kendi işini kuran kişilerle görüşmek hoşuma gidiyor. Şu an profesyonel olarak en çok neye odaklısınız?',
+ E'Bonjour [name], votre parcours dans [secteur] a retenu mon attention, surtout [point précis]. J''aime échanger avec des gens qui construisent par eux-mêmes. Sur quoi vous concentrez-vous le plus professionnellement ?',
+ E'Turquie business : LinkedIn moins utilisé qu''Insta/WhatsApp mais bon pour le corporate. Vouvoiement (siz).', false);
+
+-- ─── 🇮🇳 INDE (Hinglish) ──────────────────────────────────────────────────
+insert into public.prospection_scripts
+  (market_code, profile_slug, platform, position, kind, label, language_label, body, body_fr, tip, needs_native_review) values
+
+-- HI weight-women
+('hi','weight-women','insta',1,'first_contact','Instagram DM · First contact','🇮🇳 Hinglish',
+ E'Hi [name] 👋 Tera profile dekha, [detail] kaafi achha laga. Abhi tu zyada weight loss pe focus kar rahi hai, energy pe, ya dono pe?',
+ E'Salut [name] 👋 J''ai vu ton profil, [detail] m''a beaucoup plu. Là tu es plutôt focus perte de poids, énergie, ou les deux ?',
+ E'Inde : classe moyenne aisée écrit en Hinglish. Évite Devanagari sauf si profil le justifie.', false),
+
+('hi','weight-women','fb',1,'first_contact','Facebook Messenger · First contact','🇮🇳 Hinglish',
+ E'Hi [name], [group name] mein tera post dekha [detail] ke baare mein, dil ko chhua — main bhi us phase se guzri hu. Abhi is journey mein tu kahaan hai?',
+ E'Salut [name], vu ton post dans [groupe] sur [detail], ça m''a touchée — je suis passée par cette phase. Tu en es où dans ce parcours ?',
+ E'FB Inde ton posé. Groupes "weight loss India / healthy living" mine d''or.', false),
+
+('hi','weight-women','whatsapp',1,'first_contact','WhatsApp · Direct contact','🇮🇳 Hinglish',
+ E'Hi [name] 😊 Main [your name], hum [context] pe connect hue the. Tune better feel karne ki baat ki thi — abhi us pe kahaan hai tu?',
+ E'Salut [name] 😊 C''est [your name], on s''était connectées via [contexte]. Tu m''avais parlé de te sentir mieux — tu en es où ?',
+ E'WhatsApp = LE canal nº1 en Inde (700M+ users).', false),
+
+('hi','weight-women','sms',1,'first_contact','SMS · Short & grounded','🇮🇳 Hinglish',
+ E'Hi [name], main [your name]. DM mein kho na jaaye isliye SMS kar rahi hu. Hum [context] pe baat kar rahe the — abhi tere fitness goal pe kya scene hai?',
+ E'Salut [name], c''est [your name]. J''écris en SMS pour ne pas se perdre dans les DM. On parlait de [contexte] — où en es-tu sur ton objectif forme ?',
+ E'SMS Hinglish court, "real person" feel.', false),
+
+('hi','weight-women','tiktok',1,'first_contact','TikTok · Post-video DM','🇮🇳 Hinglish',
+ E'Hi [name]! Tera [detail] wala video achha laga. Abhi tu fitness journey pe hai, ya bas masti ke liye?',
+ E'Salut [name] ! Ta vidéo sur [detail] m''a plu. Tu es dans une démarche fitness, ou juste pour le fun ?',
+ E'TikTok Inde = ton léger, réf à la vidéo.', false),
+
+-- HI weight-men
+('hi','weight-men','insta',1,'first_contact','Instagram DM · First contact','🇮🇳 Hinglish',
+ E'Hi [name], tera [detail] wala post dekha. Quick question — tu zyada fat loss pe hai, clean muscle gain pe, ya daily energy wapas paane pe?',
+ E'Salut [name], vu ton post sur [detail]. Petite question — tu es plutôt fat loss, prise de muscle propre, ou retrouver ton énergie ?',
+ E'Hinglish naturel. Anglais technique + hindi conversationnel mélangé.', false),
+
+('hi','weight-men','fb',1,'first_contact','Facebook Messenger · First contact','🇮🇳 Hinglish',
+ E'Hi [name], [group name] mein tera [detail] wala post dekha. Abhi koi specific goal pe kaam kar raha hai ya experiment kar raha hai?',
+ E'Salut [name], vu ton post dans [groupe] sur [detail]. Tu bosses sur un objectif précis, ou tu expérimentes ?',
+ E'FB Messenger Inde ton posé. Groupes "men''s fitness India" mine d''or.', false),
+
+('hi','weight-men','whatsapp',1,'first_contact','WhatsApp · Direct contact','🇮🇳 Hinglish',
+ E'Hi [name], main [your name], hum [context] pe mile the. Tune [detail] ki baat ki thi. Abhi us pe kahaan hai?',
+ E'Salut [name], c''est [your name], on s''était rencontrés via [contexte]. Tu m''avais parlé de [detail]. Tu en es où ?',
+ E'WhatsApp #1 Inde. Hinglish chaleureux.', false),
+
+('hi','weight-men','sms',1,'first_contact','SMS · Short & grounded','🇮🇳 Hinglish',
+ E'Hi [name], main [your name]. Hum [context] pe baat kiye the. Abhi tere fitness goal pe kya scene hai?',
+ E'Salut [name], c''est [your name]. On parlait de [contexte]. Où en es-tu sur ton objectif forme ?',
+ E'SMS Hinglish court.', false),
+
+('hi','weight-men','tiktok',1,'first_contact','TikTok · Post-video DM','🇮🇳 Hinglish',
+ E'Hi [name], tera [detail] wala video dekha, badhiya. Abhi goal kya hai — fat loss, energy, ya kuch aur?',
+ E'Salut [name], vu ta vidéo sur [detail], bien joué. Ton objectif c''est quoi — fat loss, énergie, ou autre ?',
+ E'TikTok homme = punchy.', false),
+
+-- HI sport
+('hi','sport','insta',1,'first_contact','Instagram DM · First contact','🇮🇳 Hinglish',
+ E'Hi [name] 💪 Tera [detail] wala post dekha, especially [point précis]. Apne training ke around nutrition abhi kaise manage karta hai?',
+ E'Salut [name] 💪 Vu ton post sur [detail], surtout [point précis]. Tu gères comment ta nutrition autour de tes entraînements ?',
+ E'Athlètes indiens lisent EN aussi. Mentionner "desi" rassure sur la culture.', false),
+
+('hi','sport','fb',1,'first_contact','Facebook Messenger · First contact','🇮🇳 Hinglish',
+ E'Hi [name], [group name] mein tera [detail] wala post dekha. Abhi kisi specific cheez ki tayyari kar raha hai — race, goal, ya general fitness?',
+ E'Salut [name], vu ton post dans [groupe] sur [detail]. Tu prépares un truc précis — course, objectif, ou forme générale ?',
+ E'FB sport Inde = groupes running/cricket/gym.', false),
+
+('hi','sport','whatsapp',1,'first_contact','WhatsApp · Direct contact','🇮🇳 Hinglish',
+ E'Hi [name], main [your name], hum [context] pe mile the. Tune [detail] ki baat ki thi. Abhi kahaan hai us pe?',
+ E'Salut [name], c''est [your name], on s''était rencontrés via [contexte]. Tu m''avais parlé de [detail]. Tu en es où ?',
+ E'WhatsApp Inde sport : contexte d''abord.', false),
+
+('hi','sport','sms',1,'first_contact','SMS · Short & grounded','🇮🇳 Hinglish',
+ E'Hi [name], main [your name]. Tere sport goal pe baat hui thi. Abhi bhi us pe laga hua hai?',
+ E'Salut [name], c''est [your name]. On avait parlé de ton objectif sportif. Tu es toujours dessus ?',
+ E'SMS court.', false),
+
+('hi','sport','tiktok',1,'first_contact','TikTok · Post-video DM','🇮🇳 Hinglish',
+ E'Hi [name], tera [detail] wala video dekha, kamaal. Training ke around koi nutrition strategy hai, ya feeling pe chalta hai?',
+ E'Salut [name], vu ta vidéo sur [detail], impressionnant. Tu as une stratégie nutrition autour de l''entraînement, ou tu y vas au feeling ?',
+ E'TikTok sport = reconnaissance technique.', false),
+
+-- HI business
+('hi','business','insta',1,'first_contact','Instagram DM · First contact','🇮🇳 Hinglish',
+ E'Hi [name], tera [detail] dhyaan mein aaya, especially [point précis]. Tu kitne time se ye kar raha hai? Jo log apna khud ka kuch banate hai, unki journey hamesha interest karti hai mujhe.',
+ E'Salut [name], ton [detail] a attiré mon attention, surtout [point précis]. Tu fais ça depuis combien de temps ? Le parcours des gens qui construisent leur propre truc m''intéresse toujours.',
+ E'Inde = marché ULTRA saturé en DM "wellness opportunity". Le pitch direct est mortel. Curiosité sincère obligatoire.', false),
+
+('hi','business','fb',1,'first_contact','Facebook Messenger · First contact','🇮🇳 Hinglish',
+ E'Hi [name], [group name] mein tera [detail] wala post dekha, relate kiya — main bhi similar raah pe hu. Abhi tu kis pe kaam kar raha hai?',
+ E'Salut [name], vu ton post dans [groupe] sur [detail], je me suis reconnu — voie similaire. Tu bosses sur quoi en ce moment ?',
+ E'FB business = terrain commun d''abord.', false),
+
+('hi','business','whatsapp',1,'first_contact','WhatsApp · Direct contact','🇮🇳 Hinglish',
+ E'Hi [name], main [your name], hum [context] pe mile the. Honestly bata du — abhi main kuch build kar raha hu aur tera profile dekh ke tu yaad aaya. Tu naye projects ke liye open hai, ya abhi fully apne kaam pe focused hai?',
+ E'Salut [name], c''est [your name], on s''était rencontrés via [contexte]. Pour être franc — je construis quelque chose et ton profil m''a fait penser à toi. Tu es ouvert à de nouveaux projets, ou 100% focus sur ton activité ?',
+ E'WhatsApp business : transparence + filtre.', false),
+
+('hi','business','sms',1,'first_contact','SMS · Short & grounded','🇮🇳 Hinglish',
+ E'Hi [name], main [your name]. Ek specific reason se likh raha hu — tera profile mujhe ek project ki yaad dilaya jis pe main kaam kar raha hu. Interest ho sakta hai, ya bilkul nahi tera type?',
+ E'Salut [name], c''est [your name]. J''écris pour une raison précise — ton profil m''a rappelé un projet sur lequel je bosse. Ça pourrait t''intéresser, ou pas du tout ton genre ?',
+ E'SMS business = direct, porte de sortie.', false),
+
+('hi','business','tiktok',1,'first_contact','TikTok · Post-video DM','🇮🇳 Hinglish',
+ E'Hi [name], tera [detail] wala video achha laga. Iske saath-saath abhi tu kis pe kaam kar raha hai?',
+ E'Salut [name], ta vidéo sur [detail] m''a plu. À côté de ça, tu travailles sur quoi en ce moment ?',
+ E'TikTok business = curiosité, pas de pitch.', false),
+
+('hi','business','linkedin',1,'first_contact','LinkedIn · First contact','🇮🇳 Hinglish',
+ E'Hi [name], your journey in [their field] caught my attention, especially [point précis]. I enjoy connecting with people who are creating something of their own. What are you most focused on professionally these days?',
+ E'Bonjour [name], votre parcours dans [secteur] a retenu mon attention, surtout [point précis]. J''aime échanger avec des gens qui construisent par eux-mêmes. Sur quoi vous concentrez-vous le plus professionnellement ?',
+ E'Inde business : anglais corporate sur LinkedIn. Pas de pitch ni Zoom en M1.', false);
+
+-- ============================================================================
+-- INSERTS RELANCES J+3 (position=2, kind=j3_followup, platform='insta'=défaut)
+-- ============================================================================
+-- 4 profils × 6 marchés = 24 relances.
+-- weight-women + weight-men = MÊME message ("poids" unisexe).
+-- sport et business ont leur propre relance.
+
+insert into public.prospection_scripts
+  (market_code, profile_slug, platform, position, kind, label, language_label, body, body_fr, tip, needs_native_review) values
+
+-- ─── FR relances J+3 ─────────────────────────────────────────────────────
+('fr','weight-women','insta',2,'j3_followup','Relance J+3 · poids','🇫🇷 Français',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ null,
+ E'Ne pas en remettre une couche après J+3 si toujours rien.', false),
+
+('fr','weight-men','insta',2,'j3_followup','Relance J+3 · poids','🇫🇷 Français',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ null,
+ E'Ne pas en remettre une couche après J+3 si toujours rien.', false),
+
+('fr','sport','insta',2,'j3_followup','Relance J+3 · sport','🇫🇷 Français',
+ E'Hey [prénom] 🙂 Du coup, ta nutrition c''est plutôt au feeling ou tu suis un truc structuré ? Curieux de savoir ce qui marche pour toi.',
+ null,
+ E'Relance avec question ouverte, jamais de pitch.', false),
+
+('fr','business','insta',2,'j3_followup','Relance J+3 · business','🇫🇷 Français',
+ E'Hey [prénom], je voulais juste m''assurer que t''avais vu mon message. Si c''est "vu mais pas pour moi", dis-le franchement — c''est plus utile qu''un silence et je te relance pas. Et si c''est juste le timing, je suis là quand tu veux.',
+ null,
+ E'Relance business = honnête et directe, offre une sortie claire.', false),
+
+-- ─── EN relances J+3 ─────────────────────────────────────────────────────
+('en','weight-women','insta',2,'j3_followup','Relance J+3 · poids','🇬🇧 English',
+ E'Hey [name] 🙂 Didn''t want you to get lost in the DMs. If health / energy is on your mind right now, my door''s open — and if it''s not the moment, no worries at all 🌿',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ E'No salesy tone, pure conversation.', false),
+
+('en','weight-men','insta',2,'j3_followup','Relance J+3 · poids','🇬🇧 English',
+ E'Hey [name] 🙂 Didn''t want you to get lost in the DMs. If health / energy is on your mind right now, my door''s open — and if it''s not the moment, no worries at all 🌿',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ E'No salesy tone, pure conversation.', false),
+
+('en','sport','insta',2,'j3_followup','Relance J+3 · sport','🇬🇧 English',
+ E'Hey [name] 🙂 So is your nutrition more by feel, or do you follow something structured? Curious what works for you.',
+ E'Hey [prénom] 🙂 Du coup, ta nutrition c''est plutôt au feeling ou tu suis un truc structuré ? Curieux de savoir ce qui marche pour toi.',
+ E'Open question, never a pitch.', false),
+
+('en','business','insta',2,'j3_followup','Relance J+3 · business','🇬🇧 English',
+ E'Hey [name], just wanted to make sure you saw my message. If it''s "saw it, not for me", feel free to say so — more useful than silence and I won''t follow up again. And if it''s just timing, I''m around.',
+ E'Hey [prénom], je voulais juste m''assurer que t''avais vu mon message. Si c''est "vu mais pas pour moi", dis-le franchement — c''est plus utile qu''un silence et je te relance pas. Et si c''est juste le timing, je suis là quand tu veux.',
+ E'Honest and direct, offers a clean way out.', false),
+
+-- ─── ES relances J+3 ─────────────────────────────────────────────────────
+('es','weight-women','insta',2,'j3_followup','Relance J+3 · poids','🇲🇽 Español',
+ E'Hey [nombre] 🙂 No quería que se perdiera entre los DM. Si el tema forma / energía te resuena ahora, aquí estoy — y si no es el momento, tranquila 🌿',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ E'Tono conversacional, sin venta.', true),
+
+('es','weight-men','insta',2,'j3_followup','Relance J+3 · poids','🇲🇽 Español',
+ E'Hey [nombre] 🙂 No quería que se perdiera entre los DM. Si el tema forma / energía te resuena ahora, aquí estoy — y si no es el momento, tranquila 🌿',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ E'Tono conversacional, sin venta.', true),
+
+('es','sport','insta',2,'j3_followup','Relance J+3 · sport','🇲🇽 Español',
+ E'Hey [nombre] 🙂 ¿Tu nutrición la llevas más al feeling o sigues algo estructurado? Me da curiosidad saber qué te funciona.',
+ E'Hey [prénom] 🙂 Du coup, ta nutrition c''est plutôt au feeling ou tu suis un truc structuré ? Curieux de savoir ce qui marche pour toi.',
+ E'Pregunta abierta, sin pitch.', true),
+
+('es','business','insta',2,'j3_followup','Relance J+3 · business','🇲🇽 Español',
+ E'Hey [nombre], solo quería asegurarme de que viste mi mensaje. Si es "lo vi, no es para mí", dímelo con confianza — es más útil que el silencio y no insisto más. Y si es solo cuestión de timing, aquí estoy.',
+ E'Hey [prénom], je voulais juste m''assurer que t''avais vu mon message. Si c''est "vu mais pas pour moi", dis-le franchement — c''est plus utile qu''un silence et je te relance pas. Et si c''est juste le timing, je suis là quand tu veux.',
+ E'Honesto y directo, deja salida limpia.', true),
+
+-- ─── PT relances J+3 ─────────────────────────────────────────────────────
+('pt','weight-women','insta',2,'j3_followup','Relance J+3 · poids','🇧🇷 Português (BR)',
+ E'Ei [nome] 🙂 Não queria que se perdesse nas DM. Se o assunto forma / energia faz sentido pra você agora, tô aqui — e se não for o momento, sem problema 🌿',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ E'Tom de conversa, nada de venda.', true),
+
+('pt','weight-men','insta',2,'j3_followup','Relance J+3 · poids','🇧🇷 Português (BR)',
+ E'Ei [nome] 🙂 Não queria que se perdesse nas DM. Se o assunto forma / energia faz sentido pra você agora, tô aqui — e se não for o momento, sem problema 🌿',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ E'Tom de conversa, nada de venda.', true),
+
+('pt','sport','insta',2,'j3_followup','Relance J+3 · sport','🇧🇷 Português (BR)',
+ E'Ei [nome] 🙂 Sua nutrição é mais no feeling ou você segue algo estruturado? Fiquei curioso pra saber o que funciona pra você.',
+ E'Hey [prénom] 🙂 Du coup, ta nutrition c''est plutôt au feeling ou tu suis un truc structuré ? Curieux de savoir ce qui marche pour toi.',
+ E'Pergunta aberta, sem pitch.', true),
+
+('pt','business','insta',2,'j3_followup','Relance J+3 · business','🇧🇷 Português (BR)',
+ E'Ei [nome], só queria ter certeza de que você viu minha mensagem. Se for "vi, não é pra mim", pode falar tranquilo — é mais útil que o silêncio e não insisto mais. E se for só timing, tô por aqui.',
+ E'Hey [prénom], je voulais juste m''assurer que t''avais vu mon message. Si c''est "vu mais pas pour moi", dis-le franchement — c''est plus utile qu''un silence et je te relance pas. Et si c''est juste le timing, je suis là quand tu veux.',
+ E'Honesto e direto, oferece saída limpa.', true),
+
+-- ─── TR relances J+3 ─────────────────────────────────────────────────────
+('tr','weight-women','insta',2,'j3_followup','Relance J+3 · poids','🇹🇷 Türkçe',
+ E'Selam [isim] 🙂 Akışta kaybolma diye yazdım. Form / enerji konusu şu an sana hitap ediyorsa buradayım — uygun zaman değilse de hiç dert etme 🌿',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ E'Sohbet tonu, satış yok.', false),
+
+('tr','weight-men','insta',2,'j3_followup','Relance J+3 · poids','🇹🇷 Türkçe',
+ E'Selam [isim] 🙂 Akışta kaybolma diye yazdım. Form / enerji konusu şu an sana hitap ediyorsa buradayım — uygun zaman değilse de hiç dert etme 🌿',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ E'Sohbet tonu, satış yok.', false),
+
+('tr','sport','insta',2,'j3_followup','Relance J+3 · sport','🇹🇷 Türkçe',
+ E'Selam [isim] 🙂 Beslenmen daha çok içgüdüsel mi, yoksa yapılandırılmış bir şey mi takip ediyorsun? Sende ne işe yarıyor merak ettim.',
+ E'Hey [prénom] 🙂 Du coup, ta nutrition c''est plutôt au feeling ou tu suis un truc structuré ? Curieux de savoir ce qui marche pour toi.',
+ E'Açık soru, asla pitch yok.', false),
+
+('tr','business','insta',2,'j3_followup','Relance J+3 · business','🇹🇷 Türkçe',
+ E'Selam [isim], mesajımı gördün mü diye emin olmak istedim. "Gördüm ama bana göre değil" ise açıkça söyle — sessizlikten daha faydalı, bir daha rahatsız etmem. Sadece zamanlamaysa, buradayım.',
+ E'Hey [prénom], je voulais juste m''assurer que t''avais vu mon message. Si c''est "vu mais pas pour moi", dis-le franchement — c''est plus utile qu''un silence et je te relance pas. Et si c''est juste le timing, je suis là quand tu veux.',
+ E'Dürüst ve doğrudan, temiz bir çıkış sunar.', false),
+
+-- ─── HI relances J+3 ─────────────────────────────────────────────────────
+('hi','weight-women','insta',2,'j3_followup','Relance J+3 · poids','🇮🇳 Hinglish',
+ E'Hey [name] 🙂 Bas yeh ensure karna tha ki tu DM mein kho na jaaye. Agar health / energy abhi tere mind mein hai, main yahaan hu — aur agar abhi sahi time nahi hai, koi baat nahi 🌿',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ E'Conversation tone, no selling.', false),
+
+('hi','weight-men','insta',2,'j3_followup','Relance J+3 · poids','🇮🇳 Hinglish',
+ E'Hey [name] 🙂 Bas yeh ensure karna tha ki tu DM mein kho na jaaye. Agar health / energy abhi tere mind mein hai, main yahaan hu — aur agar abhi sahi time nahi hai, koi baat nahi 🌿',
+ E'Hey [prénom] 🙂 Je voulais pas te perdre dans le flux. Si le sujet forme / énergie te parle en ce moment, ma porte est ouverte — et si c''est pas le moment, ignore tranquille 🌿',
+ E'Conversation tone, no selling.', false),
+
+('hi','sport','insta',2,'j3_followup','Relance J+3 · sport','🇮🇳 Hinglish',
+ E'Hey [name] 🙂 Teri nutrition zyada feeling pe hai ya kuch structured follow karta hai? Curious hu ki tere liye kya kaam karta hai.',
+ E'Hey [prénom] 🙂 Du coup, ta nutrition c''est plutôt au feeling ou tu suis un truc structuré ? Curieux de savoir ce qui marche pour toi.',
+ E'Open question, no pitch.', false),
+
+('hi','business','insta',2,'j3_followup','Relance J+3 · business','🇮🇳 Hinglish',
+ E'Hey [name], bas confirm karna tha ki tune mera message dekha. Agar "dekha but mere liye nahi" hai, seedha bata de — silence se better hai aur main dobara follow up nahi karunga. Aur agar sirf timing ki baat hai, main yahaan hu.',
+ E'Hey [prénom], je voulais juste m''assurer que t''avais vu mon message. Si c''est "vu mais pas pour moi", dis-le franchement — c''est plus utile qu''un silence et je te relance pas. Et si c''est juste le timing, je suis là quand tu veux.',
+ E'Honest and direct, clean exit.', false);
+
+commit;
+
+-- ============================================================================
+-- VÉRIFICATION POST-SEED (à exécuter manuellement après push)
+-- ============================================================================
+-- SELECT market_code, profile_slug, COUNT(*) AS n
+--   FROM public.prospection_scripts
+--  GROUP BY market_code, profile_slug
+--  ORDER BY market_code, profile_slug;
+--
+-- Attendu : 6 marchés × 4 profils = 24 lignes.
+-- · business : 7 scripts par marché (insta/fb/wa/sms/tiktok M1 + linkedin M1 + relance J+3)
+-- · sport / weight-women / weight-men : 6 scripts (5 plateformes M1 + relance)
+--
+-- Total attendu : (6 + 6 + 6 + 7) × 6 = 150 scripts.

--- a/supabase/migrations/20261119220000_prospection_v5_replies_objections.sql
+++ b/supabase/migrations/20261119220000_prospection_v5_replies_objections.sql
@@ -1,0 +1,742 @@
+-- =============================================================================
+-- Chantier #3 V5 — Réponses M2/M3 + Objections CLEAN (2026-05-20)
+--
+-- Suite logique du seed M1 v5 clean. Mêmes principes :
+--   - Zéro pitch tant que le prospect n'a pas exprimé un besoin
+--   - Un "non" bien fermé > un non mal géré (jamais d'insistance)
+--   - M3 et objections génériques par langue (pas par plateforme)
+--
+-- Volume : 96 M2 + 48 M3 + 24 objections = 168 entrées.
+--
+-- Structure :
+--   - M2 (4 branches : positive / vague / negative / question)
+--     · weight-women + weight-men partagent contenu "perte de poids"
+--     · sport et business ont leur contenu propre
+--     · 4 profils × 4 branches × 6 langues = 96 entrées
+--   - M3 (2 chemins : hot / lukewarm) — génériques tous profils
+--     · 4 profils × 2 chemins × 6 langues = 48 entrées (dupliqué par profil)
+--   - Objections (4 slugs : cest-cher, pas-le-temps, herbalife-mlm, je-reflechis)
+--     · 4 × 6 langues = 24 entrées
+--     · upsert via ON CONFLICT (market_code, slug)
+--
+-- ES + PT marqués needs_native_review = true.
+-- =============================================================================
+
+begin;
+
+-- ─── 1. Schema : colonne needs_native_review + contrainte unique reply_tree ─
+
+alter table public.prospection_reply_tree
+  add column if not exists needs_native_review boolean not null default false;
+
+alter table public.prospection_objections
+  add column if not exists needs_native_review boolean not null default false;
+
+comment on column public.prospection_reply_tree.needs_native_review is
+  'V5 — true si le script doit être relu par natif avant prod (ES, PT).';
+comment on column public.prospection_objections.needs_native_review is
+  'V5 — true si la réponse doit être relue par natif (ES, PT).';
+
+alter table public.prospection_reply_tree
+  drop constraint if exists prospection_reply_tree_unique_combo;
+alter table public.prospection_reply_tree
+  add constraint prospection_reply_tree_unique_combo
+  unique (market_code, profile_slug, level, branch, position);
+
+-- ─── 2. Wipe existant ─────────────────────────────────────────────────────
+delete from public.prospection_reply_tree;
+delete from public.prospection_objections
+  where slug in ('cest-cher', 'pas-le-temps', 'herbalife-mlm', 'je-reflechis');
+
+-- ============================================================================
+-- M2 — Arbre 4 branches (positive / vague / negative / question)
+-- ============================================================================
+
+-- ─── 🇫🇷 FR M2 ────────────────────────────────────────────────────────────
+insert into public.prospection_reply_tree
+  (market_code, profile_slug, level, branch, body, body_fr, tip, position, needs_native_review) values
+
+-- FR poids (weight-women + weight-men même message)
+('fr','weight-women','M2','positive',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, null, 1, false),
+('fr','weight-women','M2','vague',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, null, 1, false),
+('fr','weight-women','M2','negative',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, null, 1, false),
+('fr','weight-women','M2','question',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, null, 1, false),
+
+('fr','weight-men','M2','positive',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, null, 1, false),
+('fr','weight-men','M2','vague',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, null, 1, false),
+('fr','weight-men','M2','negative',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, null, 1, false),
+('fr','weight-men','M2','question',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, null, 1, false),
+
+-- FR sport
+('fr','sport','M2','positive',
+ E'Top 💪 Dis-m''en plus : quel volume hebdo en ce moment, et c''est quoi le truc qui te gêne le plus — récup entre séances, énergie en fin de sortie, soucis digestifs en course ?',
+ null, null, 1, false),
+('fr','sport','M2','vague',
+ E'Cool si ça roule ! Juste par curiosité — tu enchaînes les semaines sans baisse, ou il y a des moments où tu sens que tu tires sur la corde ? Beaucoup se gèrent "bien" jusqu''à toucher un mur.',
+ null, null, 1, false),
+('fr','sport','M2','negative',
+ E'Pas de souci, je voulais juste poser la question 🙏 Bonne continuation sur tes entraînements, et si la nutrition devient un sujet un jour, reviens vers moi.',
+ null, null, 1, false),
+('fr','sport','M2','question',
+ E'Concrètement j''accompagne des sportifs sur la nutrition : avant/pendant/après l''effort, récup, énergie sur les longues. Mais dis-moi d''abord ce que tu cherches à améliorer — ça orientera ma réponse.',
+ null, null, 1, false),
+
+-- FR business
+('fr','business','M2','positive',
+ E'Cool, merci d''être ouvert 🙏 Pour faire simple : c''est du wellness, équipe internationale, un revenu en parallèle de ton activité. Avant de détailler — qu''est-ce qui te motive à explorer ça : revenu complémentaire, indépendance, ou curiosité ?',
+ null, null, 1, false),
+('fr','business','M2','vague',
+ E'Question légitime. Franchement : c''est un modèle de distribution de produits wellness, avec une équipe qui forme. Il y a un investissement de départ, ça se développe selon le temps mis. Tu vois le tableau ? Si c''est pas ton truc dis-le, je préfère un non clair.',
+ null, null, 1, false),
+('fr','business','M2','negative',
+ E'Pas de souci, merci d''avoir répondu franchement 🙏 J''avais tagué dans ma tête que c''était peut-être pas ton truc, c''est OK. Bonne continuation, et si un jour ça a du sens, ça se fera naturellement.',
+ null, null, 1, false),
+('fr','business','M2','question',
+ E'Tu vas droit au but, j''aime ça. Je bosse avec [entreprise] sur le wellness. Le produit c''est une moitié, l''autre c''est le modèle de distribution. Plus simple à expliquer en visio si t''es ouvert. Si t''as déjà un avis tranché sur ce type de modèle, dis-moi, on perd pas de temps.',
+ null, null, 1, false);
+
+-- ─── 🇬🇧 EN M2 ────────────────────────────────────────────────────────────
+insert into public.prospection_reply_tree
+  (market_code, profile_slug, level, branch, body, body_fr, tip, position, needs_native_review) values
+
+('en','weight-women','M2','positive',
+ E'Glad you told me [name] 🙏 To point you right — is this a long-time goal or something recent? And have you tried things that didn''t work?',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, 1, false),
+('en','weight-women','M2','vague',
+ E'I get it, it''s often like that — you feel you want to change without knowing exactly what. What bothers you most right now: the scale, how you feel in your clothes, your energy?',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, 1, false),
+('en','weight-women','M2','negative',
+ E'No worries [name], thanks for taking the time to reply 🙏 All the best, and if that ever changes, reach out anytime!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, 1, false),
+('en','weight-women','M2','question',
+ E'Good question! Basically I help with nutrition — no crash diets, we work on balance and habits that stick. But before I say more, tell me where you''re at — that''s what decides if I can actually help.',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, 1, false),
+
+('en','weight-men','M2','positive',
+ E'Glad you told me [name] 🙏 To point you right — is this a long-time goal or something recent? And have you tried things that didn''t work?',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, 1, false),
+('en','weight-men','M2','vague',
+ E'I get it, it''s often like that — you feel you want to change without knowing exactly what. What bothers you most right now: the scale, how you feel in your clothes, your energy?',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, 1, false),
+('en','weight-men','M2','negative',
+ E'No worries [name], thanks for taking the time to reply 🙏 All the best, and if that ever changes, reach out anytime!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, 1, false),
+('en','weight-men','M2','question',
+ E'Good question! Basically I help with nutrition — no crash diets, we work on balance and habits that stick. But before I say more, tell me where you''re at — that''s what decides if I can actually help.',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, 1, false),
+
+('en','sport','M2','positive',
+ E'Nice 💪 Tell me more: what''s your weekly volume right now, and what bugs you most — recovery between sessions, energy late in a run, gut issues during races?',
+ E'Top 💪 Dis-m''en plus : quel volume hebdo en ce moment, et c''est quoi le truc qui te gêne le plus — récup entre séances, énergie en fin de sortie, soucis digestifs en course ?',
+ null, 1, false),
+('en','sport','M2','vague',
+ E'Cool if it''s flowing! Just curious — do you string weeks together without a dip, or are there moments you feel you''re pushing it? Most manage "fine"... until they hit a wall.',
+ E'Cool si ça roule ! Juste par curiosité — tu enchaînes les semaines sans baisse, ou il y a des moments où tu sens que tu tires sur la corde ? Beaucoup se gèrent "bien" jusqu''à toucher un mur.',
+ null, 1, false),
+('en','sport','M2','negative',
+ E'No worries, just wanted to ask 🙏 Keep it up with your training, and if nutrition ever becomes a topic, reach out.',
+ E'Pas de souci, je voulais juste poser la question 🙏 Bonne continuation sur tes entraînements, et si la nutrition devient un sujet un jour, reviens vers moi.',
+ null, 1, false),
+('en','sport','M2','question',
+ E'Basically I work with athletes on nutrition: before/during/after effort, recovery, energy on long sessions. But tell me first what you want to improve — that''ll guide my answer.',
+ E'Concrètement j''accompagne des sportifs sur la nutrition : avant/pendant/après l''effort, récup, énergie sur les longues. Mais dis-moi d''abord ce que tu cherches à améliorer — ça orientera ma réponse.',
+ null, 1, false),
+
+('en','business','M2','positive',
+ E'Cool, thanks for being open 🙏 Simply put: it''s wellness, international team, income alongside your current thing. Before details — what''s driving you to explore this: extra income, independence, or curiosity?',
+ E'Cool, merci d''être ouvert 🙏 Pour faire simple : c''est du wellness, équipe internationale, un revenu en parallèle de ton activité. Avant de détailler — qu''est-ce qui te motive à explorer ça : revenu complémentaire, indépendance, ou curiosité ?',
+ null, 1, false),
+('en','business','M2','vague',
+ E'Fair question. Honestly: it''s a wellness product distribution model, with a team that trains you. There''s an upfront investment, it grows with the time you put in. See the picture? If it''s not your thing, say so — I prefer a clear no.',
+ E'Question légitime. Franchement : c''est un modèle de distribution de produits wellness, avec une équipe qui forme. Il y a un investissement de départ, ça se développe selon le temps mis. Tu vois le tableau ? Si c''est pas ton truc dis-le, je préfère un non clair.',
+ null, 1, false),
+('en','business','M2','negative',
+ E'No worries, thanks for the honest reply 🙏 I''d figured it might not be your thing, that''s totally fine. All the best, and if it ever makes sense down the line, it''ll happen naturally.',
+ E'Pas de souci, merci d''avoir répondu franchement 🙏 J''avais tagué dans ma tête que c''était peut-être pas ton truc, c''est OK. Bonne continuation, et si un jour ça a du sens, ça se fera naturellement.',
+ null, 1, false),
+('en','business','M2','question',
+ E'Straight to the point, I like it. I work with [company] in wellness. The product is one half, the other is the distribution model. Easier to explain over a call if you''re open. If you already have a firm opinion on this type of model, tell me — no time wasted either way.',
+ E'Tu vas droit au but, j''aime ça. Je bosse avec [entreprise] sur le wellness. Le produit c''est une moitié, l''autre c''est le modèle de distribution. Plus simple à expliquer en visio si t''es ouvert. Si t''as déjà un avis tranché sur ce type de modèle, dis-moi, on perd pas de temps.',
+ null, 1, false);
+
+-- ─── 🇲🇽 ES M2 (needs_native_review=true) ─────────────────────────────────
+insert into public.prospection_reply_tree
+  (market_code, profile_slug, level, branch, body, body_fr, tip, position, needs_native_review) values
+
+('es','weight-women','M2','positive',
+ E'Me alegra que me lo digas [nombre] 🙏 Para orientarte bien — ¿es una meta que tienes desde hace tiempo o algo reciente? ¿Ya probaste cosas que no funcionaron?',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, 1, true),
+('es','weight-women','M2','vague',
+ E'Te entiendo, suele pasar — sientes que quieres cambiar sin saber qué exactamente. ¿Qué te molesta más ahora: el número en la báscula, cómo te sientes con la ropa, tu energía?',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, 1, true),
+('es','weight-women','M2','negative',
+ E'Sin problema [nombre], gracias por tomarte el tiempo de responder 🙏 Que te vaya muy bien, y si algún día cambia, escríbeme cuando quieras.',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, 1, true),
+('es','weight-women','M2','question',
+ E'¡Buena pregunta! Básicamente acompaño en nutrición — sin dietas extremas, trabajamos el equilibrio y los hábitos que duran. Pero antes de contarte más, dime dónde estás tú — eso decide si puedo ayudarte.',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, 1, true),
+
+('es','weight-men','M2','positive',
+ E'Me alegra que me lo digas [nombre] 🙏 Para orientarte bien — ¿es una meta que tienes desde hace tiempo o algo reciente? ¿Ya probaste cosas que no funcionaron?',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, 1, true),
+('es','weight-men','M2','vague',
+ E'Te entiendo, suele pasar — sientes que quieres cambiar sin saber qué exactamente. ¿Qué te molesta más ahora: el número en la báscula, cómo te sientes con la ropa, tu energía?',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, 1, true),
+('es','weight-men','M2','negative',
+ E'Sin problema [nombre], gracias por tomarte el tiempo de responder 🙏 Que te vaya muy bien, y si algún día cambia, escríbeme cuando quieras.',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, 1, true),
+('es','weight-men','M2','question',
+ E'¡Buena pregunta! Básicamente acompaño en nutrición — sin dietas extremas, trabajamos el equilibrio y los hábitos que duran. Pero antes de contarte más, dime dónde estás tú — eso decide si puedo ayudarte.',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, 1, true),
+
+('es','sport','M2','positive',
+ E'¡Genial! 💪 Cuéntame más: ¿qué volumen semanal llevas ahora, y qué es lo que más te cuesta — recuperación entre sesiones, energía al final de una salida, problemas digestivos en carrera?',
+ E'Top 💪 Dis-m''en plus : quel volume hebdo en ce moment, et c''est quoi le truc qui te gêne le plus — récup entre séances, énergie en fin de sortie, soucis digestifs en course ?',
+ null, 1, true),
+('es','sport','M2','vague',
+ E'¡Bien si todo fluye! Solo por curiosidad — ¿encadenas semanas sin bajón, o hay momentos en que sientes que estás forzando? Muchos se manejan "bien"... hasta que chocan con un muro.',
+ E'Cool si ça roule ! Juste par curiosité — tu enchaînes les semaines sans baisse, ou il y a des moments où tu sens que tu tires sur la corde ? Beaucoup se gèrent "bien" jusqu''à toucher un mur.',
+ null, 1, true),
+('es','sport','M2','negative',
+ E'Sin problema, solo quería preguntar 🙏 Sigue así con tus entrenamientos, y si la nutrición se vuelve un tema algún día, escríbeme.',
+ E'Pas de souci, je voulais juste poser la question 🙏 Bonne continuation sur tes entraînements, et si la nutrition devient un sujet un jour, reviens vers moi.',
+ null, 1, true),
+('es','sport','M2','question',
+ E'Básicamente acompaño a deportistas en nutrición: antes/durante/después del esfuerzo, recuperación, energía en las largas. Pero dime primero qué quieres mejorar — eso orienta mi respuesta.',
+ E'Concrètement j''accompagne des sportifs sur la nutrition : avant/pendant/après l''effort, récup, énergie sur les longues. Mais dis-moi d''abord ce que tu cherches à améliorer — ça orientera ma réponse.',
+ null, 1, true),
+
+('es','business','M2','positive',
+ E'Genial, gracias por estar abierto 🙏 En simple: es wellness, equipo internacional, un ingreso en paralelo a lo tuyo. Antes de detallar — ¿qué te motiva a explorarlo: ingreso extra, independencia, o curiosidad?',
+ E'Cool, merci d''être ouvert 🙏 Pour faire simple : c''est du wellness, équipe internationale, un revenu en parallèle de ton activité. Avant de détailler — qu''est-ce qui te motive à explorer ça : revenu complémentaire, indépendance, ou curiosité ?',
+ null, 1, true),
+('es','business','M2','vague',
+ E'Pregunta válida. Honestamente: es un modelo de distribución de productos wellness, con un equipo que te forma. Hay una inversión inicial, crece según el tiempo que le metes. ¿Ves el panorama? Si no es lo tuyo, dilo — prefiero un no claro.',
+ E'Question légitime. Franchement : c''est un modèle de distribution de produits wellness, avec une équipe qui forme. Il y a un investissement de départ, ça se développe selon le temps mis. Tu vois le tableau ? Si c''est pas ton truc dis-le, je préfère un non clair.',
+ null, 1, true),
+('es','business','M2','negative',
+ E'Sin problema, gracias por responder con franqueza 🙏 Ya intuía que quizá no era lo tuyo, está perfecto. Que te vaya bien, y si algún día tiene sentido, se dará natural.',
+ E'Pas de souci, merci d''avoir répondu franchement 🙏 J''avais tagué dans ma tête que c''était peut-être pas ton truc, c''est OK. Bonne continuation, et si un jour ça a du sens, ça se fera naturellement.',
+ null, 1, true),
+('es','business','M2','question',
+ E'Vas al grano, me gusta. Trabajo con [marca] en wellness. El producto es una mitad, la otra es el modelo de distribución. Más fácil de explicar en una llamada si estás abierto. Si ya tienes una opinión firme sobre este tipo de modelo, dime — no perdemos tiempo.',
+ E'Tu vas droit au but, j''aime ça. Je bosse avec [entreprise] sur le wellness. Le produit c''est une moitié, l''autre c''est le modèle de distribution. Plus simple à expliquer en visio si t''es ouvert. Si t''as déjà un avis tranché sur ce type de modèle, dis-moi, on perd pas de temps.',
+ null, 1, true);
+
+-- ─── 🇧🇷 PT M2 (needs_native_review=true) ─────────────────────────────────
+insert into public.prospection_reply_tree
+  (market_code, profile_slug, level, branch, body, body_fr, tip, position, needs_native_review) values
+
+('pt','weight-women','M2','positive',
+ E'Que bom que você me falou [nome] 🙏 Pra te orientar direito — é uma meta antiga ou algo recente? E você já testou coisas que não deram certo?',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, 1, true),
+('pt','weight-women','M2','vague',
+ E'Te entendo, costuma ser assim — você sente que quer mudar sem saber exatamente o quê. O que mais te incomoda agora: o número na balança, como você se sente na roupa, sua energia?',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, 1, true),
+('pt','weight-women','M2','negative',
+ E'Sem problema [nome], obrigado por reservar um tempo pra responder 🙏 Tudo de bom, e se um dia mudar, me chama quando quiser!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, 1, true),
+('pt','weight-women','M2','question',
+ E'Boa pergunta! Basicamente acompanho na nutrição — sem dieta extrema, a gente trabalha equilíbrio e hábitos que duram. Mas antes de falar mais, me diz onde você está — é isso que decide se posso te ajudar.',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, 1, true),
+
+('pt','weight-men','M2','positive',
+ E'Que bom que você me falou [nome] 🙏 Pra te orientar direito — é uma meta antiga ou algo recente? E você já testou coisas que não deram certo?',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, 1, true),
+('pt','weight-men','M2','vague',
+ E'Te entendo, costuma ser assim — você sente que quer mudar sem saber exatamente o quê. O que mais te incomoda agora: o número na balança, como você se sente na roupa, sua energia?',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, 1, true),
+('pt','weight-men','M2','negative',
+ E'Sem problema [nome], obrigado por reservar um tempo pra responder 🙏 Tudo de bom, e se um dia mudar, me chama quando quiser!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, 1, true),
+('pt','weight-men','M2','question',
+ E'Boa pergunta! Basicamente acompanho na nutrição — sem dieta extrema, a gente trabalha equilíbrio e hábitos que duram. Mas antes de falar mais, me diz onde você está — é isso que decide se posso te ajudar.',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, 1, true),
+
+('pt','sport','M2','positive',
+ E'Massa! 💪 Me conta mais: qual seu volume semanal agora, e o que mais te incomoda — recuperação entre treinos, energia no fim de um treino longo, problemas digestivos na prova?',
+ E'Top 💪 Dis-m''en plus : quel volume hebdo en ce moment, et c''est quoi le truc qui te gêne le plus — récup entre séances, énergie en fin de sortie, soucis digestifs en course ?',
+ null, 1, true),
+('pt','sport','M2','vague',
+ E'Bom se tá fluindo! Só por curiosidade — você emenda as semanas sem queda, ou tem momentos que sente que tá forçando? Muita gente se vira "bem"... até bater num muro.',
+ E'Cool si ça roule ! Juste par curiosité — tu enchaînes les semaines sans baisse, ou il y a des moments où tu sens que tu tires sur la corde ? Beaucoup se gèrent "bien" jusqu''à toucher un mur.',
+ null, 1, true),
+('pt','sport','M2','negative',
+ E'Sem problema, só queria perguntar 🙏 Continua firme nos treinos, e se nutrição virar um assunto um dia, me chama.',
+ E'Pas de souci, je voulais juste poser la question 🙏 Bonne continuation sur tes entraînements, et si la nutrition devient un sujet un jour, reviens vers moi.',
+ null, 1, true),
+('pt','sport','M2','question',
+ E'Basicamente acompanho atletas na nutrição: antes/durante/depois do esforço, recuperação, energia nos longos. Mas me diz primeiro o que você quer melhorar — isso orienta minha resposta.',
+ E'Concrètement j''accompagne des sportifs sur la nutrition : avant/pendant/après l''effort, récup, énergie sur les longues. Mais dis-moi d''abord ce que tu cherches à améliorer — ça orientera ma réponse.',
+ null, 1, true),
+
+('pt','business','M2','positive',
+ E'Massa, obrigado por estar aberto 🙏 Resumindo: é wellness, equipe internacional, uma renda em paralelo ao que você faz. Antes de detalhar — o que te motiva a explorar isso: renda extra, independência, ou curiosidade?',
+ E'Cool, merci d''être ouvert 🙏 Pour faire simple : c''est du wellness, équipe internationale, un revenu en parallèle de ton activité. Avant de détailler — qu''est-ce qui te motive à explorer ça : revenu complémentaire, indépendance, ou curiosité ?',
+ null, 1, true),
+('pt','business','M2','vague',
+ E'Pergunta justa. Sinceramente: é um modelo de distribuição de produtos wellness, com uma equipe que te treina. Tem um investimento inicial, cresce conforme o tempo que você dedica. Vê o quadro? Se não é a sua praia, fala — prefiro um não claro.',
+ E'Question légitime. Franchement : c''est un modèle de distribution de produits wellness, avec une équipe qui forme. Il y a un investissement de départ, ça se développe selon le temps mis. Tu vois le tableau ? Si c''est pas ton truc dis-le, je préfère un non clair.',
+ null, 1, true),
+('pt','business','M2','negative',
+ E'Sem problema, obrigado por responder com franqueza 🙏 Já imaginava que talvez não fosse a sua praia, tá tudo certo. Tudo de bom, e se um dia fizer sentido, vai acontecer natural.',
+ E'Pas de souci, merci d''avoir répondu franchement 🙏 J''avais tagué dans ma tête que c''était peut-être pas ton truc, c''est OK. Bonne continuation, et si un jour ça a du sens, ça se fera naturellement.',
+ null, 1, true),
+('pt','business','M2','question',
+ E'Direto ao ponto, gosto disso. Trabalho com [empresa] em wellness. O produto é uma metade, a outra é o modelo de distribuição. Mais fácil explicar numa call se você estiver aberto. Se já tem uma opinião fechada sobre esse tipo de modelo, me fala — não perdemos tempo.',
+ E'Tu vas droit au but, j''aime ça. Je bosse avec [entreprise] sur le wellness. Le produit c''est une moitié, l''autre c''est le modèle de distribution. Plus simple à expliquer en visio si t''es ouvert. Si t''as déjà un avis tranché sur ce type de modèle, dis-moi, on perd pas de temps.',
+ null, 1, true);
+
+-- ─── 🇹🇷 TR M2 ────────────────────────────────────────────────────────────
+insert into public.prospection_reply_tree
+  (market_code, profile_slug, level, branch, body, body_fr, tip, position, needs_native_review) values
+
+('tr','weight-women','M2','positive',
+ E'Söylemen çok iyi oldu [isim] 🙏 Sana doğru yönlendirebilmek için — bu uzun zamandır olan bir hedef mi, yoksa yeni mi ortaya çıktı? Daha önce işe yaramayan şeyler denedin mi?',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, 1, false),
+('tr','weight-women','M2','vague',
+ E'Seni anlıyorum, çoğu zaman böyle olur — değişmek istediğini hissedersin ama tam olarak neyi bilemezsin. Şu an seni en çok ne rahatsız ediyor: tartıdaki rakam mı, kıyafetlerin içinde nasıl hissettiğin mi, enerjin mi?',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, 1, false),
+('tr','weight-women','M2','negative',
+ E'Sorun değil [isim], cevap vermeye zaman ayırdığın için teşekkürler 🙏 Yolun açık olsun, bir gün değişirse çekinmeden bana yaz!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, 1, false),
+('tr','weight-women','M2','question',
+ E'Güzel soru! Temelde beslenme konusunda eşlik ediyorum — aşırı diyet yok, dengeyi ve kalıcı alışkanlıkları çalışıyoruz. Ama daha fazlasını anlatmadan önce, sen nerede olduğunu söyle — sana yardım edebilir miyim onu belirleyen bu.',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, 1, false),
+
+('tr','weight-men','M2','positive',
+ E'Söylemen çok iyi oldu [isim] 🙏 Sana doğru yönlendirebilmek için — bu uzun zamandır olan bir hedef mi, yoksa yeni mi ortaya çıktı? Daha önce işe yaramayan şeyler denedin mi?',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, 1, false),
+('tr','weight-men','M2','vague',
+ E'Seni anlıyorum, çoğu zaman böyle olur — değişmek istediğini hissedersin ama tam olarak neyi bilemezsin. Şu an seni en çok ne rahatsız ediyor: tartıdaki rakam mı, kıyafetlerin içinde nasıl hissettiğin mi, enerjin mi?',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, 1, false),
+('tr','weight-men','M2','negative',
+ E'Sorun değil [isim], cevap vermeye zaman ayırdığın için teşekkürler 🙏 Yolun açık olsun, bir gün değişirse çekinmeden bana yaz!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, 1, false),
+('tr','weight-men','M2','question',
+ E'Güzel soru! Temelde beslenme konusunda eşlik ediyorum — aşırı diyet yok, dengeyi ve kalıcı alışkanlıkları çalışıyoruz. Ama daha fazlasını anlatmadan önce, sen nerede olduğunu söyle — sana yardım edebilir miyim onu belirleyen bu.',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, 1, false),
+
+('tr','sport','M2','positive',
+ E'Süper 💪 Biraz daha anlat: şu an haftalık hacmin ne, ve seni en çok zorlayan ne — seanslar arası toparlanma mı, uzun koşunun sonunda enerji mi, yarışta sindirim sorunları mı?',
+ E'Top 💪 Dis-m''en plus : quel volume hebdo en ce moment, et c''est quoi le truc qui te gêne le plus — récup entre séances, énergie en fin de sortie, soucis digestifs en course ?',
+ null, 1, false),
+('tr','sport','M2','vague',
+ E'İyiyse ne güzel! Sırf merak — haftaları düşüşsüz art arda getirebiliyor musun, yoksa zorladığını hissettiğin anlar oluyor mu? Çoğu kişi bir duvara toslayana kadar "iyi" idare eder.',
+ E'Cool si ça roule ! Juste par curiosité — tu enchaînes les semaines sans baisse, ou il y a des moments où tu sens que tu tires sur la corde ? Beaucoup se gèrent "bien" jusqu''à toucher un mur.',
+ null, 1, false),
+('tr','sport','M2','negative',
+ E'Sorun değil, sadece sormak istedim 🙏 Antrenmanlarında başarılar, beslenme bir gün konu olursa bana dön.',
+ E'Pas de souci, je voulais juste poser la question 🙏 Bonne continuation sur tes entraînements, et si la nutrition devient un sujet un jour, reviens vers moi.',
+ null, 1, false),
+('tr','sport','M2','question',
+ E'Temelde sporculara beslenme konusunda eşlik ediyorum: efor öncesi/sırası/sonrası, toparlanma, uzun mesafede enerji. Ama önce neyi geliştirmek istediğini söyle — cevabımı o belirler.',
+ E'Concrètement j''accompagne des sportifs sur la nutrition : avant/pendant/après l''effort, récup, énergie sur les longues. Mais dis-moi d''abord ce que tu cherches à améliorer — ça orientera ma réponse.',
+ null, 1, false),
+
+('tr','business','M2','positive',
+ E'Süper, açık olduğun için teşekkürler 🙏 Kısaca: wellness, uluslararası ekip, kendi işinin yanında bir gelir. Detaya girmeden — bunu keşfetmene ne motive ediyor: ek gelir mi, bağımsızlık mı, merak mı?',
+ E'Cool, merci d''être ouvert 🙏 Pour faire simple : c''est du wellness, équipe internationale, un revenu en parallèle de ton activité. Avant de détailler — qu''est-ce qui te motive à explorer ça : revenu complémentaire, indépendance, ou curiosité ?',
+ null, 1, false),
+('tr','business','M2','vague',
+ E'Haklı soru. Açıkçası: wellness ürünleri dağıtım modeli, seni eğiten bir ekiple. Başlangıç yatırımı var, harcadığın zamana göre büyüyor. Tabloyu görüyor musun? Senlik değilse söyle — net bir hayırı tercih ederim.',
+ E'Question légitime. Franchement : c''est un modèle de distribution de produits wellness, avec une équipe qui forme. Il y a un investissement de départ, ça se développe selon le temps mis. Tu vois le tableau ? Si c''est pas ton truc dis-le, je préfère un non clair.',
+ null, 1, false),
+('tr','business','M2','negative',
+ E'Sorun değil, açık yürekli cevap verdiğin için teşekkürler 🙏 Belki senlik olmayabilir diye düşünmüştüm, gayet normal. Yolun açık olsun, bir gün anlamlı gelirse doğal olarak olur.',
+ E'Pas de souci, merci d''avoir répondu franchement 🙏 J''avais tagué dans ma tête que c''était peut-être pas ton truc, c''est OK. Bonne continuation, et si un jour ça a du sens, ça se fera naturellement.',
+ null, 1, false),
+('tr','business','M2','question',
+ E'Sadede geliyorsun, sevdim. Wellness alanında [şirket] ile çalışıyorum. Ürün bir yarısı, diğer yarısı dağıtım modeli. Açıksan görüntülü konuşmada anlatmak daha kolay. Bu tür modeller hakkında net bir görüşün varsa söyle — ikimiz de zaman kaybetmeyiz.',
+ E'Tu vas droit au but, j''aime ça. Je bosse avec [entreprise] sur le wellness. Le produit c''est une moitié, l''autre c''est le modèle de distribution. Plus simple à expliquer en visio si t''es ouvert. Si t''as déjà un avis tranché sur ce type de modèle, dis-moi, on perd pas de temps.',
+ null, 1, false);
+
+-- ─── 🇮🇳 HI M2 ────────────────────────────────────────────────────────────
+insert into public.prospection_reply_tree
+  (market_code, profile_slug, level, branch, body, body_fr, tip, position, needs_native_review) values
+
+('hi','weight-women','M2','positive',
+ E'Achha laga ki tune bataya [name] 🙏 Theek se guide karne ke liye — ye purana goal hai ya recent? Aur tune pehle kuch try kiya jo kaam nahi aaya?',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, 1, false),
+('hi','weight-women','M2','vague',
+ E'Main samajhta hu, aksar aisa hi hota hai — change chahte ho par pata nahi exactly kya. Abhi sabse zyada kya bother karta hai: weighing scale ka number, kapdo mein kaisa feel hota hai, ya energy?',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, 1, false),
+('hi','weight-women','M2','negative',
+ E'Koi baat nahi [name], reply karne ke liye time nikalne ka shukriya 🙏 All the best, aur kabhi change ho to bina hichkichaye mujhe likhna!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, 1, false),
+('hi','weight-women','M2','question',
+ E'Achha sawaal! Basically main nutrition pe help karta hu — koi crash diet nahi, balance aur lasting habits pe kaam karte hai. Par aur batane se pehle, tu bata tu kahaan hai — wahi decide karta hai ki main help kar sakta hu ya nahi.',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, 1, false),
+
+('hi','weight-men','M2','positive',
+ E'Achha laga ki tune bataya [name] 🙏 Theek se guide karne ke liye — ye purana goal hai ya recent? Aur tune pehle kuch try kiya jo kaam nahi aaya?',
+ E'Top que tu me dises [prénom] 🙏 Pour mieux te répondre — c''est un objectif que tu as depuis longtemps ou c''est venu récemment ? Et tu as déjà testé des choses qui n''ont pas marché ?',
+ null, 1, false),
+('hi','weight-men','M2','vague',
+ E'Main samajhta hu, aksar aisa hi hota hai — change chahte ho par pata nahi exactly kya. Abhi sabse zyada kya bother karta hai: weighing scale ka number, kapdo mein kaisa feel hota hai, ya energy?',
+ E'Je te comprends, c''est souvent comme ça — on sent qu''on veut changer sans savoir quoi exactement. Qu''est-ce qui te dérange le plus aujourd''hui : le chiffre sur la balance, comment tu te sens dans tes vêtements, ton énergie ?',
+ null, 1, false),
+('hi','weight-men','M2','negative',
+ E'Koi baat nahi [name], reply karne ke liye time nikalne ka shukriya 🙏 All the best, aur kabhi change ho to bina hichkichaye mujhe likhna!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de répondre 🙏 Belle continuation, et si un jour ça change reviens vers moi sans hésiter !',
+ null, 1, false),
+('hi','weight-men','M2','question',
+ E'Achha sawaal! Basically main nutrition pe help karta hu — koi crash diet nahi, balance aur lasting habits pe kaam karte hai. Par aur batane se pehle, tu bata tu kahaan hai — wahi decide karta hai ki main help kar sakta hu ya nahi.',
+ E'Bonne question ! En gros j''accompagne en nutrition — pas de régime restrictif, on travaille l''équilibre et les habitudes qui tiennent. Mais avant de t''en dire plus, dis-moi où tu en es toi — c''est ça qui détermine si je peux t''aider.',
+ null, 1, false),
+
+('hi','sport','M2','positive',
+ E'Badhiya 💪 Aur batao: abhi weekly volume kya hai, aur sabse zyada kya pareshan karta hai — sessions ke beech recovery, lambi run ke end mein energy, ya race mein gut issues?',
+ E'Top 💪 Dis-m''en plus : quel volume hebdo en ce moment, et c''est quoi le truc qui te gêne le plus — récup entre séances, énergie en fin de sortie, soucis digestifs en course ?',
+ null, 1, false),
+('hi','sport','M2','vague',
+ E'Achha hai agar sab chal raha hai! Bas curiosity — weeks bina dip ke chalti hai, ya kabhi lagta hai over kar rahe ho? Zyadatar log "theek" manage karte hai... jab tak wall nahi aata.',
+ E'Cool si ça roule ! Juste par curiosité — tu enchaînes les semaines sans baisse, ou il y a des moments où tu sens que tu tires sur la corde ? Beaucoup se gèrent "bien" jusqu''à toucher un mur.',
+ null, 1, false),
+('hi','sport','M2','negative',
+ E'Koi baat nahi, bas poochna tha 🙏 Training mein lage raho, aur nutrition kabhi topic bane to mujhe likhna.',
+ E'Pas de souci, je voulais juste poser la question 🙏 Bonne continuation sur tes entraînements, et si la nutrition devient un sujet un jour, reviens vers moi.',
+ null, 1, false),
+('hi','sport','M2','question',
+ E'Basically main athletes ko nutrition pe help karta hu: effort se pehle/dauraan/baad, recovery, long sessions mein energy. Par pehle bata kya improve karna chahta hai — wahi meri reply guide karega.',
+ E'Concrètement j''accompagne des sportifs sur la nutrition : avant/pendant/après l''effort, récup, énergie sur les longues. Mais dis-moi d''abord ce que tu cherches à améliorer — ça orientera ma réponse.',
+ null, 1, false),
+
+('hi','business','M2','positive',
+ E'Cool, open hone ke liye shukriya 🙏 Simple mein: ye wellness hai, international team, tere kaam ke saath-saath ek income. Detail se pehle — isse explore karne ke liye kya motivate karta hai: extra income, independence, ya curiosity?',
+ E'Cool, merci d''être ouvert 🙏 Pour faire simple : c''est du wellness, équipe internationale, un revenu en parallèle de ton activité. Avant de détailler — qu''est-ce qui te motive à explorer ça : revenu complémentaire, indépendance, ou curiosité ?',
+ null, 1, false),
+('hi','business','M2','vague',
+ E'Sahi sawaal. Honestly: ye ek wellness product distribution model hai, ek team ke saath jo train karti hai. Ek starting investment hai, jitna time doge utna badhta hai. Picture samajh aaya? Agar tera type nahi hai to bata de — main clear na prefer karta hu.',
+ E'Question légitime. Franchement : c''est un modèle de distribution de produits wellness, avec une équipe qui forme. Il y a un investissement de départ, ça se développe selon le temps mis. Tu vois le tableau ? Si c''est pas ton truc dis-le, je préfère un non clair.',
+ null, 1, false),
+('hi','business','M2','negative',
+ E'Koi baat nahi, honestly reply karne ke liye shukriya 🙏 Mujhe laga tha shayad tera type na ho, bilkul theek hai. All the best, aur kabhi sense bane to naturally ho jaayega.',
+ E'Pas de souci, merci d''avoir répondu franchement 🙏 J''avais tagué dans ma tête que c''était peut-être pas ton truc, c''est OK. Bonne continuation, et si un jour ça a du sens, ça se fera naturellement.',
+ null, 1, false),
+('hi','business','M2','question',
+ E'Seedhe point pe, achha laga. Main [company] ke saath wellness mein kaam karta hu. Product ek half hai, dusra distribution model. Call pe samjhana easy hai agar tu open hai. Agar is type ke model pe already firm opinion hai to bata de — dono ka time bachega.',
+ E'Tu vas droit au but, j''aime ça. Je bosse avec [entreprise] sur le wellness. Le produit c''est une moitié, l''autre c''est le modèle de distribution. Plus simple à expliquer en visio si t''es ouvert. Si t''as déjà un avis tranché sur ce type de modèle, dis-moi, on perd pas de temps.',
+ null, 1, false);
+
+-- ============================================================================
+-- M3 — Suite de conversation (hot / lukewarm) — générique tous profils
+-- ============================================================================
+-- Thomas : "M3 et objections sont génériques par langue (pas par plateforme)".
+-- Comme la table a profile_slug NOT NULL, on duplique le contenu pour les 4
+-- profils par marché. Total : 4 profils × 2 chemins × 6 langues = 48.
+
+do $$
+declare
+  prof text;
+  profiles text[] := array['weight-women','weight-men','sport','business'];
+begin
+  foreach prof in array profiles loop
+    -- FR
+    insert into public.prospection_reply_tree (market_code, profile_slug, level, branch, body, body_fr, position, needs_native_review) values
+    ('fr', prof, 'M3', 'hot',
+     E'Ce que tu décris, je le vois souvent et c''est gérable avec la bonne approche. Je préfère pas tout balancer par écrit — on prend 15-20 min en visio cette semaine ? Je te montre comment je bosse, tu vois si ça te parle. Tu préfères [jour 1] ou [jour 2] ?',
+     null, 1, false),
+    ('fr', prof, 'M3', 'lukewarm',
+     E'Pas de souci, je veux pas te forcer la main. Je te laisse mon contact — si à un moment ça résonne, tu me fais signe. Et si tu veux un truc concret à tester d''ici là, dis-moi.',
+     null, 1, false);
+
+    -- EN
+    insert into public.prospection_reply_tree (market_code, profile_slug, level, branch, body, body_fr, position, needs_native_review) values
+    ('en', prof, 'M3', 'hot',
+     E'What you''re describing is common and very workable with the right approach. I''d rather not dump it all in writing — fancy 15-20 min on a call this week? I''ll show you how I work, you see if it clicks. [Day 1] or [Day 2]?',
+     E'Ce que tu décris, je le vois souvent et c''est gérable avec la bonne approche. Je préfère pas tout balancer par écrit — on prend 15-20 min en visio cette semaine ? Je te montre comment je bosse, tu vois si ça te parle. Tu préfères [jour 1] ou [jour 2] ?',
+     1, false),
+    ('en', prof, 'M3', 'lukewarm',
+     E'No worries, I won''t push. I''ll leave you my contact — if it ever resonates, reach out. And if you want something concrete to try in the meantime, just say.',
+     E'Pas de souci, je veux pas te forcer la main. Je te laisse mon contact — si à un moment ça résonne, tu me fais signe. Et si tu veux un truc concret à tester d''ici là, dis-moi.',
+     1, false);
+
+    -- ES (needs_native_review)
+    insert into public.prospection_reply_tree (market_code, profile_slug, level, branch, body, body_fr, position, needs_native_review) values
+    ('es', prof, 'M3', 'hot',
+     E'Lo que describes lo veo seguido y es muy manejable con el enfoque correcto. Prefiero no soltarlo todo por escrito — ¿15-20 min en una llamada esta semana? Te muestro cómo trabajo, ves si te late. ¿[Día 1] o [Día 2]?',
+     E'Ce que tu décris, je le vois souvent et c''est gérable avec la bonne approche. Je préfère pas tout balancer par écrit — on prend 15-20 min en visio cette semaine ? Je te montre comment je bosse, tu vois si ça te parle. Tu préfères [jour 1] ou [jour 2] ?',
+     1, true),
+    ('es', prof, 'M3', 'lukewarm',
+     E'Sin problema, no te quiero presionar. Te dejo mi contacto — si en algún momento te resuena, escríbeme. Y si quieres algo concreto para probar mientras, dime.',
+     E'Pas de souci, je veux pas te forcer la main. Je te laisse mon contact — si à un moment ça résonne, tu me fais signe. Et si tu veux un truc concret à tester d''ici là, dis-moi.',
+     1, true);
+
+    -- PT (needs_native_review)
+    insert into public.prospection_reply_tree (market_code, profile_slug, level, branch, body, body_fr, position, needs_native_review) values
+    ('pt', prof, 'M3', 'hot',
+     E'O que você descreve eu vejo direto e dá pra resolver com a abordagem certa. Prefiro não jogar tudo por escrito — que tal 15-20 min numa call essa semana? Te mostro como trabalho, você vê se faz sentido. [Dia 1] ou [Dia 2]?',
+     E'Ce que tu décris, je le vois souvent et c''est gérable avec la bonne approche. Je préfère pas tout balancer par écrit — on prend 15-20 min en visio cette semaine ? Je te montre comment je bosse, tu vois si ça te parle. Tu préfères [jour 1] ou [jour 2] ?',
+     1, true),
+    ('pt', prof, 'M3', 'lukewarm',
+     E'Sem problema, não quero te pressionar. Te deixo meu contato — se em algum momento fizer sentido, me chama. E se quiser algo concreto pra testar enquanto isso, é só falar.',
+     E'Pas de souci, je veux pas te forcer la main. Je te laisse mon contact — si à un moment ça résonne, tu me fais signe. Et si tu veux un truc concret à tester d''ici là, dis-moi.',
+     1, true);
+
+    -- TR
+    insert into public.prospection_reply_tree (market_code, profile_slug, level, branch, body, body_fr, position, needs_native_review) values
+    ('tr', prof, 'M3', 'hot',
+     E'Anlattığın şey sık görülür ve doğru yaklaşımla gayet çözülebilir. Hepsini yazılı dökmek istemem — bu hafta 15-20 dakika görüntülü konuşalım mı? Nasıl çalıştığımı gösteririm, sana uyuyor mu görürsün. [Gün 1] mi [Gün 2] mi?',
+     E'Ce que tu décris, je le vois souvent et c''est gérable avec la bonne approche. Je préfère pas tout balancer par écrit — on prend 15-20 min en visio cette semaine ? Je te montre comment je bosse, tu vois si ça te parle. Tu préfères [jour 1] ou [jour 2] ?',
+     1, false),
+    ('tr', prof, 'M3', 'lukewarm',
+     E'Sorun değil, zorlamak istemem. İletişimimi bırakıyorum — bir noktada içine sinerse haber ver. O zamana kadar test edecek somut bir şey istersen, söyle.',
+     E'Pas de souci, je veux pas te forcer la main. Je te laisse mon contact — si à un moment ça résonne, tu me fais signe. Et si tu veux un truc concret à tester d''ici là, dis-moi.',
+     1, false);
+
+    -- HI
+    insert into public.prospection_reply_tree (market_code, profile_slug, level, branch, body, body_fr, position, needs_native_review) values
+    ('hi', prof, 'M3', 'hot',
+     E'Jo tu describe kar raha hai wo common hai aur sahi approach se manageable hai. Sab likhke nahi dena chahta — is hafte 15-20 min call karein? Dikhata hu kaise kaam karta hu, tu dekh le click karta hai ya nahi. [Din 1] ya [Din 2]?',
+     E'Ce que tu décris, je le vois souvent et c''est gérable avec la bonne approche. Je préfère pas tout balancer par écrit — on prend 15-20 min en visio cette semaine ? Je te montre comment je bosse, tu vois si ça te parle. Tu préfères [jour 1] ou [jour 2] ?',
+     1, false),
+    ('hi', prof, 'M3', 'lukewarm',
+     E'Koi baat nahi, force nahi karunga. Apna contact chhod raha hu — kabhi resonate kare to bata dena. Aur tab tak kuch concrete try karna ho to bol dena.',
+     E'Pas de souci, je veux pas te forcer la main. Je te laisse mon contact — si à un moment ça résonne, tu me fais signe. Et si tu veux un truc concret à tester d''ici là, dis-moi.',
+     1, false);
+  end loop;
+end$$;
+
+-- ============================================================================
+-- OBJECTIONS — 4 slugs × 6 marchés = 24 entrées
+-- ============================================================================
+
+insert into public.prospection_objections
+  (market_code, slug, title, meaning, bad_response, good_response, good_response_fr, warning, position, needs_native_review) values
+
+-- ─── FR ───────────────────────────────────────────────────────────────────
+('fr','cest-cher','C''est cher',
+ E'Le prospect n''a pas vu la valeur, ou n''a pas le budget mental pour ça.',
+ E'Sortir une remise dans la seconde / minimiser ("c''est le prix d''un café").',
+ E'Je comprends. Cher par rapport à quoi ? Et qu''est-ce qui ferait que ça vaut le coup à tes yeux ? Selon ta réponse, soit c''est pas le moment, soit on voit une formule plus adaptée.',
+ null, null, 1, false),
+
+('fr','pas-le-temps','J''ai pas le temps',
+ E'Pas une vraie priorité, ou peur que ça lui prenne plus de temps qu''il en a.',
+ E'"Mais c''est rapide !" sans rien d''autre.',
+ E'C''est juste, et souvent c''est parce qu''on prend pas le temps que rien bouge. Si je te dis "on attend 3 mois et tu me redis", c''est ouvert ou c''est un non ferme ? Pas de mauvaise réponse.',
+ null, null, 2, false),
+
+('fr','herbalife-mlm','C''est un MLM / système pyramidal ?',
+ E'Méfiance saine — il a peut-être un proche déçu, ou une image négative ancrée.',
+ E'Nier, esquiver, dire "non c''est différent" sans expliquer.',
+ E'Oui c''est [entreprise], et oui c''est de la distribution multi-niveaux. Pas un système pyramidal illégal — la différence c''est qu''il y a un vrai produit consommé par des clients. Il y a du vrai et du faux qui circule là-dessus. Dis-moi ce qui te bloque précisément, je réponds franchement.',
+ null,
+ E'Mentir détruit ta crédibilité pour toujours. Transparence radicale.', 3, false),
+
+('fr','je-reflechis','Je vais réfléchir',
+ E'90 % du temps c''est un "non" poli. 10 % c''est un vrai besoin de digérer.',
+ E'"Prends ton temps !" (tu la perds définitivement).',
+ E'OK — c''est plutôt "oui mais j''ai besoin de digérer", ou "non mais je veux pas te le dire en face" ? Les deux sont OK, je préfère savoir. Si c''est non, on s''épargne du temps. Si c''est oui qui mûrit, on cale une date.',
+ null, null, 4, false),
+
+-- ─── EN ───────────────────────────────────────────────────────────────────
+('en','cest-cher','It''s expensive',
+ E'The prospect doesn''t see the value, or doesn''t have the mental budget for it.',
+ E'Drop a discount on the spot / downplay ("it''s the price of a coffee").',
+ E'I get it. Expensive compared to what? And what would make it worth it for you? Depending on your answer, either it''s not the moment, or we look at a better-fitting option.',
+ E'Je comprends. Cher par rapport à quoi ? Et qu''est-ce qui ferait que ça vaut le coup à tes yeux ? Selon ta réponse, soit c''est pas le moment, soit on voit une formule plus adaptée.',
+ null, 1, false),
+
+('en','pas-le-temps','I don''t have time',
+ E'Not a real priority, or fear it''ll take more time than they have.',
+ E'"But it''s quick!" with nothing else.',
+ E'Fair, and often it''s precisely because we don''t make time that nothing changes. If I say "let''s wait 3 months and you tell me", is that open or a firm no? No wrong answer.',
+ E'C''est juste, et souvent c''est parce qu''on prend pas le temps que rien bouge. Si je te dis "on attend 3 mois et tu me redis", c''est ouvert ou c''est un non ferme ? Pas de mauvaise réponse.',
+ null, 2, false),
+
+('en','herbalife-mlm','Is this an MLM / pyramid scheme?',
+ E'Healthy suspicion — they may know a disappointed friend, or have a negative image of this.',
+ E'Deny, deflect, say "no it''s different" without explaining.',
+ E'Yes it''s [company], and yes it''s multi-level distribution. Not an illegal pyramid — the difference is there''s a real product consumed by actual customers. There''s truth and myth around this. Tell me exactly what worries you, I''ll answer straight.',
+ E'Oui c''est [entreprise], et oui c''est de la distribution multi-niveaux. Pas un système pyramidal illégal — la différence c''est qu''il y a un vrai produit consommé par des clients. Il y a du vrai et du faux qui circule là-dessus. Dis-moi ce qui te bloque précisément, je réponds franchement.',
+ E'Lying destroys your credibility forever. Radical transparency.', 3, false),
+
+('en','je-reflechis','I''ll think about it',
+ E'90% of the time it''s a polite "no". 10% it''s a real need to digest.',
+ E'"Take your time!" (you lose them for good).',
+ E'OK — is it more "yes but I need to digest", or "no but I don''t want to say it to your face"? Both are fine, I''d rather know. If it''s no, we save time. If it''s a maturing yes, let''s set a date.',
+ E'OK — c''est plutôt "oui mais j''ai besoin de digérer", ou "non mais je veux pas te le dire en face" ? Les deux sont OK, je préfère savoir. Si c''est non, on s''épargne du temps. Si c''est oui qui mûrit, on cale une date.',
+ null, 4, false),
+
+-- ─── ES (needs_native_review=true) ────────────────────────────────────────
+('es','cest-cher','Está caro',
+ E'El prospecto no vio el valor, o no tiene el presupuesto mental para eso.',
+ E'Soltar un descuento al instante / minimizar ("es el precio de un café").',
+ E'Te entiendo. ¿Caro comparado con qué? ¿Y qué haría que valiera la pena para ti? Según tu respuesta, o no es el momento, o vemos una opción más adecuada.',
+ E'Je comprends. Cher par rapport à quoi ? Et qu''est-ce qui ferait que ça vaut le coup à tes yeux ? Selon ta réponse, soit c''est pas le moment, soit on voit une formule plus adaptée.',
+ null, 1, true),
+
+('es','pas-le-temps','No tengo tiempo',
+ E'No es una prioridad real, o miedo a que tome más tiempo del que tiene.',
+ E'"¡Pero es rápido!" sin nada más.',
+ E'Es justo, y muchas veces es porque no nos hacemos el tiempo que nada cambia. Si te digo "esperamos 3 meses y me dices", ¿es abierto o un no rotundo? No hay mala respuesta.',
+ E'C''est juste, et souvent c''est parce qu''on prend pas le temps que rien bouge. Si je te dis "on attend 3 mois et tu me redis", c''est ouvert ou c''est un non ferme ? Pas de mauvaise réponse.',
+ null, 2, true),
+
+('es','herbalife-mlm','¿Es un MLM / esquema piramidal?',
+ E'Desconfianza sana — quizás conoce a alguien decepcionado, o tiene una imagen negativa.',
+ E'Negar, esquivar, decir "no es diferente" sin explicar.',
+ E'Sí, es [marca], y sí, es distribución multinivel. No un esquema piramidal ilegal — la diferencia es que hay un producto real consumido por clientes. Hay verdades y mitos sobre esto. Dime qué te frena exactamente, te respondo con franqueza.',
+ E'Oui c''est [entreprise], et oui c''est de la distribution multi-niveaux. Pas un système pyramidal illégal — la différence c''est qu''il y a un vrai produit consommé par des clients. Il y a du vrai et du faux qui circule là-dessus. Dis-moi ce qui te bloque précisément, je réponds franchement.',
+ E'Mentir destruye tu credibilidad para siempre. Transparencia radical.', 3, true),
+
+('es','je-reflechis','Lo voy a pensar',
+ E'90 % del tiempo es un "no" educado. 10 % es real necesidad de digerir.',
+ E'"¡Tómate tu tiempo!" (lo pierdes para siempre).',
+ E'OK — ¿es más "sí pero necesito digerirlo", o "no pero no quiero decírtelo de frente"? Las dos están bien, prefiero saber. Si es no, ahorramos tiempo. Si es un sí que madura, fijamos fecha.',
+ E'OK — c''est plutôt "oui mais j''ai besoin de digérer", ou "non mais je veux pas te le dire en face" ? Les deux sont OK, je préfère savoir. Si c''est non, on s''épargne du temps. Si c''est oui qui mûrit, on cale une date.',
+ null, 4, true),
+
+-- ─── PT (needs_native_review=true) ────────────────────────────────────────
+('pt','cest-cher','Tá caro',
+ E'O prospect não viu o valor, ou não tem o orçamento mental pra isso.',
+ E'Soltar um desconto na hora / minimizar ("é o preço de um café").',
+ E'Entendo. Caro comparado com o quê? E o que faria valer a pena pra você? Dependendo da resposta, ou não é o momento, ou vemos uma opção mais adequada.',
+ E'Je comprends. Cher par rapport à quoi ? Et qu''est-ce qui ferait que ça vaut le coup à tes yeux ? Selon ta réponse, soit c''est pas le moment, soit on voit une formule plus adaptée.',
+ null, 1, true),
+
+('pt','pas-le-temps','Não tenho tempo',
+ E'Não é uma prioridade real, ou medo de que tome mais tempo do que tem.',
+ E'"Mas é rápido!" sem mais nada.',
+ E'É justo, e muitas vezes é porque a gente não arruma tempo que nada muda. Se eu disser "espera 3 meses e você me diz", é aberto ou um não firme? Não tem resposta errada.',
+ E'C''est juste, et souvent c''est parce qu''on prend pas le temps que rien bouge. Si je te dis "on attend 3 mois et tu me redis", c''est ouvert ou c''est un non ferme ? Pas de mauvaise réponse.',
+ null, 2, true),
+
+('pt','herbalife-mlm','É um MLM / esquema piramidal?',
+ E'Desconfiança saudável — talvez conheça alguém decepcionado, ou tenha uma imagem negativa.',
+ E'Negar, esquivar, dizer "não é diferente" sem explicar.',
+ E'Sim, é [empresa], e sim, é distribuição multinível. Não é pirâmide ilegal — a diferença é que tem um produto real consumido por clientes. Tem verdade e mito nisso. Me diz exatamente o que te trava, respondo na lata.',
+ E'Oui c''est [entreprise], et oui c''est de la distribution multi-niveaux. Pas un système pyramidal illégal — la différence c''est qu''il y a un vrai produit consommé par des clients. Il y a du vrai et du faux qui circule là-dessus. Dis-moi ce qui te bloque précisément, je réponds franchement.',
+ E'Mentir destrói sua credibilidade pra sempre. Transparência radical.', 3, true),
+
+('pt','je-reflechis','Vou pensar',
+ E'90 % das vezes é um "não" educado. 10 % é real necessidade de digerir.',
+ E'"Pega seu tempo!" (perde pra sempre).',
+ E'OK — é mais "sim mas preciso digerir", ou "não mas não quero falar na sua cara"? Os dois tão de boa, prefiro saber. Se for não, economizamos tempo. Se for um sim amadurecendo, marcamos uma data.',
+ E'OK — c''est plutôt "oui mais j''ai besoin de digérer", ou "non mais je veux pas te le dire en face" ? Les deux sont OK, je préfère savoir. Si c''est non, on s''épargne du temps. Si c''est oui qui mûrit, on cale une date.',
+ null, 4, true),
+
+-- ─── TR ───────────────────────────────────────────────────────────────────
+('tr','cest-cher','Pahalı',
+ E'Prospect değeri görmedi, ya da bunun için mental bütçesi yok.',
+ E'Anında indirim çıkarmak / önemsizleştirmek ("bir kahve fiyatı").',
+ E'Anlıyorum. Neye göre pahalı? Ve senin gözünde neyi değer kılardı? Cevabına göre ya zamanı değil, ya da daha uygun bir seçeneğe bakarız.',
+ E'Je comprends. Cher par rapport à quoi ? Et qu''est-ce qui ferait que ça vaut le coup à tes yeux ? Selon ta réponse, soit c''est pas le moment, soit on voit une formule plus adaptée.',
+ null, 1, false),
+
+('tr','pas-le-temps','Vaktim yok',
+ E'Gerçek bir öncelik değil, ya da olduğundan fazla zaman alacağından korkuyor.',
+ E'"Ama hızlı!" başka bir şey demeden.',
+ E'Haklısın, ve çoğu zaman tam da zaman ayırmadığımız için hiçbir şey değişmez. "3 ay bekleyelim, sonra söyle" desem, açık mı yoksa kesin bir hayır mı? Yanlış cevap yok.',
+ E'C''est juste, et souvent c''est parce qu''on prend pas le temps que rien bouge. Si je te dis "on attend 3 mois et tu me redis", c''est ouvert ou c''est un non ferme ? Pas de mauvaise réponse.',
+ null, 2, false),
+
+('tr','herbalife-mlm','Bu MLM / piramit şeması mı?',
+ E'Sağlıklı şüphe — belki hayal kırıklığına uğramış birini tanıyor, ya da olumsuz bir imgesi var.',
+ E'Reddetmek, kaçınmak, açıklamadan "hayır farklı" demek.',
+ E'Evet [şirket], ve evet çok katlı dağıtım. Yasadışı bir piramit değil — fark, gerçek müşteriler tarafından tüketilen gerçek bir ürün olması. Bu konuda doğru da var yanlış da. Tam olarak neyin seni durdurduğunu söyle, dürüstçe cevaplarım.',
+ E'Oui c''est [entreprise], et oui c''est de la distribution multi-niveaux. Pas un système pyramidal illégal — la différence c''est qu''il y a un vrai produit consommé par des clients. Il y a du vrai et du faux qui circule là-dessus. Dis-moi ce qui te bloque précisément, je réponds franchement.',
+ E'Yalan söylemek itibarını sonsuza dek yok eder. Radikal şeffaflık.', 3, false),
+
+('tr','je-reflechis','Düşüneceğim',
+ E'%90 zaman kibar bir "hayır". %10 gerçek sindirme ihtiyacı.',
+ E'"Zaman al!" (sonsuza kadar kaybedersin).',
+ E'Tamam — bu "evet ama sindirmem lazım" mı, yoksa "hayır ama yüzüne söylemek istemiyorum" mu? İkisi de olur, bilmeyi tercih ederim. Hayırsa zaman kazanırız. Olgunlaşan bir evetse bir tarih belirleriz.',
+ E'OK — c''est plutôt "oui mais j''ai besoin de digérer", ou "non mais je veux pas te le dire en face" ? Les deux sont OK, je préfère savoir. Si c''est non, on s''épargne du temps. Si c''est oui qui mûrit, on cale une date.',
+ null, 4, false),
+
+-- ─── HI ───────────────────────────────────────────────────────────────────
+('hi','cest-cher','Mehenga hai',
+ E'Prospect ne value nahi dekhi, ya iske liye mental budget nahi hai.',
+ E'Turant discount nikalna / minimize karna ("ek coffee ka price").',
+ E'Samajhta hu. Kiske comparison mein mehenga? Aur kya cheez ise tere liye worth banaegi? Tere jawab pe — ya to ye sahi time nahi, ya hum better option dekhte hai.',
+ E'Je comprends. Cher par rapport à quoi ? Et qu''est-ce qui ferait que ça vaut le coup à tes yeux ? Selon ta réponse, soit c''est pas le moment, soit on voit une formule plus adaptée.',
+ null, 1, false),
+
+('hi','pas-le-temps','Time nahi hai',
+ E'Real priority nahi hai, ya darr hai ki zyada time legi.',
+ E'"Par ye fast hai!" aur kuch nahi.',
+ E'Sahi hai, aur aksar isiliye kuch nahi badalta kyunki hum time nahi nikalte. Agar main kahu "3 mahine ruko phir batao", to wo open hai ya firm no? Koi galat jawab nahi.',
+ E'C''est juste, et souvent c''est parce qu''on prend pas le temps que rien bouge. Si je te dis "on attend 3 mois et tu me redis", c''est ouvert ou c''est un non ferme ? Pas de mauvaise réponse.',
+ null, 2, false),
+
+('hi','herbalife-mlm','Ye MLM / pyramid scheme hai?',
+ E'Healthy suspicion — shayad disappointed dost ko jaante hai, ya negative image hai.',
+ E'Deny karna, kaatna, "no it''s different" bina explain.',
+ E'Haan ye [company] hai, aur haan multi-level distribution hai. Illegal pyramid nahi — fark ye hai ki ek real product hai jo actual customers consume karte hai. Iske baare mein sach bhi hai aur myth bhi. Bata exactly kya rok raha hai, main seedha jawab dunga.',
+ E'Oui c''est [entreprise], et oui c''est de la distribution multi-niveaux. Pas un système pyramidal illégal — la différence c''est qu''il y a un vrai produit consommé par des clients. Il y a du vrai et du faux qui circule là-dessus. Dis-moi ce qui te bloque précisément, je réponds franchement.',
+ E'Jhooth bolne se credibility hamesha ke liye khatam. Radical transparency.', 3, false),
+
+('hi','je-reflechis','Sochta hu',
+ E'90% time ye polite "no" hai. 10% real need to digest.',
+ E'"Time le!" (hamesha ke liye kho diya).',
+ E'OK — ye zyada "haan par digest karna hai", ya "nahi par face pe nahi bolna chahta"? Dono theek hai, main jaanna prefer karunga. Agar no hai to time bachta hai. Agar maturing yes hai to ek date fix karte hai.',
+ E'OK — c''est plutôt "oui mais j''ai besoin de digérer", ou "non mais je veux pas te le dire en face" ? Les deux sont OK, je préfère savoir. Si c''est non, on s''épargne du temps. Si c''est oui qui mûrit, on cale une date.',
+ null, 4, false);
+
+commit;
+
+-- =============================================================================
+-- VÉRIFICATION POST-SEED (à exécuter manuellement après push)
+-- =============================================================================
+-- SELECT market_code, level, branch, COUNT(*) FROM prospection_reply_tree
+--  GROUP BY market_code, level, branch ORDER BY market_code, level, branch;
+-- Attendu : 144 entrées (96 M2 + 48 M3).
+--
+-- SELECT market_code, slug, title FROM prospection_objections
+--  ORDER BY market_code, slug;
+-- Attendu : 24 lignes (4 slugs × 6 marchés).

--- a/supabase/migrations/20261119230000_prospection_v5_followups_closing_special.sql
+++ b/supabase/migrations/20261119230000_prospection_v5_followups_closing_special.sql
@@ -1,0 +1,503 @@
+-- =============================================================================
+-- Chantier #3 V5 — Post-appel + Closing + Cas spéciaux CLEAN (2026-05-20)
+--
+-- Suite logique des seeds v5 (M1 + M2/M3 + objections déjà clean).
+--
+-- 3 chantiers :
+--   1. POST-APPEL    : 4 touches J0/J+2/J+5/J+30 × 6 langues = 24
+--   2. CLOSING       : 5 signaux + 3 scripts × 6 langues     = 48
+--   3. CAS SPÉCIAUX  : 3 playbooks × 6 langues               = 18
+--
+-- Total : 90 entrées.
+--
+-- Principes v5 appliqués partout :
+--   - Pas de "sans pression / no commitment"
+--   - Porte de sortie systématique (un "non" clair est plus utile qu'un silence)
+--   - Honnêteté radicale (jamais d'insistance, jamais de manipulation)
+--   - Sur final_no : laisser la porte ouverte propre, ne pas relancer
+--
+-- ES + PT marqués needs_native_review = true.
+-- =============================================================================
+
+begin;
+
+-- ─── Schema : colonnes needs_native_review + contraintes unique ───────────
+
+alter table public.prospection_followups
+  add column if not exists needs_native_review boolean not null default false;
+alter table public.prospection_closing
+  add column if not exists needs_native_review boolean not null default false;
+alter table public.prospection_special_cases
+  add column if not exists needs_native_review boolean not null default false;
+
+-- Contraintes unique pour idempotence
+alter table public.prospection_followups
+  drop constraint if exists prospection_followups_unique_combo;
+alter table public.prospection_followups
+  add constraint prospection_followups_unique_combo
+  unique (market_code, kind, day_offset);
+
+alter table public.prospection_closing
+  drop constraint if exists prospection_closing_unique_combo;
+alter table public.prospection_closing
+  add constraint prospection_closing_unique_combo
+  unique (market_code, kind, position);
+
+alter table public.prospection_special_cases
+  drop constraint if exists prospection_special_cases_unique_combo;
+alter table public.prospection_special_cases
+  add constraint prospection_special_cases_unique_combo
+  unique (market_code, kind);
+
+-- Wipe existant
+delete from public.prospection_followups;
+delete from public.prospection_closing;
+delete from public.prospection_special_cases;
+
+-- ============================================================================
+-- 1. POST-APPEL — 4 touches J0/J+2/J+5/J+30 × 6 langues = 24 entrées
+-- ============================================================================
+
+insert into public.prospection_followups
+  (market_code, kind, day_offset, title, body, body_fr, warning, position, needs_native_review) values
+
+-- FR
+('fr','post_call', 0, 'J0 · juste après l''appel',
+ E'Merci pour notre échange [prénom] 🙏 Petit récap : on a vu [point 1], [point 2], [point 3]. Je te laisse digérer — si tu veux qu''on creuse, dis-moi avant [date].',
+ null, null, 1, false),
+('fr','post_call', 2, 'J+2 · check léger',
+ E'Hey [prénom], j''espère que tu vas bien. Tu as eu le temps de regarder ce qu''on s''était dit ? Pas de pression — si tu as une question précise ou un blocage, dis-moi.',
+ null, null, 2, false),
+('fr','post_call', 5, 'J+5 · dernier message',
+ E'[prénom] dernier message de ma part — tu en es où dans ta réflexion ? Si c''est non c''est OK, dis-le moi clairement, je préfère un non franc qu''un silence. Et si c''est oui, on cale.',
+ null,
+ E'Si pas de réponse au J+5, tu ARRÊTES. Pas de J+6, J+10. Un non non-dit est un non.',
+ 3, false),
+('fr','post_call', 30, 'J+30 · check sympa',
+ E'Hey [prénom], ça fait un mois — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux de tes nouvelles.',
+ null, null, 4, false),
+
+-- EN
+('en','post_call', 0, 'D0 · right after the call',
+ E'Thanks for our chat [name] 🙏 Quick recap: we covered [point 1], [point 2], [point 3]. I''ll let you digest — if you want to dig deeper, let me know before [date].',
+ E'Merci pour notre échange [prénom] 🙏 Petit récap : on a vu [point 1], [point 2], [point 3]. Je te laisse digérer — si tu veux qu''on creuse, dis-moi avant [date].',
+ null, 1, false),
+('en','post_call', 2, 'D+2 · light check',
+ E'Hey [name], hope you''re well. Did you get a chance to look at what we discussed? No pressure — if you have a specific question or a sticking point, let me know.',
+ E'Hey [prénom], j''espère que tu vas bien. Tu as eu le temps de regarder ce qu''on s''était dit ? Pas de pression — si tu as une question précise ou un blocage, dis-moi.',
+ null, 2, false),
+('en','post_call', 5, 'D+5 · last message',
+ E'[name] last message from me — where are you with your thinking? If it''s no that''s OK, just tell me clearly, I''d rather a clear no than silence. And if it''s yes, let''s lock it in.',
+ E'[prénom] dernier message de ma part — tu en es où dans ta réflexion ? Si c''est non c''est OK, dis-le moi clairement, je préfère un non franc qu''un silence. Et si c''est oui, on cale.',
+ E'No reply at D+5, you STOP. No D+6, D+10. An unspoken no is a no.',
+ 3, false),
+('en','post_call', 30, 'D+30 · friendly check',
+ E'Hey [name], it''s been a month — how''s it going for you on [goal]? No pitch behind this, just genuinely curious about your news.',
+ E'Hey [prénom], ça fait un mois — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux de tes nouvelles.',
+ null, 4, false),
+
+-- ES (needs_native_review)
+('es','post_call', 0, 'D0 · justo después de la llamada',
+ E'Gracias por nuestra charla [nombre] 🙏 Resumen rápido: vimos [punto 1], [punto 2], [punto 3]. Te dejo digerirlo — si quieres profundizar, dime antes de [fecha].',
+ E'Merci pour notre échange [prénom] 🙏 Petit récap : on a vu [point 1], [point 2], [point 3]. Je te laisse digérer — si tu veux qu''on creuse, dis-moi avant [date].',
+ null, 1, true),
+('es','post_call', 2, 'D+2 · check ligero',
+ E'Hey [nombre], espero que estés bien. ¿Tuviste tiempo de mirar lo que hablamos? Sin presión — si tienes una pregunta concreta o un atasco, dime.',
+ E'Hey [prénom], j''espère que tu vas bien. Tu as eu le temps de regarder ce qu''on s''était dit ? Pas de pression — si tu as une question précise ou un blocage, dis-moi.',
+ null, 2, true),
+('es','post_call', 5, 'D+5 · último mensaje',
+ E'[nombre] último mensaje de mi parte — ¿dónde estás con tu reflexión? Si es no está OK, dímelo claramente, prefiero un no franco que un silencio. Y si es sí, lo cerramos.',
+ E'[prénom] dernier message de ma part — tu en es où dans ta réflexion ? Si c''est non c''est OK, dis-le moi clairement, je préfère un non franc qu''un silence. Et si c''est oui, on cale.',
+ E'Si no hay respuesta en D+5, PARAS. No D+6, D+10. Un no no dicho es un no.',
+ 3, true),
+('es','post_call', 30, 'D+30 · check amistoso',
+ E'Hey [nombre], pasó un mes — ¿cómo va para ti con [objetivo]? Sin pitch detrás, solo curioso de saber cómo estás.',
+ E'Hey [prénom], ça fait un mois — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux de tes nouvelles.',
+ null, 4, true),
+
+-- PT (needs_native_review)
+('pt','post_call', 0, 'D0 · logo após a call',
+ E'Obrigado pela nossa conversa [nome] 🙏 Resumo rápido: vimos [ponto 1], [ponto 2], [ponto 3]. Te deixo digerir — se quiser aprofundar, me fala antes de [data].',
+ E'Merci pour notre échange [prénom] 🙏 Petit récap : on a vu [point 1], [point 2], [point 3]. Je te laisse digérer — si tu veux qu''on creuse, dis-moi avant [date].',
+ null, 1, true),
+('pt','post_call', 2, 'D+2 · check leve',
+ E'Ei [nome], espero que esteja bem. Você teve tempo de olhar o que falamos? Sem pressão — se tiver uma pergunta específica ou um travamento, me fala.',
+ E'Hey [prénom], j''espère que tu vas bien. Tu as eu le temps de regarder ce qu''on s''était dit ? Pas de pression — si tu as une question précise ou un blocage, dis-moi.',
+ null, 2, true),
+('pt','post_call', 5, 'D+5 · última mensagem',
+ E'[nome] última mensagem da minha parte — onde você está na sua reflexão? Se for não tudo bem, me fala claramente, prefiro um não franco do que silêncio. E se for sim, a gente fecha.',
+ E'[prénom] dernier message de ma part — tu en es où dans ta réflexion ? Si c''est non c''est OK, dis-le moi clairement, je préfère un non franc qu''un silence. Et si c''est oui, on cale.',
+ E'Sem resposta no D+5, você PARA. Sem D+6, D+10. Um não não-dito é um não.',
+ 3, true),
+('pt','post_call', 30, 'D+30 · check amigável',
+ E'Ei [nome], faz um mês — como vai pra você no [objetivo]? Sem pitch atrás disso, só curioso pra saber das suas novidades.',
+ E'Hey [prénom], ça fait un mois — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux de tes nouvelles.',
+ null, 4, true),
+
+-- TR
+('tr','post_call', 0, 'G0 · görüşmeden hemen sonra',
+ E'Sohbetimiz için teşekkürler [isim] 🙏 Hızlı özet: [nokta 1], [nokta 2], [nokta 3] üzerinde durduk. Sindirmen için zaman bırakıyorum — derinleştirmek istersen, [tarih] öncesinde bana yaz.',
+ E'Merci pour notre échange [prénom] 🙏 Petit récap : on a vu [point 1], [point 2], [point 3]. Je te laisse digérer — si tu veux qu''on creuse, dis-moi avant [date].',
+ null, 1, false),
+('tr','post_call', 2, 'G+2 · hafif check',
+ E'Selam [isim], iyisindir umarım. Konuştuğumuz şeylere bakacak zaman buldun mu? Baskı yok — somut bir sorun ya da takıldığın bir yer varsa söyle.',
+ E'Hey [prénom], j''espère que tu vas bien. Tu as eu le temps de regarder ce qu''on s''était dit ? Pas de pression — si tu as une question précise ou un blocage, dis-moi.',
+ null, 2, false),
+('tr','post_call', 5, 'G+5 · son mesaj',
+ E'[isim] benden son mesaj — düşüncende nerede duruyorsun? Hayırsa da tamam, açıkça söyle, sessizliktense net bir hayırı tercih ederim. Ve evetse, sabitleyelim.',
+ E'[prénom] dernier message de ma part — tu en es où dans ta réflexion ? Si c''est non c''est OK, dis-le moi clairement, je préfère un non franc qu''un silence. Et si c''est oui, on cale.',
+ E'G+5''te cevap yoksa DURURSUN. G+6, G+10 yok. Söylenmemiş bir hayır da bir hayırdır.',
+ 3, false),
+('tr','post_call', 30, 'G+30 · samimi check',
+ E'Selam [isim], bir ay oldu — [hedef] üzerinde nasıl gidiyor? Arkasında pitch yok, sadece haberini merak ettim.',
+ E'Hey [prénom], ça fait un mois — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux de tes nouvelles.',
+ null, 4, false),
+
+-- HI
+('hi','post_call', 0, 'D0 · call ke turant baad',
+ E'Hamare baat-cheet ke liye shukriya [name] 🙏 Quick recap: humne [point 1], [point 2], [point 3] cover kiya. Digest karne ka time deta hu — dig karna ho to [date] se pehle bata.',
+ E'Merci pour notre échange [prénom] 🙏 Petit récap : on a vu [point 1], [point 2], [point 3]. Je te laisse digérer — si tu veux qu''on creuse, dis-moi avant [date].',
+ null, 1, false),
+('hi','post_call', 2, 'D+2 · halka check',
+ E'Hey [name], hope sab theek hai. Jo humne discuss kiya us pe nazar daalne ka time mila? Koi pressure nahi — agar specific sawaal hai ya kahin atak gaya hai, bata.',
+ E'Hey [prénom], j''espère que tu vas bien. Tu as eu le temps de regarder ce qu''on s''était dit ? Pas de pression — si tu as une question précise ou un blocage, dis-moi.',
+ null, 2, false),
+('hi','post_call', 5, 'D+5 · aakhri message',
+ E'[name] meri taraf se aakhri message — tu apni thinking mein kahaan hai? Agar no hai to OK, clearly bol de, silence se acha clear no hai. Aur agar yes hai to lock kar dete hai.',
+ E'[prénom] dernier message de ma part — tu en es où dans ta réflexion ? Si c''est non c''est OK, dis-le moi clairement, je préfère un non franc qu''un silence. Et si c''est oui, on cale.',
+ E'D+5 pe reply nahi to RUK JA. Koi D+6, D+10 nahi. Bina bola hua no bhi no hai.',
+ 3, false),
+('hi','post_call', 30, 'D+30 · friendly check',
+ E'Hey [name], ek mahina ho gaya — [goal] pe kaisa chal raha hai tere liye? Iske peeche koi pitch nahi, sirf curious hu teri news ke baare mein.',
+ E'Hey [prénom], ça fait un mois — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux de tes nouvelles.',
+ null, 4, false);
+
+-- ============================================================================
+-- 2. CLOSING — 5 signaux + 3 scripts × 6 langues = 48 entrées
+-- ============================================================================
+
+insert into public.prospection_closing
+  (market_code, kind, title, body, body_fr, position, needs_native_review) values
+
+-- ─── FR : 5 signaux + 3 scripts ───────────────────────────────────────────
+('fr','signal','Il pose des questions précises',
+ E'Il/elle te demande le prix, le démarrage, le délai, ce qui se passe en pratique. Quand on demande "comment", c''est qu''on a déjà dit oui mentalement.',
+ null, 1, false),
+('fr','signal','Il parle au futur',
+ E'"Quand je vais commencer", "ça va me prendre combien de temps", "je vais essayer". Le futur grammatical signale l''engagement intérieur.',
+ null, 2, false),
+('fr','signal','Il demande la durée / résultats attendus',
+ E'"En combien de temps on voit des résultats ?" Question de quelqu''un qui se projette déjà.',
+ null, 3, false),
+('fr','signal','Il compare avec un essai passé',
+ E'"J''avais essayé X et ça n''avait pas marché." Il cherche une raison de croire que cette fois c''est différent.',
+ null, 4, false),
+('fr','signal','Il pense aux autres',
+ E'"Tu pourrais aider ma sœur / mon collègue ?" Quand il pense à recommander avant même de signer, c''est mûr.',
+ null, 5, false),
+
+('fr','propose','Proposer le démarrage',
+ E'OK [prénom] — de ce que je vois on est aligné. Si tu te sens prêt(e), on démarre cette semaine. Tu choisis : pack [A] ou pack [B] ? Si tu hésites encore, dis-le moi franchement, je préfère.',
+ null, 1, false),
+('fr','hesitation','Quand il/elle hésite',
+ E'Je sens que tu hésites [prénom]. C''est plutôt le prix, le timing, ou le doute sur le résultat ? Dis-moi exactement ce qui te freine — je t''aiderai à voir clair, ou à dire non si c''est ça.',
+ null, 1, false),
+('fr','final_no','Encaisser un non',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de réfléchir 🙏 Je laisse la porte ouverte — si dans 3 ou 6 mois ça change, écris-moi sans hésiter. Belle continuation !',
+ null, 1, false),
+
+-- ─── EN ───────────────────────────────────────────────────────────────────
+('en','signal','They ask specific questions',
+ E'They ask the price, the start, the timeline, what happens in practice. Asking "how" means they''ve mentally said yes already.',
+ E'Il/elle te demande le prix, le démarrage, le délai, ce qui se passe en pratique. Quand on demande "comment", c''est qu''on a déjà dit oui mentalement.',
+ 1, false),
+('en','signal','They speak in future tense',
+ E'"When I start", "how long will it take me", "I''ll try". Grammatical future signals inner commitment.',
+ E'"Quand je vais commencer", "ça va me prendre combien de temps", "je vais essayer". Le futur grammatical signale l''engagement intérieur.',
+ 2, false),
+('en','signal','They ask about duration / expected results',
+ E'"How long before I see results?" Question of someone already projecting themselves into it.',
+ E'"En combien de temps on voit des résultats ?" Question de quelqu''un qui se projette déjà.',
+ 3, false),
+('en','signal','They compare with past attempts',
+ E'"I tried X and it didn''t work." They''re looking for a reason to believe this time is different.',
+ E'"J''avais essayé X et ça n''avait pas marché." Il cherche une raison de croire que cette fois c''est différent.',
+ 4, false),
+('en','signal','They think of others',
+ E'"Could you help my sister / colleague?" Thinking about referring before even signing themselves = ripe.',
+ E'"Tu pourrais aider ma sœur / mon collègue ?" Quand il pense à recommander avant même de signer, c''est mûr.',
+ 5, false),
+
+('en','propose','Propose the start',
+ E'OK [name] — from what I see we''re aligned. If you feel ready, let''s start this week. You pick: pack [A] or pack [B]? If you''re still hesitating, tell me frankly, I''d prefer that.',
+ E'OK [prénom] — de ce que je vois on est aligné. Si tu te sens prêt(e), on démarre cette semaine. Tu choisis : pack [A] ou pack [B] ? Si tu hésites encore, dis-le moi franchement, je préfère.',
+ 1, false),
+('en','hesitation','When they hesitate',
+ E'I sense you''re hesitating [name]. Is it the price, the timing, or doubt about the result? Tell me exactly what''s holding you back — I''ll help you see clearly, or say no if that''s it.',
+ E'Je sens que tu hésites [prénom]. C''est plutôt le prix, le timing, ou le doute sur le résultat ? Dis-moi exactement ce qui te freine — je t''aiderai à voir clair, ou à dire non si c''est ça.',
+ 1, false),
+('en','final_no','Take a no gracefully',
+ E'No worries [name], thanks for taking the time to think it through 🙏 I leave the door open — if in 3 or 6 months it changes, write me without hesitation. All the best!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de réfléchir 🙏 Je laisse la porte ouverte — si dans 3 ou 6 mois ça change, écris-moi sans hésiter. Belle continuation !',
+ 1, false),
+
+-- ─── ES (needs_native_review) ─────────────────────────────────────────────
+('es','signal','Hace preguntas específicas',
+ E'Te pregunta el precio, el inicio, el plazo, qué pasa en la práctica. Cuando alguien pregunta "cómo", ya dijo sí mentalmente.',
+ E'Il/elle te demande le prix, le démarrage, le délai, ce qui se passe en pratique. Quand on demande "comment", c''est qu''on a déjà dit oui mentalement.',
+ 1, true),
+('es','signal','Habla en futuro',
+ E'"Cuando empiece", "cuánto me va a tomar", "voy a probar". El futuro gramatical señala compromiso interior.',
+ E'"Quand je vais commencer", "ça va me prendre combien de temps", "je vais essayer". Le futur grammatical signale l''engagement intérieur.',
+ 2, true),
+('es','signal','Pregunta por duración / resultados esperados',
+ E'"¿En cuánto tiempo se ven resultados?" Pregunta de alguien que ya se proyecta dentro.',
+ E'"En combien de temps on voit des résultats ?" Question de quelqu''un qui se projette déjà.',
+ 3, true),
+('es','signal','Compara con un intento pasado',
+ E'"Probé X y no funcionó." Busca una razón para creer que esta vez es diferente.',
+ E'"J''avais essayé X et ça n''avait pas marché." Il cherche une raison de croire que cette fois c''est différent.',
+ 4, true),
+('es','signal','Piensa en otros',
+ E'"¿Podrías ayudar a mi hermana / colega?" Cuando piensa en recomendar antes de firmar = maduro.',
+ E'"Tu pourrais aider ma sœur / mon collègue ?" Quand il pense à recommander avant même de signer, c''est mûr.',
+ 5, true),
+
+('es','propose','Proponer el arranque',
+ E'OK [nombre] — por lo que veo estamos alineados. Si te sientes listo(a), arrancamos esta semana. Tú eliges: pack [A] o pack [B]? Si todavía dudas, dímelo con franqueza, lo prefiero.',
+ E'OK [prénom] — de ce que je vois on est aligné. Si tu te sens prêt(e), on démarre cette semaine. Tu choisis : pack [A] ou pack [B] ? Si tu hésites encore, dis-le moi franchement, je préfère.',
+ 1, true),
+('es','hesitation','Cuando duda',
+ E'Siento que dudas [nombre]. ¿Es más el precio, el timing, o la duda sobre el resultado? Dime exactamente qué te frena — te ayudo a ver claro, o a decir no si es eso.',
+ E'Je sens que tu hésites [prénom]. C''est plutôt le prix, le timing, ou le doute sur le résultat ? Dis-moi exactement ce qui te freine — je t''aiderai à voir clair, ou à dire non si c''est ça.',
+ 1, true),
+('es','final_no','Encajar un no con elegancia',
+ E'Sin problema [nombre], gracias por tomarte el tiempo de pensarlo 🙏 Dejo la puerta abierta — si en 3 o 6 meses cambia, escríbeme sin dudar. ¡Que te vaya muy bien!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de réfléchir 🙏 Je laisse la porte ouverte — si dans 3 ou 6 mois ça change, écris-moi sans hésiter. Belle continuation !',
+ 1, true),
+
+-- ─── PT (needs_native_review) ─────────────────────────────────────────────
+('pt','signal','Faz perguntas específicas',
+ E'Te pergunta o preço, o início, o prazo, o que acontece na prática. Quando alguém pergunta "como", já disse sim mentalmente.',
+ E'Il/elle te demande le prix, le démarrage, le délai, ce qui se passe en pratique. Quand on demande "comment", c''est qu''on a déjà dit oui mentalement.',
+ 1, true),
+('pt','signal','Fala no futuro',
+ E'"Quando eu começar", "quanto vai me levar", "vou tentar". O futuro gramatical sinaliza o compromisso interior.',
+ E'"Quand je vais commencer", "ça va me prendre combien de temps", "je vais essayer". Le futur grammatical signale l''engagement intérieur.',
+ 2, true),
+('pt','signal','Pergunta sobre duração / resultados',
+ E'"Em quanto tempo dá pra ver resultados?" Pergunta de alguém que já se projeta dentro.',
+ E'"En combien de temps on voit des résultats ?" Question de quelqu''un qui se projette déjà.',
+ 3, true),
+('pt','signal','Compara com tentativa passada',
+ E'"Tentei X e não deu certo." Procura uma razão pra acreditar que dessa vez é diferente.',
+ E'"J''avais essayé X et ça n''avait pas marché." Il cherche une raison de croire que cette fois c''est différent.',
+ 4, true),
+('pt','signal','Pensa em outros',
+ E'"Você poderia ajudar minha irmã / colega?" Quando pensa em indicar antes de assinar = maduro.',
+ E'"Tu pourrais aider ma sœur / mon collègue ?" Quand il pense à recommander avant même de signer, c''est mûr.',
+ 5, true),
+
+('pt','propose','Propor o arranque',
+ E'OK [nome] — pelo que vejo estamos alinhados. Se você se sente pronto(a), começamos essa semana. Você escolhe: pack [A] ou pack [B]? Se ainda hesita, fala com franqueza, prefiro.',
+ E'OK [prénom] — de ce que je vois on est aligné. Si tu te sens prêt(e), on démarre cette semaine. Tu choisis : pack [A] ou pack [B] ? Si tu hésites encore, dis-le moi franchement, je préfère.',
+ 1, true),
+('pt','hesitation','Quando hesita',
+ E'Sinto que você tá hesitando [nome]. É mais o preço, o timing, ou a dúvida sobre o resultado? Me diz exatamente o que te trava — te ajudo a ver claro, ou a dizer não se for isso.',
+ E'Je sens que tu hésites [prénom]. C''est plutôt le prix, le timing, ou le doute sur le résultat ? Dis-moi exactement ce qui te freine — je t''aiderai à voir clair, ou à dire non si c''est ça.',
+ 1, true),
+('pt','final_no','Aceitar um não com elegância',
+ E'Sem problema [nome], obrigado por reservar tempo pra refletir 🙏 Deixo a porta aberta — se em 3 ou 6 meses mudar, me escreve sem hesitar. Tudo de bom!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de réfléchir 🙏 Je laisse la porte ouverte — si dans 3 ou 6 mois ça change, écris-moi sans hésiter. Belle continuation !',
+ 1, true),
+
+-- ─── TR ───────────────────────────────────────────────────────────────────
+('tr','signal','Spesifik sorular soruyor',
+ E'Fiyatı, başlangıcı, süreyi, pratikte ne olduğunu soruyor. "Nasıl" sorduğunda zihninde zaten evet demiş demektir.',
+ E'Il/elle te demande le prix, le démarrage, le délai, ce qui se passe en pratique. Quand on demande "comment", c''est qu''on a déjà dit oui mentalement.',
+ 1, false),
+('tr','signal','Gelecek zamanda konuşuyor',
+ E'"Başladığımda", "ne kadar sürer", "deneyeceğim". Dilbilgisel gelecek iç bağlılığı işaret eder.',
+ E'"Quand je vais commencer", "ça va me prendre combien de temps", "je vais essayer". Le futur grammatical signale l''engagement intérieur.',
+ 2, false),
+('tr','signal','Süre / beklenen sonuçları soruyor',
+ E'"Ne kadar zamanda sonuç görüyoruz?" Kendini içine yansıtmış birinin sorusu.',
+ E'"En combien de temps on voit des résultats ?" Question de quelqu''un qui se projette déjà.',
+ 3, false),
+('tr','signal','Geçmiş bir denemeyle karşılaştırıyor',
+ E'"X''i denedim, işe yaramadı." Bu seferin farklı olduğuna inanmak için bir sebep arıyor.',
+ E'"J''avais essayé X et ça n''avait pas marché." Il cherche une raison de croire que cette fois c''est différent.',
+ 4, false),
+('tr','signal','Başkalarını düşünüyor',
+ E'"Kardeşime / meslektaşıma yardım edebilir misin?" İmzalamadan tavsiye etmeyi düşünmek = olgun.',
+ E'"Tu pourrais aider ma sœur / mon collègue ?" Quand il pense à recommander avant même de signer, c''est mûr.',
+ 5, false),
+
+('tr','propose','Başlamayı önermek',
+ E'Tamam [isim] — gördüğüm kadarıyla uyumluyuz. Kendini hazır hissediyorsan bu hafta başlayalım. Sen seç: pack [A] mı pack [B] mi? Hâlâ tereddüt ediyorsan açıkça söyle, onu tercih ederim.',
+ E'OK [prénom] — de ce que je vois on est aligné. Si tu te sens prêt(e), on démarre cette semaine. Tu choisis : pack [A] ou pack [B] ? Si tu hésites encore, dis-le moi franchement, je préfère.',
+ 1, false),
+('tr','hesitation','Tereddüt ederken',
+ E'Tereddüt ettiğini hissediyorum [isim]. Fiyat mı, zamanlama mı, yoksa sonuç hakkında şüphe mi? Tam olarak neyin seni durdurduğunu söyle — net görmene yardım edeceğim, ya da gerekirse hayır demene.',
+ E'Je sens que tu hésites [prénom]. C''est plutôt le prix, le timing, ou le doute sur le résultat ? Dis-moi exactement ce qui te freine — je t''aiderai à voir clair, ou à dire non si c''est ça.',
+ 1, false),
+('tr','final_no','Bir hayırı zarafetle karşılamak',
+ E'Sorun değil [isim], düşünmek için zaman ayırdığın için teşekkürler 🙏 Kapıyı açık bırakıyorum — 3 ya da 6 ay sonra değişirse, tereddüt etmeden yaz. Yolun açık olsun!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de réfléchir 🙏 Je laisse la porte ouverte — si dans 3 ou 6 mois ça change, écris-moi sans hésiter. Belle continuation !',
+ 1, false),
+
+-- ─── HI ───────────────────────────────────────────────────────────────────
+('hi','signal','Specific sawaal poochta hai',
+ E'Price, start, timeline, practically kya hota hai poochta hai. Jab "kaise" puchhe to mentally already yes bola hua hai.',
+ E'Il/elle te demande le prix, le démarrage, le délai, ce qui se passe en pratique. Quand on demande "comment", c''est qu''on a déjà dit oui mentalement.',
+ 1, false),
+('hi','signal','Future tense mein baat karta hai',
+ E'"Jab main start karunga", "kitna time lagega mujhe", "try karunga". Grammatical future inner commitment dikhata hai.',
+ E'"Quand je vais commencer", "ça va me prendre combien de temps", "je vais essayer". Le futur grammatical signale l''engagement intérieur.',
+ 2, false),
+('hi','signal','Duration / expected results poochta hai',
+ E'"Kitne time mein results dikhte hai?" Sawaal us insaan ka jo already khud ko isme project kar raha hai.',
+ E'"En combien de temps on voit des résultats ?" Question de quelqu''un qui se projette déjà.',
+ 3, false),
+('hi','signal','Past attempt se compare karta hai',
+ E'"Maine X try kiya tha aur kaam nahi aaya tha." Wo reason dhundh raha hai believe karne ka ki is baar alag hai.',
+ E'"J''avais essayé X et ça n''avait pas marché." Il cherche une raison de croire que cette fois c''est différent.',
+ 4, false),
+('hi','signal','Doosron ke baare mein sochta hai',
+ E'"Kya tu meri behan / colleague ki help kar sakta hai?" Sign karne se pehle recommendation soche to = mature.',
+ E'"Tu pourrais aider ma sœur / mon collègue ?" Quand il pense à recommander avant même de signer, c''est mûr.',
+ 5, false),
+
+('hi','propose','Start propose karna',
+ E'OK [name] — jo main dekh raha hu hum aligned hai. Agar ready feel kar raha hai to is hafte start karte hai. Tu choose kar: pack [A] ya pack [B]? Agar ab bhi hesitate kar raha hai to honestly bata, main wo prefer karunga.',
+ E'OK [prénom] — de ce que je vois on est aligné. Si tu te sens prêt(e), on démarre cette semaine. Tu choisis : pack [A] ou pack [B] ? Si tu hésites encore, dis-le moi franchement, je préfère.',
+ 1, false),
+('hi','hesitation','Jab hesitate kare',
+ E'Lagta hai tu hesitate kar raha hai [name]. Ye price hai, timing hai, ya result ke baare mein doubt? Exactly bata kya rok raha hai — main clear karne mein help karunga, ya no bolne mein agar wo hai.',
+ E'Je sens que tu hésites [prénom]. C''est plutôt le prix, le timing, ou le doute sur le résultat ? Dis-moi exactement ce qui te freine — je t''aiderai à voir clair, ou à dire non si c''est ça.',
+ 1, false),
+('hi','final_no','No ko gracefully accept karna',
+ E'Koi baat nahi [name], sochne ke liye time nikalne ka shukriya 🙏 Door open chhod raha hu — agar 3 ya 6 mahine mein change ho to bina hichkichaye likhna. All the best!',
+ E'Pas de souci [prénom], merci d''avoir pris le temps de réfléchir 🙏 Je laisse la porte ouverte — si dans 3 ou 6 mois ça change, écris-moi sans hésiter. Belle continuation !',
+ 1, false);
+
+-- ============================================================================
+-- 3. CAS SPÉCIAUX — 3 playbooks × 6 langues = 18 entrées
+-- ============================================================================
+
+insert into public.prospection_special_cases
+  (market_code, kind, title, body, body_fr, position, needs_native_review) values
+
+-- FR
+('fr','ghost_after_exchange','Ghosting après plusieurs échanges',
+ E'[prénom], je voulais pas te lâcher comme ça — soit le timing est pas bon, soit le sujet t''intéresse pas, soit j''ai mal expliqué. Dis-moi juste lequel des trois et je m''adapte (ou je te laisse tranquille, promis).',
+ null, 1, false),
+
+('fr','reactivation_3_6m','Réactivation après 3-6 mois',
+ E'Hey [prénom], ça fait un moment ! Je voulais juste prendre des nouvelles — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux.',
+ null, 1, false),
+
+('fr','referral_request','Demande de recommandation',
+ E'[prénom], depuis qu''on bosse ensemble t''as [résultat concret]. Qui dans ton entourage proche pourrait avoir besoin de ce qu''on a fait ensemble ? Je te demande pas de pitcher — juste 1 ou 2 prénoms et je m''en occupe à partir de là.',
+ null, 1, false),
+
+-- EN
+('en','ghost_after_exchange','Ghosting after multiple exchanges',
+ E'[name], I didn''t want to drop you like that — either the timing''s off, or the subject doesn''t interest you, or I explained badly. Just tell me which of the three and I''ll adjust (or leave you alone, promise).',
+ E'[prénom], je voulais pas te lâcher comme ça — soit le timing est pas bon, soit le sujet t''intéresse pas, soit j''ai mal expliqué. Dis-moi juste lequel des trois et je m''adapte (ou je te laisse tranquille, promis).',
+ 1, false),
+
+('en','reactivation_3_6m','Reactivation after 3-6 months',
+ E'Hey [name], it''s been a while! Just wanted to check in — how''s it going for you on [goal]? No pitch behind this, just genuinely curious.',
+ E'Hey [prénom], ça fait un moment ! Je voulais juste prendre des nouvelles — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux.',
+ 1, false),
+
+('en','referral_request','Asking for a referral',
+ E'[name], since we''ve been working together you''ve got [concrete result]. Who in your close circle might need what we did together? Not asking you to pitch — just 1 or 2 names and I''ll handle it from there.',
+ E'[prénom], depuis qu''on bosse ensemble t''as [résultat concret]. Qui dans ton entourage proche pourrait avoir besoin de ce qu''on a fait ensemble ? Je te demande pas de pitcher — juste 1 ou 2 prénoms et je m''en occupe à partir de là.',
+ 1, false),
+
+-- ES (needs_native_review)
+('es','ghost_after_exchange','Ghosting tras varios intercambios',
+ E'[nombre], no quería dejarte así — o el momento no es bueno, o el tema no te interesa, o expliqué mal. Solo dime cuál de los tres y me ajusto (o te dejo tranquilo(a), prometido).',
+ E'[prénom], je voulais pas te lâcher comme ça — soit le timing est pas bon, soit le sujet t''intéresse pas, soit j''ai mal expliqué. Dis-moi juste lequel des trois et je m''adapte (ou je te laisse tranquille, promis).',
+ 1, true),
+
+('es','reactivation_3_6m','Reactivación tras 3-6 meses',
+ E'Hey [nombre], ¡pasó un rato! Solo quería saber — ¿cómo va para ti con [objetivo]? Sin pitch detrás, solo curioso(a).',
+ E'Hey [prénom], ça fait un moment ! Je voulais juste prendre des nouvelles — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux.',
+ 1, true),
+
+('es','referral_request','Pedir una recomendación',
+ E'[nombre], desde que trabajamos juntos tienes [resultado concreto]. ¿Quién en tu círculo cercano podría necesitar lo que hicimos juntos? No te pido que vendas — solo 1 o 2 nombres y yo me encargo desde ahí.',
+ E'[prénom], depuis qu''on bosse ensemble t''as [résultat concret]. Qui dans ton entourage proche pourrait avoir besoin de ce qu''on a fait ensemble ? Je te demande pas de pitcher — juste 1 ou 2 prénoms et je m''en occupe à partir de là.',
+ 1, true),
+
+-- PT (needs_native_review)
+('pt','ghost_after_exchange','Ghosting depois de várias trocas',
+ E'[nome], não queria te largar assim — ou o timing tá ruim, ou o assunto não te interessa, ou expliquei mal. Só me diz qual dos três e eu me adapto (ou te deixo em paz, prometo).',
+ E'[prénom], je voulais pas te lâcher comme ça — soit le timing est pas bon, soit le sujet t''intéresse pas, soit j''ai mal expliqué. Dis-moi juste lequel des trois et je m''adapte (ou je te laisse tranquille, promis).',
+ 1, true),
+
+('pt','reactivation_3_6m','Reativação após 3-6 meses',
+ E'Ei [nome], faz um tempo! Só queria saber — como vai pra você no [objetivo]? Sem pitch atrás, só curioso(a) mesmo.',
+ E'Hey [prénom], ça fait un moment ! Je voulais juste prendre des nouvelles — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux.',
+ 1, true),
+
+('pt','referral_request','Pedir indicação',
+ E'[nome], desde que trabalhamos juntos você tem [resultado concreto]. Quem no seu círculo próximo poderia precisar do que fizemos juntos? Não tô pedindo pra vender — só 1 ou 2 nomes e eu cuido a partir daí.',
+ E'[prénom], depuis qu''on bosse ensemble t''as [résultat concret]. Qui dans ton entourage proche pourrait avoir besoin de ce qu''on a fait ensemble ? Je te demande pas de pitcher — juste 1 ou 2 prénoms et je m''en occupe à partir de là.',
+ 1, true),
+
+-- TR
+('tr','ghost_after_exchange','Birkaç görüşme sonrası ghost',
+ E'[isim], seni öylece bırakmak istemedim — ya zamanlama yanlış, ya konu ilgini çekmiyor, ya da kötü anlattım. Üçünden hangisi söyle, ayarlarım (ya da seni rahat bırakırım, söz).',
+ E'[prénom], je voulais pas te lâcher comme ça — soit le timing est pas bon, soit le sujet t''intéresse pas, soit j''ai mal expliqué. Dis-moi juste lequel des trois et je m''adapte (ou je te laisse tranquille, promis).',
+ 1, false),
+
+('tr','reactivation_3_6m','3-6 ay sonra yeniden iletişim',
+ E'Selam [isim], uzun zaman oldu! Sadece haberini almak istedim — [hedef] üzerinde nasıl gidiyor? Arkasında pitch yok, gerçekten meraktan.',
+ E'Hey [prénom], ça fait un moment ! Je voulais juste prendre des nouvelles — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux.',
+ 1, false),
+
+('tr','referral_request','Tavsiye istemek',
+ E'[isim], birlikte çalışmaya başladığımızdan beri [somut sonuç] elde ettin. Yakın çevrende birlikte yaptığımız şeye ihtiyacı olabilecek kim var? Senden satış yapmanı istemiyorum — sadece 1-2 isim, oradan ben hallederim.',
+ E'[prénom], depuis qu''on bosse ensemble t''as [résultat concret]. Qui dans ton entourage proche pourrait avoir besoin de ce qu''on a fait ensemble ? Je te demande pas de pitcher — juste 1 ou 2 prénoms et je m''en occupe à partir de là.',
+ 1, false),
+
+-- HI
+('hi','ghost_after_exchange','Multiple exchanges ke baad ghost',
+ E'[name], tujhe aise chhodna nahi chahta tha — ya timing galat hai, ya subject mein interest nahi, ya maine galat samjhaya. Bas teeno mein se ek bata aur main adjust kar lunga (ya tujhe shanti se chhod dunga, promise).',
+ E'[prénom], je voulais pas te lâcher comme ça — soit le timing est pas bon, soit le sujet t''intéresse pas, soit j''ai mal expliqué. Dis-moi juste lequel des trois et je m''adapte (ou je te laisse tranquille, promis).',
+ 1, false),
+
+('hi','reactivation_3_6m','3-6 mahine baad reactivation',
+ E'Hey [name], bahut time ho gaya! Bas news lena chahta tha — [goal] pe kaisa chal raha hai tere liye? Iske peeche koi pitch nahi, sirf genuine curious hu.',
+ E'Hey [prénom], ça fait un moment ! Je voulais juste prendre des nouvelles — comment ça avance pour toi sur [objectif] ? Pas de pitch derrière, juste curieux.',
+ 1, false),
+
+('hi','referral_request','Recommendation maangna',
+ E'[name], jab se hum saath kaam kar rahe hai tujhe [concrete result] mila hai. Tere close circle mein kaun ho sakta hai jisko hamare kaam ki zaroorat ho? Main tujhe sell karne ke liye nahi keh raha — bas 1-2 naam aur main wahaan se sambhal lunga.',
+ E'[prénom], depuis qu''on bosse ensemble t''as [résultat concret]. Qui dans ton entourage proche pourrait avoir besoin de ce qu''on a fait ensemble ? Je te demande pas de pitcher — juste 1 ou 2 prénoms et je m''en occupe à partir de là.',
+ 1, false);
+
+commit;
+
+-- =============================================================================
+-- VÉRIFICATION POST-SEED (à exécuter dans Supabase SQL Editor)
+-- =============================================================================
+-- SELECT 'followups' as t, market_code, COUNT(*) FROM prospection_followups
+--   GROUP BY market_code
+-- UNION ALL
+-- SELECT 'closing', market_code, COUNT(*) FROM prospection_closing
+--   GROUP BY market_code
+-- UNION ALL
+-- SELECT 'special_cases', market_code, COUNT(*) FROM prospection_special_cases
+--   GROUP BY market_code
+-- ORDER BY 1, 2;
+--
+-- Attendu :
+--   - followups     : 4 par marché × 6 = 24
+--   - closing       : 8 par marché × 6 = 48
+--   - special_cases : 3 par marché × 6 = 18
+--   - Total = 90 entrées.


### PR DESCRIPTION
## Summary

V5 seed prospection complet (408 entrées clean 6 marchés) + fix UI toggle Natif↔FR.

**4 commits :**
- `e2cf320` V5 Scripts M1+relances (150) — fix bug guard count()=0, UNIQUE constraint, zéro pitch
- `76a0a62` V5 M2/M3+objections (168) — fermeture propre sur non, jamais d'insistance
- `88ba440` V5 Post-appel+closing+cas spéciaux (90) — J+5=DERNIER msg, final_no porte ouverte 3-6m
- `6cf3037` Fix UI toggle Natif↔FR sur 5 modules (avant : FR affiché par défaut au lieu du natif)

## Migrations Supabase (déjà sur DB partagée)

- `20261119210000` Scripts V5 clean (150)
- `20261119220000` M2/M3 + objections V5 (168)
- `20261119230000` Post-appel + closing + special cases V5 (90)

## Test plan

- [x] `npm run build` OK
- [x] Migrations appliquées sur remote
- [ ] Recette visuelle prod : bascule marché EN/ES/PT/TR/HI → natif par défaut + toggle FR fonctionnel

## Backlog

ES + PT à relire par natifs avant exposition sous-marché (flag `needs_native_review`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)