### PR TITLE
fix(client-app): retire double onboarding au 1er login

### DIFF
--- a/src/components/client-app/ClientFaqChatbot.tsx
+++ b/src/components/client-app/ClientFaqChatbot.tsx
@@ -25,6 +25,8 @@ import { recordClientXp } from "../../features/client-xp/useClientXp";
 interface Props {
   token: string;
   coachFirstName?: string;
+  /** Si fourni, ajoute un bouton "Faire le tour de l'app" dans le popup. */
+  onLaunchTutorial?: () => void;
 }
 
 interface FaqEntry {
@@ -93,7 +95,7 @@ const FAQ: FaqEntry[] = [
   },
 ];
 
-export function ClientFaqChatbot({ token, coachFirstName }: Props) {
+export function ClientFaqChatbot({ token, coachFirstName, onLaunchTutorial }: Props) {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -384,6 +386,39 @@ export function ClientFaqChatbot({ token, coachFirstName }: Props) {
                 );
               })}
             </div>
+
+            {/* CTA "Faire le tour de l'app" — visible uniquement si la
+                page parente a fourni un callback (= tutorial dispo).
+                Refonte chantier C V2 2026-05-20 : l'OnboardingTutorial
+                ne s'auto-lance plus, l'utilisateur le redéclenche d'ici. */}
+            {onLaunchTutorial ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  onLaunchTutorial();
+                }}
+                style={{
+                  width: "100%",
+                  padding: "12px 16px",
+                  background: "linear-gradient(135deg, #EF9F27, #BA7517)",
+                  color: "white",
+                  border: "none",
+                  borderRadius: 12,
+                  fontSize: 13,
+                  fontWeight: 700,
+                  fontFamily: "Sora, system-ui, sans-serif",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 8,
+                  marginBottom: 10,
+                }}
+              >
+                🎓 Faire le tour interactif de l'app
+              </button>
+            ) : null}
 
             {/* CTA "Écrire question libre" */}
             <button

--- a/src/pages/ClientAppPage.tsx
+++ b/src/pages/ClientAppPage.tsx
@@ -114,17 +114,11 @@ export function ClientAppPage() {
     token: token ?? null,
     clientId: data?.client_id ?? '',
   })
-  useEffect(() => {
-    if (!onboardingState.state.loaded || !data) return
-    if (tutorialOpen) return
-    // Auto-launch si jamais vu ET jamais skipé (800ms pour laisser l'UI
-    // se stabiliser et le HERO s'afficher).
-    if (!onboardingState.state.completedAt && !onboardingState.state.skippedAt) {
-      const id = window.setTimeout(() => setTutorialOpen(true), 800)
-      return () => window.clearTimeout(id)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onboardingState.state.loaded, data?.client_id])
+  // Auto-launch désactivé (chantier C V2 2026-05-20) : ClientOnboardingTour
+  // (chantier C 2026-11-04) s'affiche déjà au 1er login avec 4 slides.
+  // L'OnboardingTutorial 9 étapes interactif (Tier B 2026-04-28) reste
+  // accessible à la demande via le FAQ chatbot (bouton "🎓 Faire le tour").
+  // Évite les 13 popups consécutifs au 1er login.
   // Chantier Messagerie bidirectionnelle (2026-04-22) : nouveau tab 'messages'
   // (conversation chat coach ↔ client). Ouverture auto si ?tab=messages dans
   // l'URL (notif push coach_message y redirige).
@@ -1189,6 +1183,7 @@ export function ClientAppPage() {
         <ClientFaqChatbot
           token={token}
           coachFirstName={(data.coach_name ?? '').split(/\s+/)[0] || 'Coach'}
+          onLaunchTutorial={() => setTutorialOpen(true)}
         />
       ) : null}
 


### PR DESCRIPTION
Diagnostic + fix sur retour Thomas : 2 systèmes onboarding s'enchaînent au 1er login client. OnboardingTutorial désormais accessible uniquement via bouton 'Faire le tour' dans le FAQ chatbot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)